### PR TITLE
fix: add legacy-peer-deps to Prisma install in Dockerfile

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -56,7 +56,7 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/package-lock.json ./package-lock.json
 
 # Install only Prisma CLI in production
-RUN npm install prisma@6.15.0 --save-dev --omit=optional
+RUN npm install prisma@6.15.0 --save-dev --omit=optional --legacy-peer-deps
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh ./docker-entrypoint.sh


### PR DESCRIPTION
Fixes second npm install step in Dockerfile that also hits peer dep conflicts.