### PR TITLE
fix: ensure user avatar image is consistent across all UI components

### DIFF
--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -219,8 +219,12 @@ export async function settings(state: object | null, formData: FormData) {
 export async function setAvatar(userId: string, images: string[]) {
   try {
     const session = await auth();
-    await userService.setUserAvatar(session?.userId!, images);
+    if (!session?.user?.id) {
+      throw new Error('User not authenticated');
+    }
+    await userService.setUserAvatar(session.user.id, images);
     revalidatePath('/account/settings');
+    revalidatePath('/');
 
     return {
       success: true,

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -1,4 +1,5 @@
 import { NextAuthConfig } from "next-auth";
+import { prisma } from "@/lib/prisma";
 
 export default {
   providers: [
@@ -9,6 +10,7 @@ export default {
       if (user) {
         token.role = user.role;
         token.name = `${user.firstname} ${user.lastname}`;
+        token.image = user.image;
         token.sub = user.id; // Ensure user ID is in token
       }
       return token;
@@ -20,6 +22,20 @@ export default {
       if (token.role) {
         session.user.role = token.role as string;
       }
+
+      // Fetch latest user data from database to ensure image is up-to-date
+      try {
+        const user = await prisma.user.findUnique({
+          where: { id: token.sub as string },
+          select: { image: true },
+        });
+        if (user?.image) {
+          session.user.image = user.image;
+        }
+      } catch (error) {
+        console.error('Failed to fetch user image in session callback:', error);
+      }
+
       return session;
     },
   },


### PR DESCRIPTION
## Summary
- UserBar now displays the same avatar image as account settings page
- Session callback fetches latest user image from database on every access
- Added root layout cache invalidation when avatar is updated
- Fixed session access pattern to use correct property names

## Technical
- Updated NextAuth session callback to query database for latest user image
- Added image field to JWT token on user login
- Modified setAvatar action to revalidate root layout (`/`) in addition to settings page
- Ensures UserBar component (in root layout) receives fresh user data from session

## Testing
- Verify avatar upload on settings page
- Check that UserBar immediately reflects updated avatar image
- Confirm both components show the same image

## Breaking Changes
None