### PR TITLE
fix: update lock file and add env_file to postgres service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,8 @@ name: next-app
 services:
   postgres:
     image: postgres:15
+    env_file:
+      - .env.production
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "fivelines",
-  "version": "0.3.2",
+  "name": "enopax-platform",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fivelines",
-      "version": "0.3.2",
+      "name": "enopax-platform",
+      "version": "0.4.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.10.0",
         "@internationalized/date": "^3.8.2",
@@ -40,7 +41,7 @@
         "geist": "^1.3.1",
         "motion": "^12.4.10",
         "nanoid": "^5.1.5",
-        "next": "^15.1.3",
+        "next": "^15.3.3",
         "next-auth": "^5.0.0-beta.25",
         "nodemailer": "^6.9.16",
         "prisma": "^6.15.0",
@@ -66,7 +67,7 @@
         "@types/react-dom": "^19",
         "@types/ws": "^8.18.0",
         "eslint": "^8",
-        "eslint-config-next": "15.0.4",
+        "eslint-config-next": "^15.3.3",
         "jest": "^30.1.3",
         "jest-environment-jsdom": "^30.1.2",
         "postcss": "^8",
@@ -1945,9 +1946,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.4.tgz",
-      "integrity": "sha512-rbsF17XGzHtR7SDWzWpavSfum3/UdnF8bAaisnKwP//si3KWPTedVUsflAdjyK1zW3rweBjbALfKcavFneLGvg==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.12.tgz",
+      "integrity": "sha512-+ZRSDFTv4aC96aMb5E41rMjysx8ApkryevnvEYZvPZO52KvkqP5rNExLUXJFr9P4s0f3oqNQR6vopCZsPWKDcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7025,13 +7026,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.4.tgz",
-      "integrity": "sha512-97mLaAhbJKVQYXUBBrenRtEUAA6bNDPxWfaFEd6mEhKfpajP4wJrW4l7BUlHuYWxR8oQa9W014qBJpumpJQwWA==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.12.tgz",
+      "integrity": "sha512-ktW3XLfd+ztEltY5scJNjxjHwtKWk6vU2iwzZqSN09UsbBmMeE/cVlJ1yESg6Yx5LW7p/Z8WzUAgYXGLEmGIpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.0.4",
+        "@next/eslint-plugin-next": "15.5.12",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -7039,7 +7040,7 @@
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
-        "eslint-plugin-react": "^7.35.0",
+        "eslint-plugin-react": "^7.37.0",
         "eslint-plugin-react-hooks": "^5.0.0"
       },
       "peerDependencies": {


### PR DESCRIPTION
## Summary
- Regenerate `package-lock.json` after Next.js 15.3.3 and eslint-config-next version bumps from #19
- Add `env_file: .env.production` to the postgres service in `docker-compose.prod.yml` so DB credentials are read from the env file (not just the nextjs-app service)

## Context
Follow-up to #19 — the build was failing because the lock file was out of sync with the updated package.json versions.