### PR TITLE
fix: use raw SSH for deploy instead of appleboy/ssh-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,9 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to Server
-        uses: appleboy/ssh-action@v1.0.0
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: deploy
-          key: ${{ secrets.SERVER_SSH_KEY }}
-          script: echo "deploy"
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/deploy_key deploy@${{ secrets.SERVER_HOST }}
+          rm ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary
- Replace appleboy/ssh-action with raw SSH call
- appleboy/ssh-action requires a shell to execute scripts, which conflicts with our forced-command security model
- Raw SSH just connects — the forced command in authorized_keys runs deploy.sh automatically
- Deploy user has /bin/sh (minimal shell for forced command execution), no interactive access

## Test plan
- [x] Tested locally: `ssh -i ~/.ssh/enopax-deploy deploy@enopax.com` runs deploy.sh successfully