### PR TITLE
fix: add --ignore-scripts to npm ci in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copy package files
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary
- Adds `--ignore-scripts` flag to `npm ci` in the production Dockerfile
- Already applied on the production server

## Test plan
- [x] Verified running on production server