### PR TITLE
fix: update Dockerfile to Node 20 for Next.js 16 compatibility

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Multi-stage production Dockerfile for Next.js
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copy package files
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
+RUN npm ci --ignore-scripts --legacy-peer-deps
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary
- Upgrade Docker base image from Node 18 to Node 20 (required for Next.js 16)
- Add `--legacy-peer-deps` to `npm ci` to resolve eslint-config-next/nodemailer peer dep conflicts

## Test plan
- [x] Fixes production Docker build failure after Next.js 16 upgrade