### PR TITLE
feat: migrate Project model to TinyBase data store

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -122,7 +122,7 @@ User (root — no dependencies, everything depends on it)
 | 6 | User model | `feat/migrate-user` | #36 | ✅ Done |
 | 7 | Organisation + OrganisationMember | `feat/migrate-organisation` | #37 | ✅ Done |
 | 8 | OrganisationJoinRequest | `feat/migrate-join-request` | #38 | ✅ Done |
-| 9 | Project | `feat/migrate-project` | — | ⬜ |
+| 9 | Project | `feat/migrate-project` | #39 | ✅ Done |
 | 10 | Resource + ProjectResource | `feat/migrate-resource` | — | ⬜ |
 | 11 | UserFile | `feat/migrate-user-file` | — | ⬜ |
 | 12 | Switch auth to Dex OIDC | `feat/dex-oidc-auth` | — | ⬜ |

--- a/src/actions/command-palette.ts
+++ b/src/actions/command-palette.ts
@@ -60,16 +60,11 @@ export async function getOrganisationProjects(organisationId: string): Promise<C
       return [];
     }
 
-    const projects = await prisma.project.findMany({
-      where: { organisationId },
-      select: {
-        id: true,
-        name: true,
-        organisationId: true,
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 50, // Limit results for performance
-    });
+    const allProjects = await store.projects.findByOrgId(organisationId);
+    const projects = allProjects
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 50)
+      .map(p => ({ id: p.id, name: p.name, organisationId: p.organisationId }));
 
     return projects;
   } catch (error) {
@@ -86,16 +81,12 @@ export async function getProjectResources(projectId: string): Promise<CommandPal
     }
 
     // First, get the project to find its organisation
-    const project = await prisma.project.findUnique({
-      where: { id: projectId },
-      select: { organisationId: true },
-    });
+    const store = await getStoreAsync();
+    const project = await store.projects.findById(projectId);
 
     if (!project) {
       return [];
     }
-
-    const store = await getStoreAsync();
     const isMember = await store.organisationMembers.findByUserAndOrg(session.user.id, project.organisationId);
 
     if (!isMember) {

--- a/src/actions/project.ts
+++ b/src/actions/project.ts
@@ -5,7 +5,6 @@ import { type ProjectStatus, type ProjectPriority } from '@/lib/store';
 import { getStoreAsync } from '@/lib/store';
 import { projectService } from '@/lib/services/project';
 import { userService } from '@/lib/services/user';
-import { prisma } from '@/lib/prisma';
 import { validateNameFormat } from '@/lib/name-validation';
 
 export interface UpdateProjectState {
@@ -148,10 +147,8 @@ export async function updateProject(
     }
 
     // Get current project to check organisation
-    const currentProject = await prisma.project.findUnique({
-      where: { id: projectId },
-      select: { organisationId: true }
-    });
+    const store = await getStoreAsync();
+    const currentProject = await store.projects.findById(projectId);
 
     if (!currentProject) {
       return {
@@ -170,26 +167,22 @@ export async function updateProject(
     }
 
     // Update project
-    await prisma.project.update({
-      where: { id: projectId },
-      data: {
-        name: name.trim(),
-        description: description?.trim() || null,
-        development,
-        status,
-        priority,
-        budget,
-        currency: currency || 'USD',
-        startDate,
-        endDate,
-        actualEndDate,
-        progress,
-        repositoryUrl: repositoryUrl?.trim() || null,
-        documentationUrl: documentationUrl?.trim() || null,
-      }
+    await store.projects.update(projectId, {
+      name: name.trim(),
+      description: description?.trim() || null,
+      development,
+      status,
+      priority,
+      budget,
+      currency: currency || 'USD',
+      startDate,
+      endDate,
+      actualEndDate,
+      progress,
+      repositoryUrl: repositoryUrl?.trim() || null,
+      documentationUrl: documentationUrl?.trim() || null,
     });
 
-    const store = await getStoreAsync();
     const org = await store.organisations.findById(currentProject.organisationId);
 
     revalidatePath('/admin/project');
@@ -308,26 +301,24 @@ export async function createProject(
       };
     }
 
-    const project = await prisma.project.create({
-      data: {
-        name: name.trim(),
-        description: description?.trim() || null,
-        development,
-        status,
-        priority,
-        budget,
-        currency: currency || 'USD',
-        startDate,
-        endDate,
-        actualEndDate,
-        progress,
-        repositoryUrl: repositoryUrl?.trim() || null,
-        documentationUrl: documentationUrl?.trim() || null,
-        organisationId,
-      },
+    const store = await getStoreAsync();
+    const project = await store.projects.create({
+      name: name.trim(),
+      description: description?.trim() || null,
+      development,
+      status,
+      priority,
+      budget,
+      currency: currency || 'USD',
+      startDate,
+      endDate,
+      actualEndDate,
+      progress,
+      repositoryUrl: repositoryUrl?.trim() || null,
+      documentationUrl: documentationUrl?.trim() || null,
+      organisationId,
     });
 
-    const store = await getStoreAsync();
     const org = await store.organisations.findById(organisationId);
 
     revalidatePath('/admin/project');

--- a/src/actions/resource.ts
+++ b/src/actions/resource.ts
@@ -118,9 +118,7 @@ export async function createResource(
 
     // Validate project if provided
     if (projectId && projectId.trim()) {
-      const projectExists = await prisma.project.findUnique({
-        where: { id: projectId }
-      });
+      const projectExists = await store.projects.findById(projectId);
 
       if (!projectExists) {
         return {
@@ -280,9 +278,8 @@ export async function updateResource(
 
     // Validate project if provided
     if (projectId && projectId.trim()) {
-      const projectExists = await prisma.project.findUnique({
-        where: { id: projectId }
-      });
+      const store = await getStoreAsync();
+      const projectExists = await store.projects.findById(projectId);
 
       if (!projectExists) {
         return {
@@ -416,9 +413,9 @@ export async function allocateResourceToProject(
     }
 
     // Check if project exists and belongs to same organisation
-    const project = await prisma.project.findUnique({
-      where: { id: projectId, isActive: true }
-    });
+    const store = await getStoreAsync();
+    const projectFound = await store.projects.findById(projectId);
+    const project = projectFound?.isActive ? projectFound : null;
 
     if (!project) {
       return { error: 'Project not found' };

--- a/src/app/(main)/admin/projects/[id]/page.tsx
+++ b/src/app/(main)/admin/projects/[id]/page.tsx
@@ -3,7 +3,6 @@ import Container from '@/components/common/Container';
 import Headline from '@/components/common/Headline';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
-import { prisma } from '@/lib/prisma';
 import { getStoreAsync } from '@/lib/store';
 import Link from 'next/link';
 import ProjectForm from '@/components/form/ProjectForm';
@@ -18,17 +17,7 @@ export default async function EditProjectPage({ params }: EditProjectPageProps) 
 
   const store = await getStoreAsync();
   const [projectRaw, allOrgs] = await Promise.all([
-    prisma.project.findUnique({
-      where: { id },
-      include: {
-        team: {
-          include: {
-            owner: true,
-            organisation: true,
-          },
-        },
-      },
-    }),
+    store.projects.findById(id),
     store.organisations.search('', 10000),
   ]);
 

--- a/src/app/(main)/admin/projects/page.tsx
+++ b/src/app/(main)/admin/projects/page.tsx
@@ -3,7 +3,7 @@ import Headline from '@/components/common/Headline';
 import { Button } from '@/components/common/Button';
 import Table from '@/components/GenericTable';
 import { columns } from '@/components/table/Project';
-import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import Link from 'next/link';
 
 export default async function ProjectAdminPage({
@@ -15,21 +15,14 @@ export default async function ProjectAdminPage({
   const { page = '1' } = await searchParams;
   const pageNumber = Number(page);
 
-  const count = await prisma.project.count();
+  const store = await getStoreAsync();
+  const allProjects = await store.projects.search('', 10000);
+  const count = allProjects.length;
 
-  const projectsRaw = await prisma.project.findMany({
-    include: {
-      team: {
-        include: {
-          owner: true,
-          organisation: true,
-        },
-      },
-    },
-    orderBy: { createdAt: 'desc' },
-    skip: (pageNumber - 1) * size,
-    take: size,
-  });
+  const sorted = allProjects.sort((a, b) =>
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  const projectsRaw = sorted.slice((pageNumber - 1) * size, pageNumber * size);
 
   // Convert Decimal to string for client components
   const projects = projectsRaw.map(project => ({

--- a/src/app/(main)/orga/[orgaName]/[projectName]/[resourceName]/layout.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/[resourceName]/layout.tsx
@@ -23,14 +23,8 @@ export default async function ResourceLayout({
     notFound();
   }
 
-  const project = await prisma.project.findFirst({
-    where: {
-      name: projectName,
-      organisationId: organisation.id,
-      isActive: true,
-    },
-    select: { id: true },
-  });
+  const projectFound = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  const project = projectFound?.isActive ? projectFound : null;
 
   if (!project) {
     notFound();

--- a/src/app/(main)/orga/[orgaName]/[projectName]/layout.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/layout.tsx
@@ -23,64 +23,47 @@ export default async function ProjectLayout({
     notFound();
   }
 
-  const projectRaw = await prisma.project.findFirst({
-    where: {
-      name: projectName,
-      organisationId: organisation.id,
-      isActive: true,
-    },
+  const projectFound = await store.projects.findByNameAndOrg(projectName, organisation.id);
+
+  if (!projectFound || !projectFound.isActive) {
+    notFound();
+  }
+
+  const allocatedResources = await prisma.projectResource.findMany({
+    where: { projectId: projectFound.id },
     include: {
-      organisation: {
-        select: {
-          id: true,
-          name: true,
-        },
-      },
-      allocatedResources: {
+      resource: {
         include: {
-          resource: {
-            include: {
-              owner: {
-                select: {
-                  id: true,
-                  name: true,
-                  firstname: true,
-                  lastname: true,
-                  email: true,
-                },
-              },
-              organisation: {
-                select: {
-                  id: true,
-                  name: true,
-                },
-              },
+          owner: {
+            select: {
+              id: true,
+              name: true,
+              firstname: true,
+              lastname: true,
+              email: true,
             },
           },
-        },
-      },
-      _count: {
-        select: {
-          allocatedResources: true,
+          organisation: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
       },
     },
   });
 
-  if (!projectRaw) {
-    notFound();
-  }
-
-  // Filter allocated resources to only active ones
-  const filteredAllocatedResources = projectRaw.allocatedResources.filter(
+  const filteredAllocatedResources = allocatedResources.filter(
     allocation => allocation.resource.isActive && allocation.resource.status === 'ACTIVE'
   );
 
-  // Convert Decimal budget to string for client components
   const project = {
-    ...projectRaw,
-    budget: projectRaw.budget?.toString() || null,
+    ...projectFound,
+    budget: projectFound.budget?.toString() || null,
+    organisation: { id: organisation.id, name: organisation.name },
     allocatedResources: filteredAllocatedResources,
+    _count: { allocatedResources: allocatedResources.length },
   };
 
   return (

--- a/src/app/(main)/orga/[orgaName]/settings/test-resource-api/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/settings/test-resource-api/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
-import { prisma } from '@/lib/prisma';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { RiArrowLeftLine } from '@remixicon/react';
@@ -42,14 +41,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
     );
   }
 
-  const projects = await prisma.project.findMany({
-    where: { organisationId: organisation.id },
-    select: {
-      id: true,
-      name: true,
-    },
-    take: 10,
-  });
+  const allProjects = await store.projects.findByOrgId(organisation.id);
+  const projects = allProjects.slice(0, 10).map(p => ({ id: p.id, name: p.name }));
 
   return (
     <div className="space-y-6">

--- a/src/lib/services/project.ts
+++ b/src/lib/services/project.ts
@@ -1,59 +1,13 @@
-import { PrismaClient, ProjectStatus, ProjectPriority } from '@prisma/client';
+import { getStoreAsync } from '@/lib/store';
+import type { Project, ProjectStatus, ProjectPriority } from '@/lib/store';
+import type { CreateProjectData, UpdateProjectData } from '@/lib/store/repositories/project.repository';
 import { organisationService } from './organisation';
 import { validateNameFormat } from '../name-validation';
 
-const prisma = new PrismaClient();
+export type { CreateProjectData, UpdateProjectData };
 
-export interface CreateProjectData {
-  name: string;
-  description?: string;
-  status?: ProjectStatus;
-  priority?: ProjectPriority;
-  budget?: number;
-  currency?: string;
-  startDate?: Date;
-  endDate?: Date;
-  progress?: number;
-  repositoryUrl?: string;
-  documentationUrl?: string;
-  organisationId: string;
-}
-
-export interface UpdateProjectData {
-  name?: string;
-  description?: string;
-  status?: ProjectStatus;
-  priority?: ProjectPriority;
-  budget?: number;
-  currency?: string;
-  startDate?: Date;
-  endDate?: Date;
-  actualEndDate?: Date;
-  progress?: number;
-  repositoryUrl?: string;
-  documentationUrl?: string;
-  organisationId?: string;
-}
-
-export interface ProjectInfo {
-  id: string;
-  name: string;
-  description?: string;
-  status: ProjectStatus;
-  priority: ProjectPriority;
-  budget?: number;
-  currency?: string;
-  startDate?: Date;
-  endDate?: Date;
-  actualEndDate?: Date;
-  progress: number;
-  repositoryUrl?: string;
-  documentationUrl?: string;
-  organisationId: string;
-  isActive: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-  organisation: {
+export interface ProjectInfo extends Project {
+  organisation?: {
     id: string;
     name: string;
   };
@@ -61,66 +15,19 @@ export interface ProjectInfo {
 }
 
 export class ProjectService {
-
   async createProject(userId: string, data: CreateProjectData): Promise<ProjectInfo> {
     try {
-      // Verify user is a member of the organisation
       const isOrganisationMember = await organisationService.isUserMember(userId, data.organisationId);
-      if (!isOrganisationMember) {
-        throw new Error('You are not a member of the specified organisation');
-      }
+      if (!isOrganisationMember) throw new Error('You are not a member of the specified organisation');
 
-      // Check if project name is already taken within the organisation
       const isNameAvailable = await this.validateProjectName(data.name, data.organisationId);
-      if (!isNameAvailable) {
-        throw new Error('Project name is already taken within this organisation');
-      }
+      if (!isNameAvailable) throw new Error('Project name is already taken within this organisation');
 
-      const project = await prisma.project.create({
-        data: {
-          name: data.name,
-          description: data.description,
-          status: data.status || ProjectStatus.PLANNING,
-          priority: data.priority || ProjectPriority.MEDIUM,
-          budget: data.budget,
-          currency: data.currency || 'GBP',
-          startDate: data.startDate,
-          endDate: data.endDate,
-          progress: data.progress || 0,
-          repositoryUrl: data.repositoryUrl,
-          documentationUrl: data.documentationUrl,
-          organisationId: data.organisationId,
-        },
-        include: {
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            }
-          }
-        }
-      });
+      const store = await getStoreAsync();
+      const project = await store.projects.create(data);
+      const org = await store.organisations.findById(data.organisationId);
 
-      return {
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        status: project.status,
-        priority: project.priority,
-        budget: project.budget ? Number(project.budget) : undefined,
-        currency: project.currency,
-        startDate: project.startDate,
-        endDate: project.endDate,
-        actualEndDate: project.actualEndDate,
-        progress: project.progress,
-        repositoryUrl: project.repositoryUrl,
-        documentationUrl: project.documentationUrl,
-        organisationId: project.organisationId,
-        isActive: project.isActive,
-        createdAt: project.createdAt,
-        updatedAt: project.updatedAt,
-        organisation: project.organisation,
-      };
+      return { ...project, organisation: org ? { id: org.id, name: org.name } : undefined };
     } catch (error) {
       console.error('Failed to create project:', error);
       throw error;
@@ -129,46 +36,12 @@ export class ProjectService {
 
   async getProjectById(projectId: string): Promise<ProjectInfo | null> {
     try {
-      const project = await prisma.project.findUnique({
-        where: { id: projectId },
-        include: {
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            }
-          },
-          _count: {
-            select: {
-              files: true,
-            }
-          }
-        }
-      });
-
+      const store = await getStoreAsync();
+      const project = await store.projects.findByIdWithFileCount(projectId);
       if (!project) return null;
 
-      return {
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        status: project.status,
-        priority: project.priority,
-        budget: project.budget ? Number(project.budget) : undefined,
-        currency: project.currency,
-        startDate: project.startDate,
-        endDate: project.endDate,
-        actualEndDate: project.actualEndDate,
-        progress: project.progress,
-        repositoryUrl: project.repositoryUrl,
-        documentationUrl: project.documentationUrl,
-        organisationId: project.organisationId,
-        isActive: project.isActive,
-        createdAt: project.createdAt,
-        updatedAt: project.updatedAt,
-        organisation: project.organisation,
-        fileCount: project._count.files,
-      };
+      const org = await store.organisations.findById(project.organisationId);
+      return { ...project, organisation: org ? { id: org.id, name: org.name } : undefined };
     } catch (error) {
       console.error('Failed to get project by ID:', error);
       throw error;
@@ -177,47 +50,13 @@ export class ProjectService {
 
   async getOrganisationProjects(organisationId: string): Promise<ProjectInfo[]> {
     try {
-      const projects = await prisma.project.findMany({
-        where: {
-          organisationId: organisationId,
-          isActive: true
-        },
-        orderBy: { createdAt: 'desc' },
-        include: {
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            }
-          },
-          _count: {
-            select: {
-              files: true,
-            }
-          }
-        }
-      });
+      const store = await getStoreAsync();
+      const projects = await store.projects.findByOrgId(organisationId, { isActive: true });
+      const org = await store.organisations.findById(organisationId);
 
-      return projects.map(project => ({
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        status: project.status,
-        priority: project.priority,
-        budget: project.budget ? Number(project.budget) : undefined,
-        currency: project.currency,
-        startDate: project.startDate,
-        endDate: project.endDate,
-        actualEndDate: project.actualEndDate,
-        progress: project.progress,
-        repositoryUrl: project.repositoryUrl,
-        documentationUrl: project.documentationUrl,
-        organisationId: project.organisationId,
-        isActive: project.isActive,
-        createdAt: project.createdAt,
-        updatedAt: project.updatedAt,
-        organisation: project.organisation,
-        fileCount: project._count.files,
+      return projects.map(p => ({
+        ...p,
+        organisation: org ? { id: org.id, name: org.name } : undefined,
       }));
     } catch (error) {
       console.error('Failed to get organisation projects:', error);
@@ -227,56 +66,22 @@ export class ProjectService {
 
   async getUserProjects(userId: string): Promise<ProjectInfo[]> {
     try {
-      // Get all organisations the user is a member of
-      const userOrganisations = await organisationService.getUserOrganisations(userId);
-      const organisationIds = userOrganisations.map(org => org.id);
+      const userOrgs = await organisationService.getUserOrganisations(userId);
+      if (userOrgs.length === 0) return [];
 
-      if (organisationIds.length === 0) {
-        return [];
+      const store = await getStoreAsync();
+      const allProjects: ProjectInfo[] = [];
+
+      for (const org of userOrgs) {
+        const projects = await store.projects.findByOrgId(org.id, { isActive: true });
+        allProjects.push(...projects.map(p => ({
+          ...p,
+          organisation: { id: org.id, name: org.name },
+        })));
       }
 
-      const projects = await prisma.project.findMany({
-        where: {
-          organisationId: { in: organisationIds },
-          isActive: true
-        },
-        orderBy: { createdAt: 'desc' },
-        include: {
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            }
-          },
-          _count: {
-            select: {
-              files: true,
-            }
-          }
-        }
-      });
-
-      return projects.map(project => ({
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        status: project.status,
-        priority: project.priority,
-        budget: project.budget ? Number(project.budget) : undefined,
-        currency: project.currency,
-        startDate: project.startDate,
-        endDate: project.endDate,
-        actualEndDate: project.actualEndDate,
-        progress: project.progress,
-        repositoryUrl: project.repositoryUrl,
-        documentationUrl: project.documentationUrl,
-        organisationId: project.organisationId,
-        isActive: project.isActive,
-        createdAt: project.createdAt,
-        updatedAt: project.updatedAt,
-        organisation: project.organisation,
-        fileCount: project._count.files,
-      }));
+      allProjects.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      return allProjects;
     } catch (error) {
       console.error('Failed to get user projects:', error);
       throw error;
@@ -285,89 +90,22 @@ export class ProjectService {
 
   async updateProject(userId: string, projectId: string, data: UpdateProjectData): Promise<ProjectInfo> {
     try {
-      // Get the existing project
       const existingProject = await this.getProjectById(projectId);
-      if (!existingProject) {
-        throw new Error('Project not found');
-      }
+      if (!existingProject) throw new Error('Project not found');
 
-      // Verify user is a member of the project's organisation
       const isOrganisationMember = await organisationService.isUserMember(userId, existingProject.organisationId);
-      if (!isOrganisationMember) {
-        throw new Error('You do not have permission to update this project');
-      }
+      if (!isOrganisationMember) throw new Error('You do not have permission to update this project');
 
-      // If organisationId is being changed, verify user is member of new organisation
-      if (data.organisationId && data.organisationId !== existingProject.organisationId) {
-        const isNewOrganisationMember = await organisationService.isUserMember(userId, data.organisationId);
-        if (!isNewOrganisationMember) {
-          throw new Error('You are not a member of the specified organisation');
-        }
-      }
-
-      // If project name is being changed, validate uniqueness within organisation
       if (data.name && data.name !== existingProject.name) {
-        const targetOrganisationId = data.organisationId || existingProject.organisationId;
-        const nameValidation = await this.validateProjectName(data.name, targetOrganisationId, projectId);
-        if (!nameValidation.isValid) {
-          throw new Error(nameValidation.error || 'Project name is already taken within this organisation');
-        }
+        const nameValidation = await this.validateProjectName(data.name, existingProject.organisationId, projectId);
+        if (!nameValidation.isValid) throw new Error(nameValidation.error || 'Project name is already taken');
       }
 
-      const updateData: any = {};
-      if (data.name !== undefined) updateData.name = data.name;
-      if (data.description !== undefined) updateData.description = data.description;
-      if (data.status !== undefined) updateData.status = data.status;
-      if (data.priority !== undefined) updateData.priority = data.priority;
-      if (data.budget !== undefined) updateData.budget = data.budget;
-      if (data.currency !== undefined) updateData.currency = data.currency;
-      if (data.startDate !== undefined) updateData.startDate = data.startDate;
-      if (data.endDate !== undefined) updateData.endDate = data.endDate;
-      if (data.actualEndDate !== undefined) updateData.actualEndDate = data.actualEndDate;
-      if (data.progress !== undefined) updateData.progress = data.progress;
-      if (data.repositoryUrl !== undefined) updateData.repositoryUrl = data.repositoryUrl;
-      if (data.documentationUrl !== undefined) updateData.documentationUrl = data.documentationUrl;
-      if (data.organisationId !== undefined) updateData.organisationId = data.organisationId;
+      const store = await getStoreAsync();
+      const updated = await store.projects.update(projectId, data);
+      const org = await store.organisations.findById(updated.organisationId);
 
-      const project = await prisma.project.update({
-        where: { id: projectId },
-        data: updateData,
-        include: {
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            }
-          },
-          _count: {
-            select: {
-              files: true,
-            }
-          }
-        }
-      });
-
-      return {
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        status: project.status,
-        priority: project.priority,
-        budget: project.budget ? Number(project.budget) : undefined,
-        currency: project.currency,
-        startDate: project.startDate,
-        endDate: project.endDate,
-        actualEndDate: project.actualEndDate,
-        progress: project.progress,
-        repositoryUrl: project.repositoryUrl,
-        documentationUrl: project.documentationUrl,
-        organisationId: project.organisationId,
-        isActive: project.isActive,
-        createdAt: project.createdAt,
-        updatedAt: project.updatedAt,
-        organisation: project.organisation,
-        fileCount: project._count.files,
-      };
+      return { ...updated, organisation: org ? { id: org.id, name: org.name } : undefined };
     } catch (error) {
       console.error('Failed to update project:', error);
       throw error;
@@ -376,23 +114,14 @@ export class ProjectService {
 
   async deleteProject(userId: string, projectId: string): Promise<void> {
     try {
-      // Get the existing project
       const existingProject = await this.getProjectById(projectId);
-      if (!existingProject) {
-        throw new Error('Project not found');
-      }
+      if (!existingProject) throw new Error('Project not found');
 
-      // Verify user is a member of the project's organisation
       const isOrganisationMember = await organisationService.isUserMember(userId, existingProject.organisationId);
-      if (!isOrganisationMember) {
-        throw new Error('You do not have permission to delete this project');
-      }
+      if (!isOrganisationMember) throw new Error('You do not have permission to delete this project');
 
-      // Soft delete (set isActive to false)
-      await prisma.project.update({
-        where: { id: projectId },
-        data: { isActive: false }
-      });
+      const store = await getStoreAsync();
+      await store.projects.update(projectId, { isActive: false });
     } catch (error) {
       console.error('Failed to delete project:', error);
       throw error;
@@ -401,31 +130,14 @@ export class ProjectService {
 
   async validateProjectName(name: string, organisationId: string, excludeId?: string): Promise<{ isValid: boolean; error?: string }> {
     try {
-      // First validate format and blocked names
       const formatValidation = validateNameFormat(name);
-      if (!formatValidation.isValid) {
-        return formatValidation;
-      }
+      if (!formatValidation.isValid) return formatValidation;
 
-      const whereClause: any = {
-        name,
-        organisationId,
-        isActive: true,
-      };
+      const store = await getStoreAsync();
+      const existing = await store.projects.findByNameAndOrg(name, organisationId);
 
-      if (excludeId) {
-        whereClause.id = { not: excludeId };
-      }
-
-      const existingProject = await prisma.project.findFirst({
-        where: whereClause
-      });
-
-      if (existingProject) {
-        return {
-          isValid: false,
-          error: 'A project with this name already exists in this organisation',
-        };
+      if (existing && existing.id !== excludeId) {
+        return { isValid: false, error: 'A project with this name already exists in this organisation' };
       }
 
       return { isValid: true };
@@ -439,7 +151,6 @@ export class ProjectService {
     try {
       const project = await this.getProjectById(projectId);
       if (!project) return false;
-
       return await organisationService.isUserMember(userId, project.organisationId);
     } catch (error) {
       console.error('Failed to check project access:', error);
@@ -449,55 +160,8 @@ export class ProjectService {
 
   async searchProjects(query: string, limit: number = 10) {
     try {
-      const projects = await prisma.project.findMany({
-        where: {
-          OR: [
-            {
-              name: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            },
-            {
-              description: {
-                contains: query,
-                mode: 'insensitive',
-              },
-            },
-          ],
-          isActive: true,
-        },
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          status: true,
-          priority: true,
-          progress: true,
-          startDate: true,
-          endDate: true,
-          budget: true,
-          currency: true,
-          repositoryUrl: true,
-          documentationUrl: true,
-          isActive: true,
-          organisationId: true,
-          organisation: {
-            select: {
-              id: true,
-              name: true,
-            },
-          },
-          createdAt: true,
-          updatedAt: true,
-        },
-        orderBy: [
-          { updatedAt: 'desc' },
-        ],
-        take: limit,
-      });
-
-      return projects;
+      const store = await getStoreAsync();
+      return await store.projects.search(query, limit);
     } catch (error) {
       console.error('Failed to search projects:', error);
       return [];

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -1,5 +1,6 @@
 import type { IUserRepository } from './repositories/user.repository';
 import type { IOrganisationRepository, IOrganisationMemberRepository } from './repositories/organisation.repository';
+import type { IProjectRepository } from './repositories/project.repository';
 import type { IApiKeyRepository } from './repositories/api-key.repository';
 import type { IAuditLogRepository } from './repositories/audit-log.repository';
 import type { IJoinRequestRepository } from './repositories/join-request.repository';
@@ -10,6 +11,7 @@ import { TinyBaseUserRepository } from './tinybase/user.tinybase';
 import { TinyBaseOrganisationRepository, TinyBaseOrganisationMemberRepository } from './tinybase/organisation.tinybase';
 import { TinyBaseApiKeyRepository } from './tinybase/api-key.tinybase';
 import { TinyBaseAuditLogRepository } from './tinybase/audit-log.tinybase';
+import { TinyBaseProjectRepository } from './tinybase/project.tinybase';
 import { TinyBaseJoinRequestRepository } from './tinybase/join-request.tinybase';
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
 import path from 'path';
@@ -19,6 +21,7 @@ export interface DataStore {
   users: IUserRepository;
   organisations: IOrganisationRepository;
   organisationMembers: IOrganisationMemberRepository;
+  projects: IProjectRepository;
   apiKeys: IApiKeyRepository;
   auditLogs: IAuditLogRepository;
   joinRequests: IJoinRequestRepository;
@@ -47,6 +50,7 @@ async function createDataStore(): Promise<DataStore> {
     users: new TinyBaseUserRepository(tinyStore),
     organisations: new TinyBaseOrganisationRepository(tinyStore),
     organisationMembers: new TinyBaseOrganisationMemberRepository(tinyStore),
+    projects: new TinyBaseProjectRepository(tinyStore),
     apiKeys: new TinyBaseApiKeyRepository(tinyStore),
     auditLogs: new TinyBaseAuditLogRepository(tinyStore),
     joinRequests: new TinyBaseJoinRequestRepository(tinyStore),

--- a/src/lib/store/tinybase/project.tinybase.ts
+++ b/src/lib/store/tinybase/project.tinybase.ts
@@ -1,0 +1,149 @@
+import type { Store } from 'tinybase';
+import type { Project, ProjectStatus, ProjectPriority } from '../types';
+import type { IProjectRepository, CreateProjectData, UpdateProjectData, ProjectWithFileCount } from '../repositories/project.repository';
+import crypto from 'crypto';
+
+const TABLE = 'projects';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToProject(id: string, row: Record<string, any>): Project {
+  return {
+    id,
+    name: row.name as string,
+    description: (row.description as string) || null,
+    development: row.development === 1,
+    status: (row.status as ProjectStatus) || 'PLANNING',
+    priority: (row.priority as ProjectPriority) || 'MEDIUM',
+    budget: row.budget ? Number(row.budget) : null,
+    currency: (row.currency as string) || null,
+    startDate: row.startDate ? new Date(row.startDate as string) : null,
+    endDate: row.endDate ? new Date(row.endDate as string) : null,
+    actualEndDate: row.actualEndDate ? new Date(row.actualEndDate as string) : null,
+    progress: (row.progress as number) || 0,
+    repositoryUrl: (row.repositoryUrl as string) || null,
+    documentationUrl: (row.documentationUrl as string) || null,
+    organisationId: row.organisationId as string,
+    isActive: row.isActive === 1,
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+  };
+}
+
+export class TinyBaseProjectRepository implements IProjectRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateProjectData): Promise<Project> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(TABLE, id, {
+      name: data.name,
+      description: data.description ?? '',
+      development: (data.development ?? false) ? 1 : 0,
+      status: data.status ?? 'PLANNING',
+      priority: data.priority ?? 'MEDIUM',
+      budget: data.budget?.toString() ?? '',
+      currency: data.currency ?? 'GBP',
+      startDate: data.startDate ? data.startDate.toISOString() : '',
+      endDate: data.endDate ? data.endDate.toISOString() : '',
+      actualEndDate: '',
+      progress: 0,
+      repositoryUrl: data.repositoryUrl ?? '',
+      documentationUrl: data.documentationUrl ?? '',
+      organisationId: data.organisationId,
+      isActive: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return rowToProject(id, this.store.getRow(TABLE, id));
+  }
+
+  async findById(id: string): Promise<Project | null> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.name) return null;
+    return rowToProject(id, row);
+  }
+
+  async findByIdWithFileCount(id: string): Promise<ProjectWithFileCount | null> {
+    const project = await this.findById(id);
+    if (!project) return null;
+    // Count files in the user-files table for this project
+    let fileCount = 0;
+    for (const fid of this.store.getRowIds('user-files')) {
+      if (this.store.getRow('user-files', fid).projectId === id) fileCount++;
+    }
+    return { ...project, fileCount };
+  }
+
+  async findByNameAndOrg(name: string, organisationId: string): Promise<Project | null> {
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.name === name && row.organisationId === organisationId && row.isActive === 1) {
+        return rowToProject(id, row);
+      }
+    }
+    return null;
+  }
+
+  async findByOrgId(organisationId: string, options?: { isActive?: boolean }): Promise<Project[]> {
+    const results: Project[] = [];
+
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.organisationId !== organisationId) continue;
+      if (options?.isActive !== undefined) {
+        if ((row.isActive === 1) !== options.isActive) continue;
+      }
+      results.push(rowToProject(id, row));
+    }
+
+    results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return results;
+  }
+
+  async update(id: string, data: UpdateProjectData): Promise<Project> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.name) throw new Error(`Project ${id} not found`);
+
+    if (data.name !== undefined) this.store.setCell(TABLE, id, 'name', data.name);
+    if (data.description !== undefined) this.store.setCell(TABLE, id, 'description', data.description ?? '');
+    if (data.development !== undefined) this.store.setCell(TABLE, id, 'development', data.development ? 1 : 0);
+    if (data.status !== undefined) this.store.setCell(TABLE, id, 'status', data.status);
+    if (data.priority !== undefined) this.store.setCell(TABLE, id, 'priority', data.priority);
+    if (data.budget !== undefined) this.store.setCell(TABLE, id, 'budget', data.budget?.toString() ?? '');
+    if (data.currency !== undefined) this.store.setCell(TABLE, id, 'currency', data.currency ?? '');
+    if (data.startDate !== undefined) this.store.setCell(TABLE, id, 'startDate', data.startDate ? data.startDate.toISOString() : '');
+    if (data.endDate !== undefined) this.store.setCell(TABLE, id, 'endDate', data.endDate ? data.endDate.toISOString() : '');
+    if (data.actualEndDate !== undefined) this.store.setCell(TABLE, id, 'actualEndDate', data.actualEndDate ? data.actualEndDate.toISOString() : '');
+    if (data.progress !== undefined) this.store.setCell(TABLE, id, 'progress', data.progress);
+    if (data.repositoryUrl !== undefined) this.store.setCell(TABLE, id, 'repositoryUrl', data.repositoryUrl ?? '');
+    if (data.documentationUrl !== undefined) this.store.setCell(TABLE, id, 'documentationUrl', data.documentationUrl ?? '');
+    if (data.isActive !== undefined) this.store.setCell(TABLE, id, 'isActive', data.isActive ? 1 : 0);
+    this.store.setCell(TABLE, id, 'updatedAt', new Date().toISOString());
+
+    return rowToProject(id, this.store.getRow(TABLE, id));
+  }
+
+  async search(query: string, limit: number = 10): Promise<Project[]> {
+    const q = query.toLowerCase();
+    let results: Project[] = [];
+
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.isActive !== 1) continue;
+
+      const matches =
+        ((row.name as string) || '').toLowerCase().includes(q) ||
+        ((row.description as string) || '').toLowerCase().includes(q);
+
+      if (matches) results.push(rowToProject(id, row));
+    }
+
+    results.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    return results.slice(0, limit);
+  }
+}

--- a/tests/store/tinybase/project.tinybase.test.ts
+++ b/tests/store/tinybase/project.tinybase.test.ts
@@ -1,0 +1,116 @@
+import { createStore } from 'tinybase';
+import { TinyBaseProjectRepository } from '@/lib/store/tinybase/project.tinybase';
+
+describe('TinyBaseProjectRepository', () => {
+  let repo: TinyBaseProjectRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseProjectRepository(createStore());
+  });
+
+  describe('create', () => {
+    it('creates a project with defaults', async () => {
+      const p = await repo.create({ name: 'my-project', organisationId: 'org-1' });
+      expect(p.id).toBeDefined();
+      expect(p.name).toBe('my-project');
+      expect(p.organisationId).toBe('org-1');
+      expect(p.status).toBe('PLANNING');
+      expect(p.priority).toBe('MEDIUM');
+      expect(p.isActive).toBe(true);
+      expect(p.progress).toBe(0);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns project when found', async () => {
+      const created = await repo.create({ name: 'test', organisationId: 'org-1' });
+      const found = await repo.findById(created.id);
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe('test');
+    });
+
+    it('returns null for missing', async () => {
+      expect(await repo.findById('missing')).toBeNull();
+    });
+  });
+
+  describe('findByNameAndOrg', () => {
+    it('finds active project by name and org', async () => {
+      await repo.create({ name: 'alpha', organisationId: 'org-1' });
+      await repo.create({ name: 'alpha', organisationId: 'org-2' });
+
+      const found = await repo.findByNameAndOrg('alpha', 'org-1');
+      expect(found).not.toBeNull();
+      expect(found!.organisationId).toBe('org-1');
+    });
+
+    it('returns null for inactive project', async () => {
+      const p = await repo.create({ name: 'alpha', organisationId: 'org-1' });
+      await repo.update(p.id, { isActive: false });
+      expect(await repo.findByNameAndOrg('alpha', 'org-1')).toBeNull();
+    });
+  });
+
+  describe('findByOrgId', () => {
+    it('returns projects for org', async () => {
+      await repo.create({ name: 'p1', organisationId: 'org-1' });
+      await repo.create({ name: 'p2', organisationId: 'org-1' });
+      await repo.create({ name: 'p3', organisationId: 'org-2' });
+
+      const results = await repo.findByOrgId('org-1');
+      expect(results).toHaveLength(2);
+    });
+
+    it('filters by isActive', async () => {
+      const p = await repo.create({ name: 'p1', organisationId: 'org-1' });
+      await repo.create({ name: 'p2', organisationId: 'org-1' });
+      await repo.update(p.id, { isActive: false });
+
+      expect(await repo.findByOrgId('org-1', { isActive: true })).toHaveLength(1);
+      expect(await repo.findByOrgId('org-1', { isActive: false })).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it('updates name and status', async () => {
+      const p = await repo.create({ name: 'old', organisationId: 'org-1' });
+      const updated = await repo.update(p.id, { name: 'new', status: 'ACTIVE' });
+      expect(updated.name).toBe('new');
+      expect(updated.status).toBe('ACTIVE');
+    });
+
+    it('soft deletes via isActive', async () => {
+      const p = await repo.create({ name: 'test', organisationId: 'org-1' });
+      const deleted = await repo.update(p.id, { isActive: false });
+      expect(deleted.isActive).toBe(false);
+    });
+
+    it('throws for missing project', async () => {
+      await expect(repo.update('missing', { name: 'x' })).rejects.toThrow();
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(async () => {
+      await repo.create({ name: 'web-app', organisationId: 'org-1', description: 'Frontend' });
+      await repo.create({ name: 'api-server', organisationId: 'org-1', description: 'Backend API' });
+      await repo.create({ name: 'docs-site', organisationId: 'org-2', description: 'Documentation' });
+    });
+
+    it('searches by name (case-insensitive)', async () => {
+      const results = await repo.search('web');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('web-app');
+    });
+
+    it('searches by description', async () => {
+      const results = await repo.search('backend');
+      expect(results).toHaveLength(1);
+    });
+
+    it('respects limit', async () => {
+      const results = await repo.search('', 2);
+      expect(results).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Zero `prisma.project.*` calls remain
- ProjectService and 8 page/action files updated
- TinyBase repository with search, name validation, file count
- 13 new tests, 146 total

## Context
Phase 9. Remaining Prisma calls: `prisma.resource.*`, `prisma.projectResource.*`, `prisma.userFile.*`

## Test plan
- [x] 146 store tests pass
- [x] `grep "prisma\.project\." src/` returns nothing
- [ ] Manual: project CRUD, org project listing, admin projects