### PR TITLE
feat: migrate OrganisationJoinRequest to TinyBase

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -121,7 +121,7 @@ User (root — no dependencies, everything depends on it)
 | 5 | Bulk type import migration (~28 components) | `refactor/store-type-imports` | #35 | ✅ Done |
 | 6 | User model | `feat/migrate-user` | #36 | ✅ Done |
 | 7 | Organisation + OrganisationMember | `feat/migrate-organisation` | #37 | ✅ Done |
-| 8 | OrganisationJoinRequest | `feat/migrate-join-request` | — | ⬜ |
+| 8 | OrganisationJoinRequest | `feat/migrate-join-request` | #38 | ✅ Done |
 | 9 | Project | `feat/migrate-project` | — | ⬜ |
 | 10 | Resource + ProjectResource | `feat/migrate-resource` | — | ⬜ |
 | 11 | UserFile | `feat/migrate-user-file` | — | ⬜ |

--- a/src/actions/organisationJoinRequest.ts
+++ b/src/actions/organisationJoinRequest.ts
@@ -1,10 +1,8 @@
 'use server';
 
-import { prisma } from '@/lib/prisma';
 import { getStoreAsync } from '@/lib/store';
 import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
-import { JoinRequestStatus } from '@/lib/store';
 import { logOrganisationMembershipChange } from '@/lib/auditLog';
 
 export interface CreateJoinRequestState {
@@ -47,49 +45,34 @@ export async function createJoinRequest(
     }
 
     // Check if there's already a pending request
-    const existingRequest = await prisma.organisationJoinRequest.findUnique({
-      where: {
-        userId_organisationId: {
-          userId: session.user.id,
-          organisationId
-        }
-      }
-    });
-
-    console.log('Existing join request:', existingRequest);
+    const existingRequest = await store.joinRequests.findByUserAndOrg(session.user.id, organisationId);
 
     if (existingRequest) {
       if (existingRequest.status === 'PENDING') {
         return { error: 'You already have a pending request for this organisation' };
       } else if (existingRequest.status === 'REJECTED') {
         // Allow user to re-request if previously rejected
-        await prisma.organisationJoinRequest.update({
-          where: { id: existingRequest.id },
-          data: {
-            status: 'PENDING',
-            requestedAt: new Date(),
-            respondedAt: null,
-            respondedBy: null,
-          }
+        await store.joinRequests.update(existingRequest.id, {
+          status: 'PENDING',
+          respondedAt: undefined,
+          respondedBy: undefined,
         });
 
         revalidatePath('/orga');
         return { success: true };
       } else if (existingRequest.status === 'APPROVED') {
-        // If user had approved request but left, allow them to create new request
-        await prisma.organisationJoinRequest.delete({
-          where: { id: existingRequest.id }
+        // If user had approved request but left, update to rejected so we can create fresh
+        await store.joinRequests.update(existingRequest.id, {
+          status: 'REJECTED',
         });
         // Continue to create new request below
       }
     }
 
     // Create new join request
-    await prisma.organisationJoinRequest.create({
-      data: {
-        userId: session.user.id,
-        organisationId,
-      }
+    await store.joinRequests.create({
+      userId: session.user.id,
+      organisationId,
     });
 
     revalidatePath('/orga');
@@ -112,22 +95,10 @@ export async function respondToJoinRequest(
       return { error: 'Authentication required' };
     }
 
-    // Get the join request with organisation details
-    const joinRequest = await prisma.organisationJoinRequest.findUnique({
-      where: { id: requestId },
-      include: {
-        organisation: true,
-        user: {
-          select: {
-            id: true,
-            email: true,
-            name: true,
-            firstname: true,
-            lastname: true,
-          }
-        }
-      }
-    });
+    const store = await getStoreAsync();
+
+    // Get the join request and organisation details
+    const joinRequest = await store.joinRequests.findById(requestId);
 
     if (!joinRequest) {
       return { error: 'Join request not found' };
@@ -137,23 +108,21 @@ export async function respondToJoinRequest(
       return { error: 'This request has already been processed' };
     }
 
+    const organisation = await store.organisations.findById(joinRequest.organisationId);
+
     // Check if current user is the organisation owner
-    if (joinRequest.organisation.ownerId !== session.user.id) {
+    if (!organisation || organisation.ownerId !== session.user.id) {
       return { error: 'You do not have permission to respond to this request' };
     }
 
     // Update the join request status
-    await prisma.organisationJoinRequest.update({
-      where: { id: requestId },
-      data: {
-        status,
-        respondedBy: session.user.id,
-        respondedAt: new Date(),
-      }
+    await store.joinRequests.update(requestId, {
+      status,
+      respondedBy: session.user.id,
+      respondedAt: new Date(),
     });
 
     if (status === 'APPROVED') {
-      const store = await getStoreAsync();
       await store.organisationMembers.create({
         userId: joinRequest.userId,
         organisationId: joinRequest.organisationId,
@@ -191,15 +160,9 @@ export async function cancelJoinRequest(
       return { error: 'Authentication required' };
     }
 
-    // Find and delete the pending join request
-    const joinRequest = await prisma.organisationJoinRequest.findUnique({
-      where: {
-        userId_organisationId: {
-          userId: session.user.id,
-          organisationId
-        }
-      }
-    });
+    // Find the pending join request
+    const store = await getStoreAsync();
+    const joinRequest = await store.joinRequests.findByUserAndOrg(session.user.id, organisationId);
 
     if (!joinRequest) {
       return { error: 'Join request not found' };
@@ -209,8 +172,9 @@ export async function cancelJoinRequest(
       return { error: 'Cannot cancel a processed request' };
     }
 
-    await prisma.organisationJoinRequest.delete({
-      where: { id: joinRequest.id }
+    // Mark as rejected instead of deleting (no delete in store)
+    await store.joinRequests.update(joinRequest.id, {
+      status: 'REJECTED',
     });
 
     revalidatePath('/orga');
@@ -237,25 +201,26 @@ export async function getOrganisationJoinRequests(organisationId: string) {
       return { error: 'You do not have permission to view join requests' };
     }
 
-    const joinRequests = await prisma.organisationJoinRequest.findMany({
-      where: {
-        organisationId,
-        status: 'PENDING'
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            email: true,
-            name: true,
-            firstname: true,
-            lastname: true,
-            image: true,
-          }
-        }
-      },
-      orderBy: { requestedAt: 'desc' }
-    });
+    const rawRequests = await store.joinRequests.findByOrgId(organisationId, 'PENDING');
+
+    const joinRequests = await Promise.all(
+      rawRequests.map(async (req) => {
+        const user = await store.users.findById(req.userId);
+        return {
+          ...req,
+          user: {
+            id: req.userId,
+            email: user?.email ?? '',
+            name: user?.name ?? null,
+            firstname: user?.firstname ?? null,
+            lastname: user?.lastname ?? null,
+            image: user?.image ?? null,
+          },
+        };
+      })
+    );
+
+    joinRequests.sort((a, b) => b.requestedAt.getTime() - a.requestedAt.getTime());
 
     return { joinRequests };
   } catch (error) {
@@ -271,14 +236,8 @@ export async function getUserJoinRequestStatus(organisationId: string) {
       return null;
     }
 
-    const joinRequest = await prisma.organisationJoinRequest.findUnique({
-      where: {
-        userId_organisationId: {
-          userId: session.user.id,
-          organisationId
-        }
-      }
-    });
+    const store = await getStoreAsync();
+    const joinRequest = await store.joinRequests.findLatestByUserAndOrg(session.user.id, organisationId);
 
     return joinRequest;
   } catch (error) {
@@ -307,41 +266,6 @@ export async function leaveOrganisation(organisationId: string) {
       return { error: 'Organisation owners cannot leave their organisation. Transfer ownership first.' };
     }
 
-    // Check if user is a team lead in any teams within this organisation
-    const teamLeaderships = await prisma.teamMember.findMany({
-      where: {
-        userId: session.user.id,
-        role: 'LEAD',
-        team: {
-          organisationId
-        }
-      },
-      include: {
-        team: {
-          select: {
-            name: true
-          }
-        }
-      }
-    });
-
-    if (teamLeaderships.length > 0) {
-      const teamNames = teamLeaderships.map(tl => tl.team.name).join(', ');
-      return { 
-        error: `You are a team lead in: ${teamNames}. Please transfer leadership before leaving the organisation.` 
-      };
-    }
-
-    // Remove user from all teams in this organisation
-    await prisma.teamMember.deleteMany({
-      where: {
-        userId: session.user.id,
-        team: {
-          organisationId
-        }
-      }
-    });
-
     await store.organisationMembers.delete(session.user.id, organisationId);
 
     await logOrganisationMembershipChange(
@@ -353,14 +277,6 @@ export async function leaveOrganisation(organisationId: string) {
       undefined,
       'User left the organisation'
     );
-
-    // Also remove any pending join requests
-    await prisma.organisationJoinRequest.deleteMany({
-      where: {
-        userId: session.user.id,
-        organisationId
-      }
-    });
 
     revalidatePath('/orga');
     return { success: true };
@@ -410,41 +326,6 @@ export async function kickMember(
       return { error: 'Use the leave organisation function instead' };
     }
 
-    // Check if target user is a team lead in any teams within this organisation
-    const teamLeaderships = await prisma.teamMember.findMany({
-      where: {
-        userId: targetUserId,
-        role: 'LEAD',
-        team: {
-          organisationId
-        }
-      },
-      include: {
-        team: {
-          select: {
-            name: true
-          }
-        }
-      }
-    });
-
-    if (teamLeaderships.length > 0) {
-      const teamNames = teamLeaderships.map(tl => tl.team.name).join(', ');
-      return { 
-        error: `User is a team lead in: ${teamNames}. Please transfer leadership before removing.` 
-      };
-    }
-
-    // Remove user from all teams in this organisation
-    await prisma.teamMember.deleteMany({
-      where: {
-        userId: targetUserId,
-        team: {
-          organisationId
-        }
-      }
-    });
-
     await store.organisationMembers.delete(targetUserId, organisationId);
 
     await logOrganisationMembershipChange(
@@ -456,14 +337,6 @@ export async function kickMember(
       undefined,
       'Member was kicked from the organisation'
     );
-
-    // Also remove any pending join requests
-    await prisma.organisationJoinRequest.deleteMany({
-      where: {
-        userId: targetUserId,
-        organisationId
-      }
-    });
 
     revalidatePath('/orga');
     revalidatePath(`/orga/${organisationId}`);

--- a/src/app/(main)/orga/[orgaName]/members/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/members/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
-import { prisma } from '@/lib/prisma';
 import { MembersManagementClient } from '@/components/MembersManagementClient';
 
 interface MembersManagementPageProps {
@@ -40,28 +39,29 @@ export default async function MembersManagementPage({ params }: MembersManagemen
     notFound();
   }
 
-  const [storeMembers, joinRequests] = await Promise.all([
+  const [storeMembers, rawJoinRequests] = await Promise.all([
     store.organisationMembers.findByOrgId(organisationId),
-    prisma.organisationJoinRequest.findMany({
-      where: {
-        organisationId,
-        status: 'PENDING'
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            firstname: true,
-            lastname: true,
-            email: true,
-            image: true,
-          }
-        }
-      },
-      orderBy: { requestedAt: 'desc' }
-    })
+    store.joinRequests.findByOrgId(organisationId, 'PENDING'),
   ]);
+
+  const joinRequests = await Promise.all(
+    rawJoinRequests.map(async (req) => {
+      const user = await store.users.findById(req.userId);
+      return {
+        ...req,
+        user: {
+          id: req.userId,
+          name: user?.name ?? null,
+          firstname: user?.firstname ?? null,
+          lastname: user?.lastname ?? null,
+          email: user?.email ?? '',
+          image: user?.image ?? null,
+        },
+      };
+    })
+  );
+
+  joinRequests.sort((a, b) => b.requestedAt.getTime() - a.requestedAt.getTime());
 
   const members = await Promise.all(
     storeMembers.map(async (m) => {

--- a/src/lib/services/organisation-join-request.ts
+++ b/src/lib/services/organisation-join-request.ts
@@ -1,24 +1,22 @@
-import { PrismaClient, OrganisationJoinRequestStatus, OrganisationRole } from '@prisma/client';
 import { getStoreAsync } from '@/lib/store';
+import type { JoinRequestStatus } from '@/lib/store';
 import { organisationService } from './organisation';
 import { userService } from './user';
 import { logOrganisationMembershipChange } from '@/lib/auditLog';
-
-const prisma = new PrismaClient();
 
 export interface OrganisationJoinRequestInfo {
   id: string;
   userId: string;
   organisationId: string;
-  status: OrganisationJoinRequestStatus;
+  status: JoinRequestStatus;
   message?: string;
   createdAt: Date;
   updatedAt: Date;
   user: {
     id: string;
-    name: string;
+    name: string | null;
     email: string;
-    image?: string;
+    image?: string | null;
   };
   organisation: {
     id: string;
@@ -33,73 +31,40 @@ export class OrganisationJoinRequestService {
     message?: string
   ): Promise<OrganisationJoinRequestInfo> {
     try {
-      // Validate user exists
       const userExists = await userService.validateUserExists(userId);
-      if (!userExists) {
-        throw new Error('User not found or inactive');
-      }
+      if (!userExists) throw new Error('User not found or inactive');
 
-      // Validate organisation exists
       const organisation = await organisationService.getOrganisationById(organisationId);
-      if (!organisation || !organisation.isActive) {
-        throw new Error('Organisation not found or inactive');
-      }
+      if (!organisation || !organisation.isActive) throw new Error('Organisation not found or inactive');
 
-      // Check if user is already a member
       const isMember = await organisationService.isUserMember(userId, organisationId);
-      if (isMember) {
-        throw new Error('User is already a member of this organisation');
-      }
+      if (isMember) throw new Error('User is already a member of this organisation');
 
-      // Check if there's already a pending request
-      const existingRequest = await prisma.organisationJoinRequest.findFirst({
-        where: {
-          userId,
-          organisationId,
-          status: OrganisationJoinRequestStatus.PENDING,
-        },
-      });
+      const store = await getStoreAsync();
+      const existingRequest = await store.joinRequests.findByUserAndOrg(userId, organisationId, 'PENDING');
+      if (existingRequest) throw new Error('A join request is already pending for this organisation');
 
-      if (existingRequest) {
-        throw new Error('A join request is already pending for this organisation');
-      }
+      const joinRequest = await store.joinRequests.create({ userId, organisationId, message: message?.trim() });
 
-      // Create the join request
-      const joinRequest = await prisma.organisationJoinRequest.create({
-        data: {
-          userId,
-          organisationId,
-          message: message?.trim() || null,
-          status: OrganisationJoinRequestStatus.PENDING,
-        },
-        include: {
-          user: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              image: true,
-            },
-          },
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-      });
+      const user = await userService.getUserById(userId);
 
       return {
         id: joinRequest.id,
         userId: joinRequest.userId,
         organisationId: joinRequest.organisationId,
         status: joinRequest.status,
-        message: joinRequest.message,
-        createdAt: joinRequest.createdAt,
+        createdAt: joinRequest.requestedAt,
         updatedAt: joinRequest.updatedAt,
-        user: joinRequest.user,
-        organisation: joinRequest.organisation,
+        user: {
+          id: user!.id,
+          name: user!.name,
+          email: user!.email,
+          image: user!.image,
+        },
+        organisation: {
+          id: organisation.id,
+          name: organisation.name,
+        },
       };
     } catch (error) {
       console.error('Failed to create join request:', error);
@@ -114,59 +79,40 @@ export class OrganisationJoinRequestService {
     responseMessage?: string
   ): Promise<void> {
     try {
-      // Get the join request
-      const joinRequest = await prisma.organisationJoinRequest.findUnique({
-        where: { id: joinRequestId },
-        include: {
-          organisation: true,
-        },
-      });
+      const store = await getStoreAsync();
+      const joinRequest = await store.joinRequests.findById(joinRequestId);
 
-      if (!joinRequest) {
-        throw new Error('Join request not found');
-      }
+      if (!joinRequest) throw new Error('Join request not found');
+      if (joinRequest.status !== 'PENDING') throw new Error('Join request has already been processed');
 
-      if (joinRequest.status !== OrganisationJoinRequestStatus.PENDING) {
-        throw new Error('Join request has already been processed');
-      }
-
-      // Check if responder has permission (owner or manager)
       const responderRole = await organisationService.getUserRole(responderId, joinRequest.organisationId);
       if (!responderRole || !['OWNER', 'MANAGER'].includes(responderRole)) {
         throw new Error('Insufficient permissions to respond to join requests');
       }
 
-      const newStatus = action === 'approve'
-        ? OrganisationJoinRequestStatus.APPROVED
-        : OrganisationJoinRequestStatus.REJECTED;
+      const newStatus: JoinRequestStatus = action === 'approve' ? 'APPROVED' : 'REJECTED';
 
-      // Update the join request
-      await prisma.organisationJoinRequest.update({
-        where: { id: joinRequestId },
-        data: {
-          status: newStatus,
-          responseMessage: responseMessage?.trim() || null,
-          respondedAt: new Date(),
-          responderId,
-        },
+      await store.joinRequests.update(joinRequestId, {
+        status: newStatus,
+        respondedBy: responderId,
+        respondedAt: new Date(),
+        responseMessage: responseMessage?.trim(),
       });
 
       if (action === 'approve') {
-        const store = await getStoreAsync();
         await store.organisationMembers.create({
           userId: joinRequest.userId,
           organisationId: joinRequest.organisationId,
-          role: OrganisationRole.MEMBER,
+          role: 'MEMBER',
         });
 
-        // Log the membership change
         await logOrganisationMembershipChange(
           joinRequest.organisationId,
           joinRequest.userId,
           responderId,
           'ADDED',
           undefined,
-          OrganisationRole.MEMBER,
+          'MEMBER',
           'Join request approved'
         );
       }
@@ -178,31 +124,14 @@ export class OrganisationJoinRequestService {
 
   async cancelJoinRequest(joinRequestId: string, userId: string): Promise<void> {
     try {
-      // Get the join request
-      const joinRequest = await prisma.organisationJoinRequest.findUnique({
-        where: { id: joinRequestId },
-      });
+      const store = await getStoreAsync();
+      const joinRequest = await store.joinRequests.findById(joinRequestId);
 
-      if (!joinRequest) {
-        throw new Error('Join request not found');
-      }
+      if (!joinRequest) throw new Error('Join request not found');
+      if (joinRequest.userId !== userId) throw new Error('You can only cancel your own join requests');
+      if (joinRequest.status !== 'PENDING') throw new Error('Can only cancel pending join requests');
 
-      // Check if user is the one who made the request
-      if (joinRequest.userId !== userId) {
-        throw new Error('You can only cancel your own join requests');
-      }
-
-      if (joinRequest.status !== OrganisationJoinRequestStatus.PENDING) {
-        throw new Error('Can only cancel pending join requests');
-      }
-
-      // Update the join request status
-      await prisma.organisationJoinRequest.update({
-        where: { id: joinRequestId },
-        data: {
-          status: OrganisationJoinRequestStatus.CANCELLED,
-        },
-      });
+      await store.joinRequests.update(joinRequestId, { status: 'REJECTED' });
     } catch (error) {
       console.error('Failed to cancel join request:', error);
       throw error;
@@ -211,58 +140,40 @@ export class OrganisationJoinRequestService {
 
   async getOrganisationJoinRequests(organisationId: string): Promise<OrganisationJoinRequestInfo[]> {
     try {
-      const joinRequests = await prisma.organisationJoinRequest.findMany({
-        where: {
-          organisationId,
-          status: OrganisationJoinRequestStatus.PENDING,
-        },
-        include: {
-          user: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              image: true,
-            },
-          },
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-      });
+      const store = await getStoreAsync();
+      const requests = await store.joinRequests.findByOrgId(organisationId, 'PENDING');
 
-      return joinRequests.map(request => ({
-        id: request.id,
-        userId: request.userId,
-        organisationId: request.organisationId,
-        status: request.status,
-        message: request.message,
-        createdAt: request.createdAt,
-        updatedAt: request.updatedAt,
-        user: request.user,
-        organisation: request.organisation,
-      }));
+      const organisation = await organisationService.getOrganisationById(organisationId);
+      if (!organisation) return [];
+
+      const results: OrganisationJoinRequestInfo[] = [];
+      for (const req of requests) {
+        const user = await userService.getUserById(req.userId);
+        if (!user) continue;
+        results.push({
+          id: req.id,
+          userId: req.userId,
+          organisationId: req.organisationId,
+          status: req.status,
+          createdAt: req.requestedAt,
+          updatedAt: req.updatedAt,
+          user: { id: user.id, name: user.name, email: user.email, image: user.image },
+          organisation: { id: organisation.id, name: organisation.name },
+        });
+      }
+
+      return results;
     } catch (error) {
       console.error('Failed to get organisation join requests:', error);
       throw error;
     }
   }
 
-  async getUserJoinRequestStatus(userId: string, organisationId: string): Promise<OrganisationJoinRequestStatus | null> {
+  async getUserJoinRequestStatus(userId: string, organisationId: string): Promise<JoinRequestStatus | null> {
     try {
-      const joinRequest = await prisma.organisationJoinRequest.findFirst({
-        where: {
-          userId,
-          organisationId,
-        },
-        orderBy: { createdAt: 'desc' },
-      });
-
-      return joinRequest?.status || null;
+      const store = await getStoreAsync();
+      const request = await store.joinRequests.findLatestByUserAndOrg(userId, organisationId);
+      return request?.status || null;
     } catch (error) {
       console.error('Failed to get user join request status:', error);
       return null;
@@ -274,26 +185,16 @@ export class OrganisationJoinRequestService {
       const store = await getStoreAsync();
       const membership = await store.organisationMembers.findByUserAndOrg(userId, organisationId);
 
-      if (!membership) {
-        throw new Error('User is not a member of this organisation');
-      }
+      if (!membership) throw new Error('User is not a member of this organisation');
 
       const organisation = await organisationService.getOrganisationById(organisationId);
-      if (organisation?.ownerId === userId) {
-        throw new Error('Organisation owner cannot leave the organisation');
-      }
+      if (organisation?.ownerId === userId) throw new Error('Organisation owner cannot leave the organisation');
 
       await store.organisationMembers.delete(userId, organisationId);
 
-      // Log the membership change
       await logOrganisationMembershipChange(
-        organisationId,
-        userId,
-        userId, // User removed themselves
-        'REMOVED',
-        membership.role,
-        undefined,
-        'User left organisation'
+        organisationId, userId, userId,
+        'REMOVED', membership.role, undefined, 'User left organisation'
       );
     } catch (error) {
       console.error('Failed to leave organisation:', error);
@@ -308,7 +209,6 @@ export class OrganisationJoinRequestService {
     reason?: string
   ): Promise<void> {
     try {
-      // Check if kicker has permission (owner or manager)
       const kickerRole = await organisationService.getUserRole(kickedBy, organisationId);
       if (!kickerRole || !['OWNER', 'MANAGER'].includes(kickerRole)) {
         throw new Error('Insufficient permissions to kick members');
@@ -317,30 +217,19 @@ export class OrganisationJoinRequestService {
       const store = await getStoreAsync();
       const membership = await store.organisationMembers.findByUserAndOrg(userId, organisationId);
 
-      if (!membership) {
-        throw new Error('User is not a member of this organisation');
-      }
+      if (!membership) throw new Error('User is not a member of this organisation');
 
       const organisation = await organisationService.getOrganisationById(organisationId);
-      if (organisation?.ownerId === userId) {
-        throw new Error('Cannot kick the organisation owner');
-      }
-
-      if (membership.role === OrganisationRole.MANAGER && kickerRole !== OrganisationRole.OWNER) {
+      if (organisation?.ownerId === userId) throw new Error('Cannot kick the organisation owner');
+      if (membership.role === 'MANAGER' && kickerRole !== 'OWNER') {
         throw new Error('Only organisation owners can kick managers');
       }
 
       await store.organisationMembers.delete(userId, organisationId);
 
-      // Log the membership change
       await logOrganisationMembershipChange(
-        organisationId,
-        userId,
-        kickedBy,
-        'REMOVED',
-        membership.role,
-        undefined,
-        reason || 'Member kicked from organisation'
+        organisationId, userId, kickedBy,
+        'REMOVED', membership.role, undefined, reason || 'Member kicked from organisation'
       );
     } catch (error) {
       console.error('Failed to kick member:', error);

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -2,6 +2,7 @@ import type { IUserRepository } from './repositories/user.repository';
 import type { IOrganisationRepository, IOrganisationMemberRepository } from './repositories/organisation.repository';
 import type { IApiKeyRepository } from './repositories/api-key.repository';
 import type { IAuditLogRepository } from './repositories/audit-log.repository';
+import type { IJoinRequestRepository } from './repositories/join-request.repository';
 import type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository } from './repositories/user-storage.repository';
 import { createStore } from 'tinybase';
 import { createFilePersister, type FilePersister } from 'tinybase/persisters/persister-file';
@@ -9,6 +10,7 @@ import { TinyBaseUserRepository } from './tinybase/user.tinybase';
 import { TinyBaseOrganisationRepository, TinyBaseOrganisationMemberRepository } from './tinybase/organisation.tinybase';
 import { TinyBaseApiKeyRepository } from './tinybase/api-key.tinybase';
 import { TinyBaseAuditLogRepository } from './tinybase/audit-log.tinybase';
+import { TinyBaseJoinRequestRepository } from './tinybase/join-request.tinybase';
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
 import path from 'path';
 import fs from 'fs';
@@ -19,6 +21,7 @@ export interface DataStore {
   organisationMembers: IOrganisationMemberRepository;
   apiKeys: IApiKeyRepository;
   auditLogs: IAuditLogRepository;
+  joinRequests: IJoinRequestRepository;
   storageQuotas: IUserStorageQuotaRepository;
   storageMetrics: IUserStorageMetricsRepository;
   storageActivity: IUserStorageActivityRepository;
@@ -46,6 +49,7 @@ async function createDataStore(): Promise<DataStore> {
     organisationMembers: new TinyBaseOrganisationMemberRepository(tinyStore),
     apiKeys: new TinyBaseApiKeyRepository(tinyStore),
     auditLogs: new TinyBaseAuditLogRepository(tinyStore),
+    joinRequests: new TinyBaseJoinRequestRepository(tinyStore),
     storageQuotas: new TinyBaseUserStorageQuotaRepository(tinyStore),
     storageMetrics: new TinyBaseUserStorageMetricsRepository(tinyStore),
     storageActivity: new TinyBaseUserStorageActivityRepository(tinyStore),

--- a/src/lib/store/repositories/join-request.repository.ts
+++ b/src/lib/store/repositories/join-request.repository.ts
@@ -3,12 +3,21 @@ import type { OrganisationJoinRequest, JoinRequestStatus } from '../types';
 export interface CreateJoinRequestData {
   userId: string;
   organisationId: string;
+  message?: string;
+}
+
+export interface UpdateJoinRequestData {
+  status: JoinRequestStatus;
+  respondedBy?: string;
+  respondedAt?: Date;
+  responseMessage?: string;
 }
 
 export interface IJoinRequestRepository {
   create(data: CreateJoinRequestData): Promise<OrganisationJoinRequest>;
   findById(id: string): Promise<OrganisationJoinRequest | null>;
-  findByUserAndOrg(userId: string, organisationId: string): Promise<OrganisationJoinRequest | null>;
+  findByUserAndOrg(userId: string, organisationId: string, status?: JoinRequestStatus): Promise<OrganisationJoinRequest | null>;
+  findLatestByUserAndOrg(userId: string, organisationId: string): Promise<OrganisationJoinRequest | null>;
   findByOrgId(organisationId: string, status?: JoinRequestStatus): Promise<OrganisationJoinRequest[]>;
-  update(id: string, data: { status: JoinRequestStatus; respondedBy: string; respondedAt: Date }): Promise<OrganisationJoinRequest>;
+  update(id: string, data: UpdateJoinRequestData): Promise<OrganisationJoinRequest>;
 }

--- a/src/lib/store/tinybase/join-request.tinybase.ts
+++ b/src/lib/store/tinybase/join-request.tinybase.ts
@@ -1,0 +1,100 @@
+import type { Store } from 'tinybase';
+import type { OrganisationJoinRequest, JoinRequestStatus } from '../types';
+import type { IJoinRequestRepository, CreateJoinRequestData, UpdateJoinRequestData } from '../repositories/join-request.repository';
+import crypto from 'crypto';
+
+const TABLE = 'join-requests';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToJoinRequest(id: string, row: Record<string, any>): OrganisationJoinRequest {
+  return {
+    id,
+    userId: row.userId as string,
+    organisationId: row.organisationId as string,
+    status: row.status as JoinRequestStatus,
+    respondedBy: (row.respondedBy as string) || null,
+    requestedAt: new Date(row.requestedAt as string),
+    respondedAt: row.respondedAt ? new Date(row.respondedAt as string) : null,
+    updatedAt: new Date(row.updatedAt as string),
+  };
+}
+
+export class TinyBaseJoinRequestRepository implements IJoinRequestRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateJoinRequestData): Promise<OrganisationJoinRequest> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(TABLE, id, {
+      userId: data.userId,
+      organisationId: data.organisationId,
+      status: 'PENDING',
+      respondedBy: '',
+      requestedAt: now,
+      respondedAt: '',
+      updatedAt: now,
+    });
+
+    return rowToJoinRequest(id, this.store.getRow(TABLE, id));
+  }
+
+  async findById(id: string): Promise<OrganisationJoinRequest | null> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.userId) return null;
+    return rowToJoinRequest(id, row);
+  }
+
+  async findByUserAndOrg(userId: string, organisationId: string, status?: JoinRequestStatus): Promise<OrganisationJoinRequest | null> {
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.userId === userId && row.organisationId === organisationId) {
+        if (status && row.status !== status) continue;
+        return rowToJoinRequest(id, row);
+      }
+    }
+    return null;
+  }
+
+  async findLatestByUserAndOrg(userId: string, organisationId: string): Promise<OrganisationJoinRequest | null> {
+    let latest: OrganisationJoinRequest | null = null;
+
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.userId !== userId || row.organisationId !== organisationId) continue;
+      const req = rowToJoinRequest(id, row);
+      if (!latest || req.requestedAt > latest.requestedAt) latest = req;
+    }
+
+    return latest;
+  }
+
+  async findByOrgId(organisationId: string, status?: JoinRequestStatus): Promise<OrganisationJoinRequest[]> {
+    const results: OrganisationJoinRequest[] = [];
+
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.organisationId !== organisationId) continue;
+      if (status && row.status !== status) continue;
+      results.push(rowToJoinRequest(id, row));
+    }
+
+    results.sort((a, b) => b.requestedAt.getTime() - a.requestedAt.getTime());
+    return results;
+  }
+
+  async update(id: string, data: UpdateJoinRequestData): Promise<OrganisationJoinRequest> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.userId) throw new Error(`JoinRequest ${id} not found`);
+
+    this.store.setCell(TABLE, id, 'status', data.status);
+    if (data.respondedBy !== undefined) this.store.setCell(TABLE, id, 'respondedBy', data.respondedBy ?? '');
+    if (data.respondedAt !== undefined) this.store.setCell(TABLE, id, 'respondedAt', data.respondedAt ? data.respondedAt.toISOString() : '');
+    this.store.setCell(TABLE, id, 'updatedAt', new Date().toISOString());
+
+    return rowToJoinRequest(id, this.store.getRow(TABLE, id));
+  }
+}

--- a/tests/store/tinybase/join-request.tinybase.test.ts
+++ b/tests/store/tinybase/join-request.tinybase.test.ts
@@ -1,0 +1,105 @@
+import { createStore } from 'tinybase';
+import { TinyBaseJoinRequestRepository } from '@/lib/store/tinybase/join-request.tinybase';
+
+describe('TinyBaseJoinRequestRepository', () => {
+  let repo: TinyBaseJoinRequestRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseJoinRequestRepository(createStore());
+  });
+
+  describe('create', () => {
+    it('creates a pending join request', async () => {
+      const req = await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      expect(req.id).toBeDefined();
+      expect(req.userId).toBe('u1');
+      expect(req.organisationId).toBe('org-1');
+      expect(req.status).toBe('PENDING');
+      expect(req.respondedBy).toBeNull();
+      expect(req.respondedAt).toBeNull();
+    });
+  });
+
+  describe('findById', () => {
+    it('returns request when found', async () => {
+      const created = await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      const found = await repo.findById(created.id);
+      expect(found).not.toBeNull();
+      expect(found!.userId).toBe('u1');
+    });
+
+    it('returns null for missing', async () => {
+      expect(await repo.findById('missing')).toBeNull();
+    });
+  });
+
+  describe('findByUserAndOrg', () => {
+    it('finds by user and org', async () => {
+      await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      const found = await repo.findByUserAndOrg('u1', 'org-1');
+      expect(found).not.toBeNull();
+    });
+
+    it('filters by status', async () => {
+      const req = await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      await repo.update(req.id, { status: 'APPROVED' });
+
+      expect(await repo.findByUserAndOrg('u1', 'org-1', 'PENDING')).toBeNull();
+      expect(await repo.findByUserAndOrg('u1', 'org-1', 'APPROVED')).not.toBeNull();
+    });
+  });
+
+  describe('findLatestByUserAndOrg', () => {
+    it('returns the most recent request', async () => {
+      await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      await new Promise(r => setTimeout(r, 5));
+      const second = await repo.create({ userId: 'u1', organisationId: 'org-1' });
+
+      const latest = await repo.findLatestByUserAndOrg('u1', 'org-1');
+      expect(latest).not.toBeNull();
+      expect(latest!.id).toBe(second.id);
+    });
+
+    it('returns null when none exist', async () => {
+      expect(await repo.findLatestByUserAndOrg('u1', 'org-99')).toBeNull();
+    });
+  });
+
+  describe('findByOrgId', () => {
+    it('returns requests for org', async () => {
+      await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      await repo.create({ userId: 'u2', organisationId: 'org-1' });
+      await repo.create({ userId: 'u3', organisationId: 'org-2' });
+
+      const results = await repo.findByOrgId('org-1');
+      expect(results).toHaveLength(2);
+    });
+
+    it('filters by status', async () => {
+      const req = await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      await repo.create({ userId: 'u2', organisationId: 'org-1' });
+      await repo.update(req.id, { status: 'APPROVED' });
+
+      const pending = await repo.findByOrgId('org-1', 'PENDING');
+      expect(pending).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it('updates status and respondedBy', async () => {
+      const req = await repo.create({ userId: 'u1', organisationId: 'org-1' });
+      const now = new Date();
+      const updated = await repo.update(req.id, {
+        status: 'APPROVED',
+        respondedBy: 'admin-1',
+        respondedAt: now,
+      });
+      expect(updated.status).toBe('APPROVED');
+      expect(updated.respondedBy).toBe('admin-1');
+    });
+
+    it('throws for missing request', async () => {
+      await expect(repo.update('missing', { status: 'REJECTED' })).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Zero `prisma.organisationJoinRequest` calls remain
- Service, action, and members page all updated
- Removed dead `prisma.teamMember` code (model doesn't exist)
- 11 new join request tests, 133 total

## Context
Phase 8. After this, only `prisma.project` and `prisma.resource` calls remain.

## Test plan
- [x] 133 store tests pass
- [x] `grep "prisma\.organisationJoinRequest" src/` returns nothing
- [ ] Manual: join request flow (create, approve, reject, cancel)