### PR TITLE
feat: migrate User model to TinyBase data store

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -119,7 +119,7 @@ User (root — no dependencies, everything depends on it)
 | 3 | MembershipAuditLog (TinyBase) | `feat/migrate-audit-log` | #33 | ✅ Done |
 | 4 | User storage models (Quota + Metrics + Activity) | `feat/migrate-user-storage` | #34 | ✅ Done |
 | 5 | Bulk type import migration (~28 components) | `refactor/store-type-imports` | #35 | ✅ Done |
-| 6 | User model | `feat/migrate-user` | — | ⬜ |
+| 6 | User model | `feat/migrate-user` | #36 | ✅ Done |
 | 7 | Organisation + OrganisationMember | `feat/migrate-organisation` | — | ⬜ |
 | 8 | OrganisationJoinRequest | `feat/migrate-join-request` | — | ⬜ |
 | 9 | Project | `feat/migrate-project` | — | ⬜ |

--- a/src/actions/resource.ts
+++ b/src/actions/resource.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import { revalidatePath } from 'next/cache';
 import { deployResource } from '@/lib/deployment-service';
 import { validateNameFormat } from '@/lib/name-validation';
@@ -87,9 +88,8 @@ export async function createResource(
     }
 
     // Validate owner exists
-    const ownerExists = await prisma.user.findUnique({
-      where: { id: ownerId }
-    });
+    const store = await getStoreAsync();
+    const ownerExists = await store.users.findById(ownerId);
 
     if (!ownerExists) {
       return {

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -3,8 +3,8 @@
 import { genSaltSync, hashSync } from 'bcrypt-ts';
 import { revalidatePath } from 'next/cache';
 import { auth, signIn } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
-import { UserRole } from '@/lib/store';
+import { getStoreAsync } from '@/lib/store';
+import type { UserRole } from '@/lib/store';
 import { userService } from '@/lib/services/user';
 
 export async function sendCredentials(state: object | null, formData: FormData) {
@@ -45,11 +45,12 @@ export async function sendEmail(state: object | null, formData: FormData) {
   try {
     const email = formData.get('email') as string;
     if (email.length < 3) throw new Error('Your email address is too short!');
-    const exists = await prisma.user.findUnique({ where: { email: email } });
+    const store = await getStoreAsync();
+    const exists = await store.users.findByEmail(email);
     if (!exists) throw new Error('Your email address is not available!');
     await signIn('nodemailer', {
       email: email,
-    });    
+    });
 
     return {
       payload: {
@@ -85,15 +86,14 @@ export async function register(state: object | null, formData: FormData) {
     const hash = hashSync(password, salt);
     if (email.length < 3) throw new Error('Your email is too short!');
     if (password != password2) throw new Error('Passwords are not the same!');
-    const user = await prisma.user.create({
-      data: {
-        name: username,
-        firstname: firstname,
-        lastname: lastname,
-        email: email,
-        password: hash,
-        role: 'CUSTOMER',
-      }
+    const store = await getStoreAsync();
+    const user = await store.users.create({
+      name: username,
+      firstname: firstname,
+      lastname: lastname,
+      email: email,
+      password: hash,
+      role: 'CUSTOMER',
     });
 
     await signIn('credentials', {
@@ -137,15 +137,13 @@ export async function settings(state: object | null, formData: FormData) {
     if (email.length < 3) throw new Error('Your email is too short!');
     if (password != password2) throw new Error('Passwords are not the same!');
 
-    const user = await prisma.user.update({
-      where: { id: session?.user?.id },
-      data: {
-        name: username,
-        firstname: firstname,
-        lastname: lastname,
-        email: email,
-        ...(password.length > 0 && { password: hash })
-      }
+    const store = await getStoreAsync();
+    const user = await store.users.update(session?.user?.id, {
+      name: username,
+      firstname: firstname,
+      lastname: lastname,
+      email: email,
+      ...(password.length > 0 && { password: hash })
     });
 
     revalidatePath('/account/settings');
@@ -210,15 +208,13 @@ export async function updateUserAdmin(userId: string, _prevState: UpdateUserStat
       return { success: false, fieldErrors: { email: 'Email is required' } };
     }
 
-    await prisma.user.update({
-      where: { id: userId },
-      data: {
-        firstname: firstname || null,
-        lastname: lastname || null,
-        name: name || null,
-        email,
-        role: role as UserRole,
-      },
+    const store = await getStoreAsync();
+    await store.users.update(userId, {
+      firstname: firstname || null,
+      lastname: lastname || null,
+      name: name || null,
+      email,
+      role: role as UserRole,
     });
 
     revalidatePath(`/admin/users/${userId}`);

--- a/src/app/(main)/account/settings/page.tsx
+++ b/src/app/(main)/account/settings/page.tsx
@@ -4,7 +4,7 @@ import { Card } from '@/components/common/Card';
 import BackButton from '@/components/common/BackButton';
 import SettingsForm from '@/components/form/SettingsForm';
 import { auth } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import Avatar from '@/components/common/Avatar';
 import UploadImageForm from '@/components/form/UploadImageForm';
 import { setAvatar } from '@/actions/user';
@@ -13,20 +13,8 @@ import Breadcrumbs from '@/components/common/Breadcrumbs';
 export default async function Page() {
   const session = await auth();
 
-  const user = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      image: true,
-      firstname: true,
-      lastname: true,
-      role: true,
-      storageTier: true,
-      emailVerified: true
-    }
-  });
+  const store = await getStoreAsync();
+  const user = await store.users.findById(session.user.id);
 
   if (!user) return notFound();
 

--- a/src/app/(main)/admin/organisations/[id]/page.tsx
+++ b/src/app/(main)/admin/organisations/[id]/page.tsx
@@ -4,6 +4,7 @@ import Headline from '@/components/common/Headline';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
 import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import Link from 'next/link';
 import OrganisationForm from '@/components/form/OrganisationForm';
 import MemberList from '@/components/common/MemberList';
@@ -52,16 +53,7 @@ export default async function EditOrganisationPage({ params }: EditOrganisationP
         }
       },
     }),
-    prisma.user.findMany({
-      orderBy: { email: 'asc' },
-      select: {
-        id: true,
-        email: true,
-        name: true,
-        firstname: true,
-        lastname: true,
-      },
-    }),
+    getStoreAsync().then(store => store.users.findMany()),
   ]);
 
   if (!organisation) {

--- a/src/app/(main)/admin/organisations/new/page.tsx
+++ b/src/app/(main)/admin/organisations/new/page.tsx
@@ -2,21 +2,13 @@ import Container from '@/components/common/Container';
 import Headline from '@/components/common/Headline';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
-import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import Link from 'next/link';
 import OrganisationForm from '@/components/form/OrganisationForm';
 
 export default async function NewOrganisationPage() {
-  const users = await prisma.user.findMany({
-    orderBy: { email: 'asc' },
-    select: {
-      id: true,
-      email: true,
-      name: true,
-      firstname: true,
-      lastname: true,
-    },
-  });
+  const store = await getStoreAsync();
+  const users = await store.users.findMany();
 
   return (
     <main className="mt-4">

--- a/src/app/(main)/admin/users/[id]/page.tsx
+++ b/src/app/(main)/admin/users/[id]/page.tsx
@@ -3,7 +3,7 @@ import Container from '@/components/common/Container';
 import Headline from '@/components/common/Headline';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
-import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import Link from 'next/link';
 import UpdateUserForm from '@/components/form/UpdateUserForm';
 
@@ -14,9 +14,8 @@ interface EditUserPageProps {
 export default async function EditUserPage({ params }: EditUserPageProps) {
   const { id } = await params;
 
-  const user = await prisma.user.findUnique({
-    where: { id },
-  });
+  const store = await getStoreAsync();
+  const user = await store.users.findById(id);
 
   if (!user) {
     notFound();

--- a/src/app/(main)/admin/users/page.tsx
+++ b/src/app/(main)/admin/users/page.tsx
@@ -4,7 +4,7 @@ import { Divider } from '@/components/common/Divider';
 import { Intro } from '@/components/Intro';
 import Table from '@/components/GenericTable';
 import { columns } from '@/components/table/User';
-import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 
 export default async function Page({
   searchParams,
@@ -15,10 +15,11 @@ export default async function Page({
   const { page = '1' } = await searchParams;
   const pageNumber = Number(page);
 
-  const count = await prisma.user.count();
+  const store = await getStoreAsync();
+  const count = await store.users.count();
 
-  const users = await prisma.user.findMany({
-    orderBy: { createdAt: 'desc' },
+  const users = await store.users.findMany({
+    orderBy: 'createdAt',
     skip: (pageNumber - 1) * size,
     take: size,
   });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import Credentials from 'next-auth/providers/credentials';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import { compare } from 'bcrypt-ts';
 import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import authConfig from '@/lib/auth.config';
 
 // Build providers array conditionally
@@ -24,9 +25,8 @@ providers.push(
   Credentials({
     authorize: async (credentials: Partial<Record<string, unknown>>) => {
       const { email, password } = credentials as { email: string; password: string };
-      const user = await prisma.user.findUnique({
-        where: { email },
-      });
+      const store = await getStoreAsync();
+      const user = await store.users.findByEmail(email);
       if (!user) return null;
 
       const passwordsMatch = await compare(password, user.password);

--- a/src/lib/services/user.ts
+++ b/src/lib/services/user.ts
@@ -1,51 +1,14 @@
-import { PrismaClient, User, UserRole } from '@prisma/client';
+import { getStoreAsync } from '@/lib/store';
+import type { User, UserRole } from '@/lib/store';
+import type { CreateUserData, UpdateUserData, UserSearchResult } from '@/lib/store/repositories/user.repository';
 
-const prisma = new PrismaClient();
-
-export interface CreateUserData {
-  name?: string;
-  firstname?: string;
-  lastname?: string;
-  email: string;
-  image?: string;
-  role?: UserRole;
-  password?: string;
-}
-
-export interface UpdateUserData {
-  name?: string;
-  firstname?: string;
-  lastname?: string;
-  email?: string;
-  image?: string;
-  role?: UserRole;
-}
-
-export interface UserSearchResult {
-  id: string;
-  name?: string;
-  firstname?: string;
-  lastname?: string;
-  email: string;
-  image?: string;
-  role: UserRole;
-  createdAt: Date;
-}
+export type { CreateUserData, UpdateUserData, UserSearchResult };
 
 export class UserService {
   async createUser(data: CreateUserData): Promise<User> {
     try {
-      return await prisma.user.create({
-        data: {
-          name: data.name,
-          firstname: data.firstname,
-          lastname: data.lastname,
-          email: data.email,
-          image: data.image,
-          role: data.role ?? UserRole.CUSTOMER,
-          password: data.password ?? '',
-        },
-      });
+      const store = await getStoreAsync();
+      return await store.users.create(data);
     } catch (error) {
       console.error('Failed to create user:', error);
       throw error;
@@ -54,9 +17,8 @@ export class UserService {
 
   async getUserById(userId: string): Promise<User | null> {
     try {
-      return await prisma.user.findUnique({
-        where: { id: userId },
-      });
+      const store = await getStoreAsync();
+      return await store.users.findById(userId);
     } catch (error) {
       console.error('Failed to get user by ID:', error);
       throw error;
@@ -65,9 +27,8 @@ export class UserService {
 
   async getUserByEmail(email: string): Promise<User | null> {
     try {
-      return await prisma.user.findUnique({
-        where: { email },
-      });
+      const store = await getStoreAsync();
+      return await store.users.findByEmail(email);
     } catch (error) {
       console.error('Failed to get user by email:', error);
       throw error;
@@ -76,17 +37,8 @@ export class UserService {
 
   async updateUser(userId: string, data: UpdateUserData): Promise<User> {
     try {
-      return await prisma.user.update({
-        where: { id: userId },
-        data: {
-          name: data.name,
-          firstname: data.firstname,
-          lastname: data.lastname,
-          email: data.email,
-          image: data.image,
-          role: data.role,
-        },
-      });
+      const store = await getStoreAsync();
+      return await store.users.update(userId, data);
     } catch (error) {
       console.error('Failed to update user:', error);
       throw error;
@@ -95,12 +47,10 @@ export class UserService {
 
   async updateUserAdmin(userId: string, data: UpdateUserData, adminUserId: string): Promise<User> {
     try {
-      // Check if the admin user has admin privileges
       const adminUser = await this.getUserById(adminUserId);
-      if (adminUser?.role !== UserRole.ADMIN) {
+      if (adminUser?.role !== 'ADMIN') {
         throw new Error('Insufficient permissions to update user');
       }
-
       return await this.updateUser(userId, data);
     } catch (error) {
       console.error('Failed to update user as admin:', error);
@@ -111,11 +61,8 @@ export class UserService {
   async setUserAvatar(userId: string, images: string[]): Promise<User> {
     try {
       const imageUrl = images.length > 0 ? images[0] : null;
-
-      return await prisma.user.update({
-        where: { id: userId },
-        data: { image: imageUrl },
-      });
+      const store = await getStoreAsync();
+      return await store.users.update(userId, { image: imageUrl });
     } catch (error) {
       console.error('Failed to set user avatar:', error);
       throw error;
@@ -124,52 +71,8 @@ export class UserService {
 
   async searchUsers(query: string, limit: number = 10): Promise<UserSearchResult[]> {
     try {
-      const users = await prisma.user.findMany({
-        where: {
-          OR: [
-            {
-              name: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            },
-            {
-              firstname: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            },
-            {
-              lastname: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            },
-            {
-              email: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            },
-          ],
-        },
-        select: {
-          id: true,
-          name: true,
-          firstname: true,
-          lastname: true,
-          email: true,
-          image: true,
-          role: true,
-          createdAt: true,
-        },
-        orderBy: [
-          { name: 'asc' },
-        ],
-        take: limit,
-      });
-
-      return users;
+      const store = await getStoreAsync();
+      return await store.users.search(query, limit);
     } catch (error) {
       console.error('Failed to search users:', error);
       return [];
@@ -178,12 +81,8 @@ export class UserService {
 
   async deactivateUser(userId: string): Promise<User> {
     try {
-      // Since there's no isActive field, we could use role or implement a soft delete differently
-      // For now, let's change role to GUEST to indicate inactive status
-      return await prisma.user.update({
-        where: { id: userId },
-        data: { role: UserRole.GUEST },
-      });
+      const store = await getStoreAsync();
+      return await store.users.update(userId, { role: 'GUEST' });
     } catch (error) {
       console.error('Failed to deactivate user:', error);
       throw error;
@@ -203,7 +102,7 @@ export class UserService {
   async isUserAdmin(userId: string): Promise<boolean> {
     try {
       const user = await this.getUserById(userId);
-      return user?.role === UserRole.ADMIN;
+      return user?.role === 'ADMIN';
     } catch (error) {
       console.error('Failed to check admin status:', error);
       return false;

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -1,8 +1,10 @@
+import type { IUserRepository } from './repositories/user.repository';
 import type { IApiKeyRepository } from './repositories/api-key.repository';
 import type { IAuditLogRepository } from './repositories/audit-log.repository';
 import type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository } from './repositories/user-storage.repository';
 import { createStore } from 'tinybase';
 import { createFilePersister, type FilePersister } from 'tinybase/persisters/persister-file';
+import { TinyBaseUserRepository } from './tinybase/user.tinybase';
 import { TinyBaseApiKeyRepository } from './tinybase/api-key.tinybase';
 import { TinyBaseAuditLogRepository } from './tinybase/audit-log.tinybase';
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
@@ -10,6 +12,7 @@ import path from 'path';
 import fs from 'fs';
 
 export interface DataStore {
+  users: IUserRepository;
   apiKeys: IApiKeyRepository;
   auditLogs: IAuditLogRepository;
   storageQuotas: IUserStorageQuotaRepository;
@@ -34,6 +37,7 @@ async function createDataStore(): Promise<DataStore> {
   await persister.startAutoSave();
 
   return {
+    users: new TinyBaseUserRepository(tinyStore),
     apiKeys: new TinyBaseApiKeyRepository(tinyStore),
     auditLogs: new TinyBaseAuditLogRepository(tinyStore),
     storageQuotas: new TinyBaseUserStorageQuotaRepository(tinyStore),

--- a/src/lib/store/repositories/user.repository.ts
+++ b/src/lib/store/repositories/user.repository.ts
@@ -11,12 +11,13 @@ export interface CreateUserData {
 }
 
 export interface UpdateUserData {
-  name?: string;
-  firstname?: string;
-  lastname?: string;
+  name?: string | null;
+  firstname?: string | null;
+  lastname?: string | null;
   email?: string;
-  image?: string;
+  image?: string | null;
   role?: UserRole;
+  password?: string;
 }
 
 export interface UserSearchResult {
@@ -34,6 +35,7 @@ export interface IUserRepository {
   create(data: CreateUserData): Promise<User>;
   findById(id: string): Promise<User | null>;
   findByEmail(email: string): Promise<User | null>;
+  findMany(options?: { skip?: number; take?: number; orderBy?: 'createdAt' }): Promise<User[]>;
   update(id: string, data: UpdateUserData): Promise<User>;
   search(query: string, limit?: number): Promise<UserSearchResult[]>;
   count(): Promise<number>;

--- a/src/lib/store/tinybase/user.tinybase.ts
+++ b/src/lib/store/tinybase/user.tinybase.ts
@@ -1,0 +1,138 @@
+import type { Store } from 'tinybase';
+import type { User, UserRole, StorageTier } from '../types';
+import type { IUserRepository, CreateUserData, UpdateUserData, UserSearchResult } from '../repositories/user.repository';
+import crypto from 'crypto';
+
+const TABLE = 'users';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToUser(id: string, row: Record<string, any>): User {
+  return {
+    id,
+    firstname: (row.firstname as string) || null,
+    lastname: (row.lastname as string) || null,
+    name: (row.name as string) || null,
+    email: row.email as string,
+    emailVerified: row.emailVerified ? new Date(row.emailVerified as string) : null,
+    image: (row.image as string) || null,
+    password: row.password as string,
+    role: row.role as UserRole,
+    storageTier: (row.storageTier as StorageTier) || 'FREE_500MB',
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+  };
+}
+
+export class TinyBaseUserRepository implements IUserRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateUserData): Promise<User> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(TABLE, id, {
+      firstname: data.firstname ?? '',
+      lastname: data.lastname ?? '',
+      name: data.name ?? '',
+      email: data.email,
+      emailVerified: '',
+      image: data.image ?? '',
+      password: data.password ?? '',
+      role: data.role ?? 'CUSTOMER',
+      storageTier: 'FREE_500MB',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return rowToUser(id, this.store.getRow(TABLE, id));
+  }
+
+  async findById(id: string): Promise<User | null> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.email) return null;
+    return rowToUser(id, row);
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const rowIds = this.store.getRowIds(TABLE);
+    for (const id of rowIds) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.email === email) return rowToUser(id, row);
+    }
+    return null;
+  }
+
+  async findMany(options?: { skip?: number; take?: number; orderBy?: 'createdAt' }): Promise<User[]> {
+    const rowIds = this.store.getRowIds(TABLE);
+    let results: User[] = [];
+
+    for (const id of rowIds) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.email) results.push(rowToUser(id, row));
+    }
+
+    if (options?.orderBy === 'createdAt') {
+      results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    }
+
+    if (options?.skip) results = results.slice(options.skip);
+    if (options?.take) results = results.slice(0, options.take);
+    return results;
+  }
+
+  async update(id: string, data: UpdateUserData): Promise<User> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.email) throw new Error(`User ${id} not found`);
+
+    if (data.name !== undefined) this.store.setCell(TABLE, id, 'name', data.name ?? '');
+    if (data.firstname !== undefined) this.store.setCell(TABLE, id, 'firstname', data.firstname ?? '');
+    if (data.lastname !== undefined) this.store.setCell(TABLE, id, 'lastname', data.lastname ?? '');
+    if (data.email !== undefined) this.store.setCell(TABLE, id, 'email', data.email);
+    if (data.image !== undefined) this.store.setCell(TABLE, id, 'image', data.image ?? '');
+    if (data.role !== undefined) this.store.setCell(TABLE, id, 'role', data.role);
+    if (data.password !== undefined) this.store.setCell(TABLE, id, 'password', data.password);
+    this.store.setCell(TABLE, id, 'updatedAt', new Date().toISOString());
+
+    return rowToUser(id, this.store.getRow(TABLE, id));
+  }
+
+  async search(query: string, limit: number = 10): Promise<UserSearchResult[]> {
+    const rowIds = this.store.getRowIds(TABLE);
+    const q = query.toLowerCase();
+    let results: UserSearchResult[] = [];
+
+    for (const id of rowIds) {
+      const row = this.store.getRow(TABLE, id);
+      if (!row.email) continue;
+
+      const matches =
+        ((row.name as string) || '').toLowerCase().includes(q) ||
+        ((row.firstname as string) || '').toLowerCase().includes(q) ||
+        ((row.lastname as string) || '').toLowerCase().includes(q) ||
+        ((row.email as string) || '').toLowerCase().includes(q);
+
+      if (matches) {
+        results.push({
+          id,
+          name: (row.name as string) || null,
+          firstname: (row.firstname as string) || null,
+          lastname: (row.lastname as string) || null,
+          email: row.email as string,
+          image: (row.image as string) || null,
+          role: row.role as UserRole,
+          createdAt: new Date(row.createdAt as string),
+        });
+      }
+    }
+
+    results.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+    return results.slice(0, limit);
+  }
+
+  async count(): Promise<number> {
+    return this.store.getRowIds(TABLE).length;
+  }
+}

--- a/tests/store/tinybase/user.tinybase.test.ts
+++ b/tests/store/tinybase/user.tinybase.test.ts
@@ -1,0 +1,167 @@
+import { createStore } from 'tinybase';
+import { TinyBaseUserRepository } from '@/lib/store/tinybase/user.tinybase';
+import type { CreateUserData } from '@/lib/store/repositories/user.repository';
+
+describe('TinyBaseUserRepository', () => {
+  let repo: TinyBaseUserRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseUserRepository(createStore());
+  });
+
+  const sampleUser: CreateUserData = {
+    name: 'John Doe',
+    firstname: 'John',
+    lastname: 'Doe',
+    email: 'john@example.com',
+    password: 'hashed-password',
+    role: 'CUSTOMER',
+  };
+
+  describe('create', () => {
+    it('creates a user with generated id and timestamps', async () => {
+      const user = await repo.create(sampleUser);
+      expect(user.id).toBeDefined();
+      expect(user.name).toBe('John Doe');
+      expect(user.email).toBe('john@example.com');
+      expect(user.role).toBe('CUSTOMER');
+      expect(user.storageTier).toBe('FREE_500MB');
+      expect(user.createdAt).toBeInstanceOf(Date);
+    });
+
+    it('defaults role to CUSTOMER', async () => {
+      const user = await repo.create({ email: 'test@example.com' });
+      expect(user.role).toBe('CUSTOMER');
+    });
+  });
+
+  describe('findById', () => {
+    it('returns user when found', async () => {
+      const created = await repo.create(sampleUser);
+      const found = await repo.findById(created.id);
+      expect(found).not.toBeNull();
+      expect(found!.email).toBe('john@example.com');
+    });
+
+    it('returns null for missing id', async () => {
+      expect(await repo.findById('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('findByEmail', () => {
+    it('returns user when found', async () => {
+      await repo.create(sampleUser);
+      const found = await repo.findByEmail('john@example.com');
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe('John Doe');
+    });
+
+    it('returns null for unknown email', async () => {
+      expect(await repo.findByEmail('unknown@example.com')).toBeNull();
+    });
+  });
+
+  describe('findMany', () => {
+    it('returns all users', async () => {
+      await repo.create(sampleUser);
+      await repo.create({ ...sampleUser, email: 'jane@example.com', name: 'Jane' });
+      const users = await repo.findMany();
+      expect(users).toHaveLength(2);
+    });
+
+    it('supports pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await repo.create({ ...sampleUser, email: `user${i}@example.com` });
+      }
+      const page = await repo.findMany({ skip: 1, take: 2 });
+      expect(page).toHaveLength(2);
+    });
+
+    it('orders by createdAt desc', async () => {
+      await repo.create({ ...sampleUser, email: 'first@example.com', name: 'First' });
+      await new Promise(r => setTimeout(r, 5));
+      await repo.create({ ...sampleUser, email: 'second@example.com', name: 'Second' });
+
+      const users = await repo.findMany({ orderBy: 'createdAt' });
+      expect(users[0].name).toBe('Second');
+    });
+  });
+
+  describe('update', () => {
+    it('updates name and email', async () => {
+      const user = await repo.create(sampleUser);
+      const updated = await repo.update(user.id, { name: 'Jane Doe', email: 'jane@example.com' });
+      expect(updated.name).toBe('Jane Doe');
+      expect(updated.email).toBe('jane@example.com');
+    });
+
+    it('updates role', async () => {
+      const user = await repo.create(sampleUser);
+      const updated = await repo.update(user.id, { role: 'ADMIN' });
+      expect(updated.role).toBe('ADMIN');
+    });
+
+    it('sets nullable fields to null', async () => {
+      const user = await repo.create(sampleUser);
+      const updated = await repo.update(user.id, { firstname: null, lastname: null });
+      expect(updated.firstname).toBeNull();
+      expect(updated.lastname).toBeNull();
+    });
+
+    it('updates password', async () => {
+      const user = await repo.create(sampleUser);
+      const updated = await repo.update(user.id, { password: 'new-hash' });
+      expect(updated.password).toBe('new-hash');
+    });
+
+    it('throws for missing user', async () => {
+      await expect(repo.update('missing', { name: 'x' })).rejects.toThrow();
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(async () => {
+      await repo.create({ ...sampleUser, email: 'alice@example.com', name: 'Alice Smith', firstname: 'Alice', lastname: 'Smith' });
+      await repo.create({ ...sampleUser, email: 'bob@example.com', name: 'Bob Jones', firstname: 'Bob', lastname: 'Jones' });
+      await repo.create({ ...sampleUser, email: 'carol@example.com', name: 'Carol Smith', firstname: 'Carol', lastname: 'Smith' });
+    });
+
+    it('searches by name (case-insensitive)', async () => {
+      const results = await repo.search('alice');
+      expect(results).toHaveLength(1);
+      expect(results[0].email).toBe('alice@example.com');
+    });
+
+    it('searches by email', async () => {
+      const results = await repo.search('bob@');
+      expect(results).toHaveLength(1);
+    });
+
+    it('searches by lastname', async () => {
+      const results = await repo.search('smith');
+      expect(results).toHaveLength(2);
+    });
+
+    it('respects limit', async () => {
+      const results = await repo.search('example.com', 2);
+      expect(results).toHaveLength(2);
+    });
+
+    it('returns empty for no match', async () => {
+      const results = await repo.search('zzzzz');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('count', () => {
+    it('returns 0 when empty', async () => {
+      expect(await repo.count()).toBe(0);
+    });
+
+    it('returns correct count', async () => {
+      await repo.create(sampleUser);
+      await repo.create({ ...sampleUser, email: 'other@example.com' });
+      expect(await repo.count()).toBe(2);
+    });
+  });
+});

--- a/tests/store/types.test.ts
+++ b/tests/store/types.test.ts
@@ -362,6 +362,7 @@ describe('Store types', () => {
       resetStore();
       const store = await getStoreAsync();
       expect(store).toBeDefined();
+      expect(store.users).toBeDefined();
       expect(store.apiKeys).toBeDefined();
       expect(store.auditLogs).toBeDefined();
       expect(store.storageQuotas).toBeDefined();


### PR DESCRIPTION
## Summary
- **Zero `prisma.user.*` calls remain** in the entire codebase
- TinyBaseUserRepository with create, findById, findByEmail, findMany, update, search, count
- UserService refactored to delegate to store repository
- auth.ts Credentials authorize uses store for user lookup
- All user actions, admin pages, and settings page updated

## Files modified (12)
- `src/lib/services/user.ts` — fully rewritten to use store
- `src/lib/auth.ts` — authorize callback uses store (PrismaAdapter kept for now)
- `src/actions/user.ts` — all prisma calls replaced
- `src/actions/resource.ts` — user existence check
- 5 page files (settings, admin users, admin orgs)
- `src/lib/store/data-store.ts` — added users repository

## Test plan
- [x] 106 store tests pass (`npx jest --selectProjects store`)
- [x] 21 new User tests: CRUD, search, pagination, count
- [x] `grep -r "prisma\.user\." src/` returns nothing
- [ ] Manual: login, register, user settings, admin user management