### PR TITLE
feat: migrate user storage models to TinyBase data store

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -117,7 +117,7 @@ User (root — no dependencies, everything depends on it)
 | 1 | ApiKey — first Prisma repository | `feat/migrate-apikey` | #31 | ✅ Done |
 | 2 | TinyBase for ApiKey — prove the pattern | `feat/tinybase-apikey` | #32 | ✅ Done |
 | 3 | MembershipAuditLog (TinyBase) | `feat/migrate-audit-log` | #33 | ✅ Done |
-| 4 | User storage models (Quota + Metrics + Activity) | `feat/migrate-user-storage` | — | ⬜ |
+| 4 | User storage models (Quota + Metrics + Activity) | `feat/migrate-user-storage` | #34 | ✅ Done |
 | 5 | Bulk type import migration (~28 components) | `refactor/store-type-imports` | — | ⬜ |
 | 6 | User model | `feat/migrate-user` | — | ⬜ |
 | 7 | Organisation + OrganisationMember | `feat/migrate-organisation` | — | ⬜ |

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -1,15 +1,20 @@
 import type { IApiKeyRepository } from './repositories/api-key.repository';
 import type { IAuditLogRepository } from './repositories/audit-log.repository';
+import type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository } from './repositories/user-storage.repository';
 import { createStore } from 'tinybase';
 import { createFilePersister, type FilePersister } from 'tinybase/persisters/persister-file';
 import { TinyBaseApiKeyRepository } from './tinybase/api-key.tinybase';
 import { TinyBaseAuditLogRepository } from './tinybase/audit-log.tinybase';
+import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
 import path from 'path';
 import fs from 'fs';
 
 export interface DataStore {
   apiKeys: IApiKeyRepository;
   auditLogs: IAuditLogRepository;
+  storageQuotas: IUserStorageQuotaRepository;
+  storageMetrics: IUserStorageMetricsRepository;
+  storageActivity: IUserStorageActivityRepository;
   destroy(): Promise<void>;
 }
 
@@ -31,6 +36,9 @@ async function createDataStore(): Promise<DataStore> {
   return {
     apiKeys: new TinyBaseApiKeyRepository(tinyStore),
     auditLogs: new TinyBaseAuditLogRepository(tinyStore),
+    storageQuotas: new TinyBaseUserStorageQuotaRepository(tinyStore),
+    storageMetrics: new TinyBaseUserStorageMetricsRepository(tinyStore),
+    storageActivity: new TinyBaseUserStorageActivityRepository(tinyStore),
     async destroy() {
       await persister.destroy();
     },

--- a/src/lib/store/tinybase/user-storage.tinybase.ts
+++ b/src/lib/store/tinybase/user-storage.tinybase.ts
@@ -1,0 +1,234 @@
+import type { Store } from 'tinybase';
+import type { UserStorageQuota, UserStorageMetrics, UserStorageActivity, StorageTier } from '../types';
+import type {
+  IUserStorageQuotaRepository, CreateStorageQuotaData,
+  IUserStorageMetricsRepository, CreateStorageMetricsData,
+  IUserStorageActivityRepository, CreateStorageActivityData,
+} from '../repositories/user-storage.repository';
+import crypto from 'crypto';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+const QUOTA_TABLE = 'storage-quotas';
+const METRICS_TABLE = 'storage-metrics';
+const ACTIVITY_TABLE = 'storage-activity';
+
+function rowToQuota(id: string, row: Record<string, any>): UserStorageQuota {
+  return {
+    id,
+    userId: row.userId as string,
+    tier: row.tier as StorageTier,
+    allocatedBytes: BigInt(row.allocatedBytes as string),
+    usedBytes: BigInt(row.usedBytes as string),
+    lastUpdated: new Date(row.lastUpdated as string),
+    tierUpdatedAt: row.tierUpdatedAt ? new Date(row.tierUpdatedAt as string) : null,
+    tierUpdatedBy: (row.tierUpdatedBy as string) || null,
+    subscriptionId: (row.subscriptionId as string) || null,
+    subscriptionEnds: row.subscriptionEnds ? new Date(row.subscriptionEnds as string) : null,
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+  };
+}
+
+function rowToMetrics(id: string, row: Record<string, any>): UserStorageMetrics {
+  return {
+    id,
+    userId: row.userId as string,
+    date: new Date(row.date as string),
+    totalFiles: row.totalFiles as number,
+    totalSize: BigInt(row.totalSize as string),
+    pinnedFiles: row.pinnedFiles as number,
+    pinnedSize: BigInt(row.pinnedSize as string),
+    uploadCount: row.uploadCount as number,
+    downloadCount: row.downloadCount as number,
+    deleteCount: row.deleteCount as number,
+    documentFiles: row.documentFiles as number,
+    imageFiles: row.imageFiles as number,
+    videoFiles: row.videoFiles as number,
+    archiveFiles: row.archiveFiles as number,
+    otherFiles: row.otherFiles as number,
+    avgResponseTime: row.avgResponseTime as number,
+    availabilityRate: row.availabilityRate as number,
+  };
+}
+
+function rowToActivity(id: string, row: Record<string, any>): UserStorageActivity {
+  return {
+    id,
+    userId: row.userId as string,
+    action: row.action as string,
+    fileName: (row.fileName as string) || null,
+    fileSize: row.fileSize ? BigInt(row.fileSize as string) : null,
+    ipfsHash: (row.ipfsHash as string) || null,
+    timestamp: new Date(row.timestamp as string),
+    responseTime: row.responseTime ? (row.responseTime as number) : null,
+    success: row.success === 1,
+    errorMessage: (row.errorMessage as string) || null,
+  };
+}
+
+export class TinyBaseUserStorageQuotaRepository implements IUserStorageQuotaRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateStorageQuotaData): Promise<UserStorageQuota> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(QUOTA_TABLE, id, {
+      userId: data.userId,
+      tier: data.tier ?? 'FREE_500MB',
+      allocatedBytes: (data.allocatedBytes ?? BigInt(524288000)).toString(),
+      usedBytes: '0',
+      lastUpdated: now,
+      tierUpdatedAt: '',
+      tierUpdatedBy: '',
+      subscriptionId: '',
+      subscriptionEnds: '',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return rowToQuota(id, this.store.getRow(QUOTA_TABLE, id));
+  }
+
+  async findByUserId(userId: string): Promise<UserStorageQuota | null> {
+    const rowIds = this.store.getRowIds(QUOTA_TABLE);
+    for (const id of rowIds) {
+      const row = this.store.getRow(QUOTA_TABLE, id);
+      if (row.userId === userId) return rowToQuota(id, row);
+    }
+    return null;
+  }
+
+  async update(
+    userId: string,
+    data: Partial<Pick<UserStorageQuota, 'tier' | 'allocatedBytes' | 'usedBytes' | 'tierUpdatedAt' | 'tierUpdatedBy' | 'subscriptionId' | 'subscriptionEnds'>>
+  ): Promise<UserStorageQuota> {
+    const rowIds = this.store.getRowIds(QUOTA_TABLE);
+    let targetId: string | null = null;
+    for (const id of rowIds) {
+      const row = this.store.getRow(QUOTA_TABLE, id);
+      if (row.userId === userId) { targetId = id; break; }
+    }
+    if (!targetId) throw new Error(`StorageQuota for user ${userId} not found`);
+
+    if (data.tier !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'tier', data.tier);
+    if (data.allocatedBytes !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'allocatedBytes', data.allocatedBytes.toString());
+    if (data.usedBytes !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'usedBytes', data.usedBytes.toString());
+    if (data.tierUpdatedAt !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'tierUpdatedAt', data.tierUpdatedAt ? data.tierUpdatedAt.toISOString() : '');
+    if (data.tierUpdatedBy !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'tierUpdatedBy', data.tierUpdatedBy ?? '');
+    if (data.subscriptionId !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'subscriptionId', data.subscriptionId ?? '');
+    if (data.subscriptionEnds !== undefined) this.store.setCell(QUOTA_TABLE, targetId, 'subscriptionEnds', data.subscriptionEnds ? data.subscriptionEnds.toISOString() : '');
+    this.store.setCell(QUOTA_TABLE, targetId, 'lastUpdated', new Date().toISOString());
+    this.store.setCell(QUOTA_TABLE, targetId, 'updatedAt', new Date().toISOString());
+
+    return rowToQuota(targetId, this.store.getRow(QUOTA_TABLE, targetId));
+  }
+}
+
+export class TinyBaseUserStorageMetricsRepository implements IUserStorageMetricsRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateStorageMetricsData): Promise<UserStorageMetrics> {
+    const id = generateId();
+    const now = new Date();
+
+    this.store.setRow(METRICS_TABLE, id, {
+      userId: data.userId,
+      date: (data.date ?? now).toISOString(),
+      totalFiles: data.totalFiles ?? 0,
+      totalSize: (data.totalSize ?? BigInt(0)).toString(),
+      pinnedFiles: data.pinnedFiles ?? 0,
+      pinnedSize: (data.pinnedSize ?? BigInt(0)).toString(),
+      uploadCount: data.uploadCount ?? 0,
+      downloadCount: data.downloadCount ?? 0,
+      deleteCount: data.deleteCount ?? 0,
+      documentFiles: data.documentFiles ?? 0,
+      imageFiles: data.imageFiles ?? 0,
+      videoFiles: data.videoFiles ?? 0,
+      archiveFiles: data.archiveFiles ?? 0,
+      otherFiles: data.otherFiles ?? 0,
+      avgResponseTime: data.avgResponseTime ?? 0,
+      availabilityRate: data.availabilityRate ?? 100.0,
+    });
+
+    return rowToMetrics(id, this.store.getRow(METRICS_TABLE, id));
+  }
+
+  async findByUserId(userId: string, options?: { from?: Date; to?: Date }): Promise<UserStorageMetrics[]> {
+    const rowIds = this.store.getRowIds(METRICS_TABLE);
+    const results: UserStorageMetrics[] = [];
+
+    for (const id of rowIds) {
+      const row = this.store.getRow(METRICS_TABLE, id);
+      if (row.userId !== userId) continue;
+      const date = new Date(row.date as string);
+      if (options?.from && date < options.from) continue;
+      if (options?.to && date > options.to) continue;
+      results.push(rowToMetrics(id, row));
+    }
+
+    results.sort((a, b) => b.date.getTime() - a.date.getTime());
+    return results;
+  }
+
+  async findByUserAndDate(userId: string, date: Date): Promise<UserStorageMetrics | null> {
+    const dateStr = date.toISOString().split('T')[0];
+    const rowIds = this.store.getRowIds(METRICS_TABLE);
+
+    for (const id of rowIds) {
+      const row = this.store.getRow(METRICS_TABLE, id);
+      if (row.userId !== userId) continue;
+      const rowDate = (row.date as string).split('T')[0];
+      if (rowDate === dateStr) return rowToMetrics(id, row);
+    }
+    return null;
+  }
+}
+
+export class TinyBaseUserStorageActivityRepository implements IUserStorageActivityRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateStorageActivityData): Promise<UserStorageActivity> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(ACTIVITY_TABLE, id, {
+      userId: data.userId,
+      action: data.action,
+      fileName: data.fileName ?? '',
+      fileSize: data.fileSize ? data.fileSize.toString() : '',
+      ipfsHash: data.ipfsHash ?? '',
+      timestamp: now,
+      responseTime: data.responseTime ?? 0,
+      success: (data.success ?? true) ? 1 : 0,
+      errorMessage: data.errorMessage ?? '',
+    });
+
+    return rowToActivity(id, this.store.getRow(ACTIVITY_TABLE, id));
+  }
+
+  async findByUserId(
+    userId: string,
+    options?: { from?: Date; to?: Date; skip?: number; take?: number }
+  ): Promise<UserStorageActivity[]> {
+    const rowIds = this.store.getRowIds(ACTIVITY_TABLE);
+    let results: UserStorageActivity[] = [];
+
+    for (const id of rowIds) {
+      const row = this.store.getRow(ACTIVITY_TABLE, id);
+      if (row.userId !== userId) continue;
+      const ts = new Date(row.timestamp as string);
+      if (options?.from && ts < options.from) continue;
+      if (options?.to && ts > options.to) continue;
+      results.push(rowToActivity(id, row));
+    }
+
+    results.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+    if (options?.skip) results = results.slice(options.skip);
+    if (options?.take) results = results.slice(0, options.take);
+    return results;
+  }
+}

--- a/tests/store/tinybase/user-storage.tinybase.test.ts
+++ b/tests/store/tinybase/user-storage.tinybase.test.ts
@@ -1,0 +1,185 @@
+import { createStore } from 'tinybase';
+import {
+  TinyBaseUserStorageQuotaRepository,
+  TinyBaseUserStorageMetricsRepository,
+  TinyBaseUserStorageActivityRepository,
+} from '@/lib/store/tinybase/user-storage.tinybase';
+
+describe('TinyBaseUserStorageQuotaRepository', () => {
+  let repo: TinyBaseUserStorageQuotaRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseUserStorageQuotaRepository(createStore());
+  });
+
+  it('creates a quota with defaults', async () => {
+    const quota = await repo.create({ userId: 'user-1' });
+    expect(quota.userId).toBe('user-1');
+    expect(quota.tier).toBe('FREE_500MB');
+    expect(quota.allocatedBytes).toBe(BigInt(524288000));
+    expect(quota.usedBytes).toBe(BigInt(0));
+    expect(quota.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('creates a quota with custom tier', async () => {
+    const quota = await repo.create({
+      userId: 'user-1',
+      tier: 'PRO_50GB',
+      allocatedBytes: BigInt(53687091200),
+    });
+    expect(quota.tier).toBe('PRO_50GB');
+    expect(quota.allocatedBytes).toBe(BigInt(53687091200));
+  });
+
+  it('finds quota by userId', async () => {
+    await repo.create({ userId: 'user-1' });
+    const found = await repo.findByUserId('user-1');
+    expect(found).not.toBeNull();
+    expect(found!.userId).toBe('user-1');
+  });
+
+  it('returns null for unknown user', async () => {
+    expect(await repo.findByUserId('unknown')).toBeNull();
+  });
+
+  it('updates tier and allocatedBytes', async () => {
+    await repo.create({ userId: 'user-1' });
+    const updated = await repo.update('user-1', {
+      tier: 'PRO_50GB',
+      allocatedBytes: BigInt(53687091200),
+    });
+    expect(updated.tier).toBe('PRO_50GB');
+    expect(updated.allocatedBytes).toBe(BigInt(53687091200));
+  });
+
+  it('updates usedBytes', async () => {
+    await repo.create({ userId: 'user-1' });
+    const updated = await repo.update('user-1', {
+      usedBytes: BigInt(1000000),
+    });
+    expect(updated.usedBytes).toBe(BigInt(1000000));
+  });
+
+  it('throws when updating nonexistent user', async () => {
+    await expect(repo.update('missing', { tier: 'PRO_50GB' })).rejects.toThrow();
+  });
+});
+
+describe('TinyBaseUserStorageMetricsRepository', () => {
+  let repo: TinyBaseUserStorageMetricsRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseUserStorageMetricsRepository(createStore());
+  });
+
+  it('creates metrics with defaults', async () => {
+    const m = await repo.create({ userId: 'user-1' });
+    expect(m.userId).toBe('user-1');
+    expect(m.totalFiles).toBe(0);
+    expect(m.totalSize).toBe(BigInt(0));
+    expect(m.availabilityRate).toBe(100.0);
+  });
+
+  it('creates metrics with custom values', async () => {
+    const m = await repo.create({
+      userId: 'user-1',
+      totalFiles: 50,
+      totalSize: BigInt(5000000),
+      uploadCount: 10,
+    });
+    expect(m.totalFiles).toBe(50);
+    expect(m.totalSize).toBe(BigInt(5000000));
+    expect(m.uploadCount).toBe(10);
+  });
+
+  it('finds by userId', async () => {
+    await repo.create({ userId: 'user-1' });
+    await repo.create({ userId: 'user-2' });
+    const results = await repo.findByUserId('user-1');
+    expect(results).toHaveLength(1);
+  });
+
+  it('filters by date range', async () => {
+    await repo.create({ userId: 'user-1', date: new Date('2026-01-15') });
+    await repo.create({ userId: 'user-1', date: new Date('2026-02-15') });
+    await repo.create({ userId: 'user-1', date: new Date('2026-03-15') });
+
+    const results = await repo.findByUserId('user-1', {
+      from: new Date('2026-02-01'),
+      to: new Date('2026-02-28'),
+    });
+    expect(results).toHaveLength(1);
+  });
+
+  it('finds by user and date', async () => {
+    await repo.create({ userId: 'user-1', date: new Date('2026-03-15T10:00:00Z') });
+    const found = await repo.findByUserAndDate('user-1', new Date('2026-03-15'));
+    expect(found).not.toBeNull();
+  });
+
+  it('returns null for missing date', async () => {
+    await repo.create({ userId: 'user-1', date: new Date('2026-03-15') });
+    const found = await repo.findByUserAndDate('user-1', new Date('2026-03-16'));
+    expect(found).toBeNull();
+  });
+});
+
+describe('TinyBaseUserStorageActivityRepository', () => {
+  let repo: TinyBaseUserStorageActivityRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseUserStorageActivityRepository(createStore());
+  });
+
+  it('creates an activity entry', async () => {
+    const a = await repo.create({
+      userId: 'user-1',
+      action: 'upload',
+      fileName: 'test.txt',
+      fileSize: BigInt(1024),
+    });
+    expect(a.userId).toBe('user-1');
+    expect(a.action).toBe('upload');
+    expect(a.fileName).toBe('test.txt');
+    expect(a.fileSize).toBe(BigInt(1024));
+    expect(a.success).toBe(true);
+    expect(a.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('creates a failed activity', async () => {
+    const a = await repo.create({
+      userId: 'user-1',
+      action: 'upload',
+      success: false,
+      errorMessage: 'Disk full',
+    });
+    expect(a.success).toBe(false);
+    expect(a.errorMessage).toBe('Disk full');
+  });
+
+  it('finds by userId', async () => {
+    await repo.create({ userId: 'user-1', action: 'upload' });
+    await repo.create({ userId: 'user-1', action: 'download' });
+    await repo.create({ userId: 'user-2', action: 'upload' });
+
+    const results = await repo.findByUserId('user-1');
+    expect(results).toHaveLength(2);
+  });
+
+  it('supports pagination', async () => {
+    for (let i = 0; i < 5; i++) {
+      await repo.create({ userId: 'user-1', action: `action-${i}` });
+    }
+    const page = await repo.findByUserId('user-1', { skip: 1, take: 2 });
+    expect(page).toHaveLength(2);
+  });
+
+  it('filters by date range', async () => {
+    await repo.create({ userId: 'user-1', action: 'upload' });
+    const results = await repo.findByUserId('user-1', {
+      from: new Date('2020-01-01'),
+      to: new Date('2030-01-01'),
+    });
+    expect(results).toHaveLength(1);
+  });
+});

--- a/tests/store/types.test.ts
+++ b/tests/store/types.test.ts
@@ -364,6 +364,9 @@ describe('Store types', () => {
       expect(store).toBeDefined();
       expect(store.apiKeys).toBeDefined();
       expect(store.auditLogs).toBeDefined();
+      expect(store.storageQuotas).toBeDefined();
+      expect(store.storageMetrics).toBeDefined();
+      expect(store.storageActivity).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- TinyBase implementations for UserStorageQuota, UserStorageMetrics, UserStorageActivity
- All three wired into DataStore
- BigInt fields (allocatedBytes, usedBytes, totalSize, etc.) stored as strings
- 18 new tests, 85 total store tests passing

## Context
Phase 4 of TinyBase migration. These three leaf models had zero active Prisma usage — no files needed modification beyond data-store.ts. The repositories are ready for when storage features are built out.

## Test plan
- [x] 85 store tests pass (`npx jest --selectProjects store`)
- [x] 18 new tests: quota CRUD, metrics date filtering, activity pagination