### PR TITLE
fix: correct PostgreSQL database name configuration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+- run dev ✓
+- integrate with API
+- design / user flow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     environment:
       POSTGRES_USER: yannik
       POSTGRES_PASSWORD: yannik123
-      POSTGRES_DB: pinning
+      POSTGRES_DB: platform
     ports:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U yannik -d pinning"]
+      test: ["CMD-SHELL", "pg_isready -U yannik -d platform"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Corrected PostgreSQL database name from 'pinning' to 'platform' in docker-compose.yml
- Updated healthcheck command to use correct database name
- Added TODO.md for project task tracking

## Technical
- Docker Compose environment variable `POSTGRES_DB` updated
- Healthcheck command now verifies connection to 'platform' database
- No breaking changes - database schema remains unchanged

## Testing
- [x] Docker Compose configuration verified
- [x] Changes align with project naming conventions
- [x] No code changes requiring lint/test execution

## Breaking Changes
None