### PR TITLE
refactor: replace @prisma/client type imports with store types

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -118,7 +118,7 @@ User (root — no dependencies, everything depends on it)
 | 2 | TinyBase for ApiKey — prove the pattern | `feat/tinybase-apikey` | #32 | ✅ Done |
 | 3 | MembershipAuditLog (TinyBase) | `feat/migrate-audit-log` | #33 | ✅ Done |
 | 4 | User storage models (Quota + Metrics + Activity) | `feat/migrate-user-storage` | #34 | ✅ Done |
-| 5 | Bulk type import migration (~28 components) | `refactor/store-type-imports` | — | ⬜ |
+| 5 | Bulk type import migration (~28 components) | `refactor/store-type-imports` | #35 | ✅ Done |
 | 6 | User model | `feat/migrate-user` | — | ⬜ |
 | 7 | Organisation + OrganisationMember | `feat/migrate-organisation` | — | ⬜ |
 | 8 | OrganisationJoinRequest | `feat/migrate-join-request` | — | ⬜ |

--- a/src/actions/organisationJoinRequest.ts
+++ b/src/actions/organisationJoinRequest.ts
@@ -3,7 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
-import { JoinRequestStatus } from '@prisma/client';
+import { JoinRequestStatus } from '@/lib/store';
 import { logOrganisationMembershipChange } from '@/lib/auditLog';
 
 export interface CreateJoinRequestState {

--- a/src/actions/project.ts
+++ b/src/actions/project.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { type ProjectStatus, type ProjectPriority } from '@prisma/client';
+import { type ProjectStatus, type ProjectPriority } from '@/lib/store';
 import { projectService } from '@/lib/services/project';
 import { userService } from '@/lib/services/user';
 import { prisma } from '@/lib/prisma';

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -4,7 +4,7 @@ import { genSaltSync, hashSync } from 'bcrypt-ts';
 import { revalidatePath } from 'next/cache';
 import { auth, signIn } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { UserRole } from '@prisma/client';
+import { UserRole } from '@/lib/store';
 import { userService } from '@/lib/services/user';
 
 export async function sendCredentials(state: object | null, formData: FormData) {

--- a/src/components/OrganisationSearchSection.tsx
+++ b/src/components/OrganisationSearchSection.tsx
@@ -18,7 +18,7 @@ import {
   RiCheckLine,
   RiCloseLine
 } from '@remixicon/react';
-import { OrganisationJoinRequest } from '@prisma/client';
+import { OrganisationJoinRequest } from '@/lib/store';
 
 type SearchableOrganisation = {
   id: string;

--- a/src/components/common/OrganisationSelector.tsx
+++ b/src/components/common/OrganisationSelector.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Select, SelectValue } from '@/components/common/Select';
 import { useOrganisation } from '@/components/context/OrganisationContext';
-import { Organisation } from '@prisma/client';
+import { Organisation } from '@/lib/store';
 import { RiBuildingLine, RiAddLine } from '@remixicon/react';
 import { Button } from '@/components/common/Button';
 import Link from 'next/link';

--- a/src/components/context/OrganisationContext.tsx
+++ b/src/components/context/OrganisationContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { Organisation } from '@prisma/client';
+import { Organisation } from '@/lib/store';
 
 type OrganisationContextType = {
   selectedOrganisation: Organisation | null;

--- a/src/components/context/ProjectContext.tsx
+++ b/src/components/context/ProjectContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { Project } from '@prisma/client';
+import { Project } from '@/lib/store';
 
 type ProjectContextType = {
   selectedProject: Project | null;

--- a/src/components/form/EditOrganisationForm.tsx
+++ b/src/components/form/EditOrganisationForm.tsx
@@ -17,7 +17,7 @@ import {
   RiProjectorLine
 } from '@remixicon/react';
 import { updateOrganisation } from '@/actions/organisation';
-import { type Organisation, type User } from '@prisma/client';
+import { type Organisation, type User } from '@/lib/store';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 

--- a/src/components/form/OrganisationForm.tsx
+++ b/src/components/form/OrganisationForm.tsx
@@ -9,7 +9,7 @@ import { Textarea } from '@/components/common/Textarea';
 import { Switch } from '@/components/common/Switch';
 import ClientDate from '@/components/common/ClientDate';
 import UserSearch from '@/components/search/UserSearch';
-import { type Organisation, type User } from '@prisma/client';
+import { type Organisation, type User } from '@/lib/store';
 import { RiCheckLine, RiErrorWarningLine } from '@remixicon/react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';

--- a/src/components/form/OrganisationSettingsForm.tsx
+++ b/src/components/form/OrganisationSettingsForm.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/common/Label';
 import { Callout } from '@/components/common/Callout';
 import { Textarea } from '@/components/common/Textarea';
 import { Switch } from '@/components/common/Switch';
-import { type Organisation } from '@prisma/client';
+import { type Organisation } from '@/lib/store';
 import { RiCheckLine, RiErrorWarningLine } from '@remixicon/react';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';

--- a/src/components/form/ProjectForm.tsx
+++ b/src/components/form/ProjectForm.tsx
@@ -12,7 +12,7 @@ import { Checkbox } from '@/components/common/Checkbox';
 import { Slider } from '@/components/common/Slider';
 import ClientDate from '@/components/common/ClientDate';
 import { DatePicker } from '@/components/common/DatePicker';
-import { type Project, type User, type Organisation } from '@prisma/client';
+import { type Project, type User, type Organisation } from '@/lib/store';
 import { RiCheckLine, RiErrorWarningLine, RiDatabase2Line } from '@remixicon/react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';

--- a/src/components/form/UpdateUserForm.tsx
+++ b/src/components/form/UpdateUserForm.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/common/Label';
 import { Callout } from '@/components/common/Callout';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
 import ClientDate from '@/components/common/ClientDate';
-import { type User } from '@prisma/client';
+import { type User } from '@/lib/store';
 import { RiCheckLine, RiErrorWarningLine } from '@remixicon/react';
 import Link from 'next/link';
 

--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -1,4 +1,4 @@
-import { type User } from '@prisma/client';
+import { type User } from '@/lib/store';
 
 import Link from 'next/link';
 import { Button } from '@/components/common/Button';

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -23,7 +23,7 @@ import {
 import { Button } from '@/components/common/Button';
 import { Badge } from '@/components/common/Badge';
 import Avatar from '@/components/common/Avatar';
-import { User } from '@prisma/client';
+import { User } from '@/lib/store';
 import { useCommandPalette } from '@/hooks/useCommandPalette';
 import { handleSignOut } from '@/actions/auth';
 

--- a/src/components/navigation/SidebarNavigation.tsx
+++ b/src/components/navigation/SidebarNavigation.tsx
@@ -18,7 +18,7 @@ import {
   RiShieldLine
 } from '@remixicon/react';
 import { Button } from '@/components/common/Button';
-import { User } from '@prisma/client';
+import { User } from '@/lib/store';
 import { useCommandPalette } from '@/hooks/useCommandPalette';
 import { Badge } from '@/components/common/Badge';
 

--- a/src/components/project/EnhancedProjectGrid.tsx
+++ b/src/components/project/EnhancedProjectGrid.tsx
@@ -18,7 +18,7 @@ import {
 } from '@remixicon/react';
 import Link from 'next/link';
 import { useState } from 'react';
-import { type Project } from '@prisma/client';
+import { type Project } from '@/lib/store';
 
 type ProjectWithTeamsAndResources = Project & {
   organisation: {

--- a/src/components/search/OrganisationSearch.tsx
+++ b/src/components/search/OrganisationSearch.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Organisation } from '@prisma/client';
+import type { Organisation } from '@/lib/store';
 import GenericSearch, { type GenericSearchProps } from '@/components/GenericSearch';
 import { findOrganisations } from '@/actions/organisation';
 

--- a/src/components/search/ProjectSearch.tsx
+++ b/src/components/search/ProjectSearch.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Project, ProjectStatus, ProjectPriority } from '@prisma/client';
+import type { Project, ProjectStatus, ProjectPriority } from '@/lib/store';
 import GenericSearch, { type GenericSearchProps } from '@/components/GenericSearch';
 import { findProjects } from '@/actions/project';
 

--- a/src/components/search/UserSearch.tsx
+++ b/src/components/search/UserSearch.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { User } from '@prisma/client';
+import type { User } from '@/lib/store';
 import GenericSearch, { type GenericSearchProps } from '@/components/GenericSearch';
 import { findUsers } from '@/actions/user';
 

--- a/src/components/table/Organisation.tsx
+++ b/src/components/table/Organisation.tsx
@@ -4,7 +4,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import { Button } from '@/components/common/Button';
 import { Tooltip } from '@/components/common/Tooltip';
-import { type Organisation, type User } from '@prisma/client';
+import { type Organisation, type User } from '@/lib/store';
 import Link from 'next/link';
 
 type OrganisationWithOwner = Organisation & {

--- a/src/components/table/Project.tsx
+++ b/src/components/table/Project.tsx
@@ -4,7 +4,12 @@ import { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import { Button } from '@/components/common/Button';
 import { Tooltip } from '@/components/common/Tooltip';
-import { type Project, type User, type Organisation, type ProjectStatus, type ProjectPriority, type Team } from '@prisma/client';
+import { type Project, type User, type Organisation, type ProjectStatus, type ProjectPriority } from '@/lib/store';
+
+type Team = {
+  id: string;
+  name: string;
+};
 import Link from 'next/link';
 
 type ProjectWithDetails = Project & {

--- a/src/components/table/Resource.tsx
+++ b/src/components/table/Resource.tsx
@@ -5,7 +5,12 @@ import { format } from 'date-fns';
 import { Button } from '@/components/common/Button';
 import { Tooltip } from '@/components/common/Tooltip';
 import { Badge } from '@/components/common/Badge';
-import { type Resource, type User, type Team } from '@prisma/client';
+import { type Resource, type User } from '@/lib/store';
+
+type Team = {
+  id: string;
+  name: string;
+};
 import Link from 'next/link';
 import {
   RiServerLine,

--- a/src/components/table/User.tsx
+++ b/src/components/table/User.tsx
@@ -4,7 +4,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import { Button } from '@/components/common/Button';
 import { Tooltip } from '@/components/common/Tooltip';
-import { type User } from '@prisma/client';
+import { type User } from '@/lib/store';
 import Link from 'next/link';
 
 const columns: ColumnDef<User>[] = [

--- a/src/components/user/UserInfo.tsx
+++ b/src/components/user/UserInfo.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type User } from '@prisma/client'
+import { type User } from '@/lib/store'
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/common/Popover';
 import UserListItem from '@/components/list/UserListItem';


### PR DESCRIPTION
## Summary
- Replace `@prisma/client` type imports with `@/lib/store` in 24 files
- Components, actions, contexts, search, navigation, forms all updated
- `Team` type inlined in 2 table components (model doesn't exist in schema)
- Zero runtime changes — purely type-level

## Context
Phase 5 of TinyBase migration. After this, only service files and the Prisma singleton still import from `@prisma/client`.

## Test plan
- [x] 85 store tests pass
- [x] `npm run build` — no new errors