### PR TITLE
fix: correct Docker build context path in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: ./platform
-          file: ./platform/Dockerfile.prod
+          context: .
+          file: ./Dockerfile.prod
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Fix `context: ./platform` → `context: .` in deploy workflow
- The GitHub repo root IS the platform code, not a subdirectory

## Test plan
- [ ] Merge and verify GitHub Actions build succeeds