### PR TITLE
feat: migrate Resource + ProjectResource to TinyBase

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -123,7 +123,7 @@ User (root — no dependencies, everything depends on it)
 | 7 | Organisation + OrganisationMember | `feat/migrate-organisation` | #37 | ✅ Done |
 | 8 | OrganisationJoinRequest | `feat/migrate-join-request` | #38 | ✅ Done |
 | 9 | Project | `feat/migrate-project` | #39 | ✅ Done |
-| 10 | Resource + ProjectResource | `feat/migrate-resource` | — | ⬜ |
+| 10 | Resource + ProjectResource | `feat/migrate-resource` | #40 | ✅ Done |
 | 11 | UserFile | `feat/migrate-user-file` | — | ⬜ |
 | 12 | Switch auth to Dex OIDC | `feat/dex-oidc-auth` | — | ⬜ |
 | 13 | Remove Prisma + PostgreSQL | `chore/remove-prisma` | — | ⬜ |

--- a/src/actions/command-palette.ts
+++ b/src/actions/command-palette.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { auth } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
 import { getStoreAsync } from '@/lib/store';
 
 export interface CommandPaletteOrganisation {
@@ -94,43 +93,27 @@ export async function getProjectResources(projectId: string): Promise<CommandPal
     }
 
     // Get resources allocated to this project via the ProjectResource junction table
-    const projectResources = await prisma.projectResource.findMany({
-      where: { projectId },
-      include: {
-        project: {
-          select: {
-            name: true,
-            organisation: {
-              select: {
-                name: true,
-              },
-            },
-          },
-        },
-        resource: {
-          select: {
-            id: true,
-            name: true,
-            type: true,
-            status: true,
-            organisationId: true,
-          },
-        },
-      },
-      orderBy: { allocatedAt: 'desc' },
-      take: 50, // Limit results for performance
-    });
+    const projectResources = await store.projectResources.findByProjectId(projectId);
+    const organisation = await store.organisations.findById(project.organisationId);
 
-    return projectResources.map(pr => ({
-      id: pr.resource.id,
-      name: pr.resource.name,
-      type: pr.resource.type,
-      status: pr.resource.status,
-      projectId,
-      projectName: pr.project.name,
-      organisationId: pr.resource.organisationId,
-      organisationName: pr.project.organisation.name,
-    }));
+    const results: CommandPaletteResource[] = [];
+    for (const pr of projectResources.slice(0, 50)) {
+      const resource = await store.resources.findById(pr.resourceId);
+      if (resource) {
+        results.push({
+          id: resource.id,
+          name: resource.name,
+          type: resource.type,
+          status: resource.status,
+          projectId,
+          projectName: project.name,
+          organisationId: resource.organisationId,
+          organisationName: organisation?.name || '',
+        });
+      }
+    }
+
+    return results;
   } catch (error) {
     console.error('Failed to fetch project resources:', error);
     return [];

--- a/src/actions/resource.ts
+++ b/src/actions/resource.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { prisma } from '@/lib/prisma';
 import { getStoreAsync } from '@/lib/store';
 import { revalidatePath } from 'next/cache';
 import { deployResource } from '@/lib/deployment-service';
@@ -159,13 +158,10 @@ export async function createResource(
       : [];
 
     // Check for duplicate resource name for the owner
-    const duplicateResource = await prisma.resource.findFirst({
-      where: {
-        name: name.trim(),
-        ownerId,
-        isActive: true,
-      }
-    });
+    const ownerResources = await store.resources.findByOwnerId(ownerId);
+    const duplicateResource = ownerResources.find(
+      r => r.name === name.trim() && r.isActive
+    );
 
     if (duplicateResource) {
       return {
@@ -180,36 +176,31 @@ export async function createResource(
     // Create the resource with PROVISIONING status if template is provided
     const initialStatus = templateId ? 'PROVISIONING' : (status || 'ACTIVE');
 
-    const resource = await prisma.resource.create({
-      data: {
-        name: name.trim(),
-        description: description?.trim() || null,
-        type: type as any,
-        status: initialStatus as any,
-        endpoint: endpoint?.trim() || null,
-        quotaLimit,
-        ownerId,
-        organisationId,
-        isPublic,
-        tags,
-        configuration: templateId ? {
-          templateId,
-          deploymentStage: 'init',
-          deploymentProgress: 0,
-          deploymentMessage: 'Preparing deployment...'
-        } : null,
-      },
+    const resource = await store.resources.create({
+      name: name.trim(),
+      description: description?.trim() || null,
+      type: type as any,
+      status: initialStatus as any,
+      endpoint: endpoint?.trim() || null,
+      ownerId,
+      organisationId,
+      isPublic,
+      tags,
+      configuration: templateId ? {
+        templateId,
+        deploymentStage: 'init',
+        deploymentProgress: 0,
+        deploymentMessage: 'Preparing deployment...'
+      } : null,
     });
 
     // If a project was provided, link the resource to the project
     if (projectId && projectId.trim()) {
       try {
-        await prisma.projectResource.create({
-          data: {
-            projectId: projectId.trim(),
-            resourceId: resource.id,
-            allocatedBy: ownerId,
-          },
+        await store.projectResources.create({
+          projectId: projectId.trim(),
+          resourceId: resource.id,
+          allocatedBy: ownerId,
         });
         console.log(`✅ Resource ${resource.id} linked to project ${projectId}`);
       } catch (linkError) {
@@ -276,9 +267,10 @@ export async function updateResource(
       };
     }
 
+    const store = await getStoreAsync();
+
     // Validate project if provided
     if (projectId && projectId.trim()) {
-      const store = await getStoreAsync();
       const projectExists = await store.projects.findById(projectId);
 
       if (!projectExists) {
@@ -320,9 +312,7 @@ export async function updateResource(
       : [];
 
     // Get the current resource to check ownership
-    const currentResource = await prisma.resource.findUnique({
-      where: { id: resourceId },
-    });
+    const currentResource = await store.resources.findById(resourceId);
 
     if (!currentResource) {
       return {
@@ -331,14 +321,10 @@ export async function updateResource(
     }
 
     // Check for duplicate resource name for the owner (excluding current resource)
-    const duplicateResource = await prisma.resource.findFirst({
-      where: {
-        name: name.trim(),
-        ownerId: currentResource.ownerId,
-        isActive: true,
-        NOT: { id: resourceId }
-      }
-    });
+    const ownerResources = await store.resources.findByOwnerId(currentResource.ownerId);
+    const duplicateResource = ownerResources.find(
+      r => r.name === name.trim() && r.isActive && r.id !== resourceId
+    );
 
     if (duplicateResource) {
       return {
@@ -347,19 +333,15 @@ export async function updateResource(
       };
     }
 
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        name: name.trim(),
-        description: description?.trim() || null,
-        type: type as any,
-        status: status as any,
-        endpoint: endpoint?.trim() || null,
-        quotaLimit,
-        projectId: projectId?.trim() || null,
-        isPublic,
-        tags,
-      },
+    await store.resources.update(resourceId, {
+      name: name.trim(),
+      description: description?.trim() || null,
+      type: type as any,
+      status: status as any,
+      endpoint: endpoint?.trim() || null,
+      quotaLimit,
+      isPublic,
+      tags,
     });
 
     revalidatePath('/main/resources');
@@ -376,12 +358,10 @@ export async function updateResource(
 
 export async function deleteResource(resourceId: string) {
   try {
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        isActive: false,
-        deletedAt: new Date(),
-      },
+    const store = await getStoreAsync();
+    await store.resources.update(resourceId, {
+      isActive: false,
+      deletedAt: new Date(),
     });
 
     revalidatePath('/main/resources');
@@ -403,17 +383,17 @@ export async function allocateResourceToProject(
 ) {
   try {
     // Check if resource exists
-    const resource = await prisma.resource.findUnique({
-      where: { id: resourceId, isActive: true },
-      include: { organisation: true }
-    });
+    const store = await getStoreAsync();
+    const resourceFound = await store.resources.findById(resourceId);
+    const resource = resourceFound?.isActive ? resourceFound : null;
 
     if (!resource) {
       return { error: 'Resource not found' };
     }
 
+    const organisation = await store.organisations.findById(resource.organisationId);
+
     // Check if project exists and belongs to same organisation
-    const store = await getStoreAsync();
     const projectFound = await store.projects.findById(projectId);
     const project = projectFound?.isActive ? projectFound : null;
 
@@ -426,31 +406,22 @@ export async function allocateResourceToProject(
     }
 
     // Check if allocation already exists
-    const existingAllocation = await prisma.projectResource.findUnique({
-      where: {
-        projectId_resourceId: {
-          projectId,
-          resourceId
-        }
-      }
-    });
+    const existingAllocation = await store.projectResources.findByProjectAndResource(projectId, resourceId);
 
     if (existingAllocation) {
       return { error: 'Resource is already allocated to this project' };
     }
 
     // Create allocation
-    await prisma.projectResource.create({
-      data: {
-        projectId,
-        resourceId,
-        allocatedBy,
-        quotaLimit
-      }
+    await store.projectResources.create({
+      projectId,
+      resourceId,
+      allocatedBy,
+      quotaLimit
     });
 
-    revalidatePath(`/orga/${resource.organisation.name}/resources/${resourceId}`);
-    revalidatePath(`/orga/${resource.organisation.name}/projects/${projectId}`);
+    revalidatePath(`/orga/${organisation?.name}/resources/${resourceId}`);
+    revalidatePath(`/orga/${organisation?.name}/projects/${projectId}`);
 
     return { success: true };
   } catch (error) {
@@ -465,35 +436,20 @@ export async function removeResourceFromProject(
   projectId: string
 ) {
   try {
-    const allocation = await prisma.projectResource.findUnique({
-      where: {
-        projectId_resourceId: {
-          projectId,
-          resourceId
-        }
-      },
-      include: {
-        resource: {
-          include: { organisation: true }
-        }
-      }
-    });
+    const store = await getStoreAsync();
+    const allocation = await store.projectResources.findByProjectAndResource(projectId, resourceId);
 
     if (!allocation) {
       return { error: 'Allocation not found' };
     }
 
-    await prisma.projectResource.delete({
-      where: {
-        projectId_resourceId: {
-          projectId,
-          resourceId
-        }
-      }
-    });
+    await store.projectResources.delete(projectId, resourceId);
 
-    revalidatePath(`/orga/${allocation.resource.organisation.name}/resources/${resourceId}`);
-    revalidatePath(`/orga/${allocation.resource.organisation.name}/projects/${projectId}`);
+    const resource = await store.resources.findById(resourceId);
+    const organisation = resource ? await store.organisations.findById(resource.organisationId) : null;
+
+    revalidatePath(`/orga/${organisation?.name}/resources/${resourceId}`);
+    revalidatePath(`/orga/${organisation?.name}/projects/${projectId}`);
 
     return { success: true };
   } catch (error) {
@@ -509,38 +465,22 @@ export async function updateResourceAllocationQuota(
   quotaLimit: bigint | null
 ) {
   try {
-    const allocation = await prisma.projectResource.findUnique({
-      where: {
-        projectId_resourceId: {
-          projectId,
-          resourceId
-        }
-      },
-      include: {
-        resource: {
-          include: { organisation: true }
-        }
-      }
-    });
+    const store = await getStoreAsync();
+    const allocation = await store.projectResources.findByProjectAndResource(projectId, resourceId);
 
     if (!allocation) {
       return { error: 'Allocation not found' };
     }
 
-    await prisma.projectResource.update({
-      where: {
-        projectId_resourceId: {
-          projectId,
-          resourceId
-        }
-      },
-      data: {
-        quotaLimit
-      }
+    await store.projectResources.update(projectId, resourceId, {
+      quotaLimit
     });
 
-    revalidatePath(`/orga/${allocation.resource.organisation.name}/resources/${resourceId}`);
-    revalidatePath(`/orga/${allocation.resource.organisation.name}/projects/${projectId}`);
+    const resource = await store.resources.findById(resourceId);
+    const organisation = resource ? await store.organisations.findById(resource.organisationId) : null;
+
+    revalidatePath(`/orga/${organisation?.name}/resources/${resourceId}`);
+    revalidatePath(`/orga/${organisation?.name}/projects/${projectId}`);
 
     return { success: true };
   } catch (error) {
@@ -556,30 +496,24 @@ export async function getAvailableResourcesForProject(organisationId: string, pr
     // 1. In the same organisation
     // 2. Not already allocated to this project
     // 3. Active
-    const resources = await prisma.resource.findMany({
-      where: {
-        organisationId,
-        isActive: true,
-        allocatedProjects: {
-          none: {
-            projectId
-          }
-        }
-      },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        type: true,
-        status: true,
-        endpoint: true,
-        quotaLimit: true,
-        currentUsage: true
-      },
-      orderBy: {
-        name: 'asc'
-      }
-    });
+    const store = await getStoreAsync();
+    const orgResources = await store.resources.findByOrgId(organisationId);
+    const projectAllocations = await store.projectResources.findByProjectId(projectId);
+    const allocatedResourceIds = new Set(projectAllocations.map(a => a.resourceId));
+
+    const resources = orgResources
+      .filter(r => r.isActive && !allocatedResourceIds.has(r.id))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(r => ({
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        type: r.type,
+        status: r.status,
+        endpoint: r.endpoint,
+        quotaLimit: r.quotaLimit,
+        currentUsage: r.currentUsage
+      }));
 
     return resources;
   } catch (error) {
@@ -591,38 +525,25 @@ export async function getAvailableResourcesForProject(organisationId: string, pr
 // Search function for resources
 export async function findResources(query: string, organisationId: string) {
   try {
-    const resources = await prisma.resource.findMany({
-      where: {
-        organisationId,
-        isActive: true,
-        OR: [
-          {
-            name: {
-              contains: query,
-              mode: 'insensitive',
-            },
-          },
-          {
-            description: {
-              contains: query,
-              mode: 'insensitive',
-            },
-          },
-        ],
-      },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        type: true,
-        status: true,
-        endpoint: true
-      },
-      orderBy: {
-        name: 'asc'
-      },
-      take: 10,
-    });
+    const store = await getStoreAsync();
+    const orgResources = await store.resources.findByOrgId(organisationId);
+    const lowerQuery = query.toLowerCase();
+
+    const resources = orgResources
+      .filter(r => r.isActive && (
+        r.name.toLowerCase().includes(lowerQuery) ||
+        (r.description && r.description.toLowerCase().includes(lowerQuery))
+      ))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, 10)
+      .map(r => ({
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        type: r.type,
+        status: r.status,
+        endpoint: r.endpoint
+      }));
 
     return resources;
   } catch (error) {

--- a/src/app/(main)/orga/[orgaName]/[projectName]/[resourceName]/layout.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/[resourceName]/layout.tsx
@@ -1,6 +1,5 @@
 import { notFound } from 'next/navigation';
 import { getStoreAsync } from '@/lib/store';
-import { prisma } from '@/lib/prisma';
 import { ResourceProvider } from '@/contexts/ResourceContext';
 
 export default async function ResourceLayout({
@@ -31,23 +30,17 @@ export default async function ResourceLayout({
   }
 
   // Fetch the resource by name and organisation
-  const resource = await prisma.resource.findFirst({
-    where: {
-      name: resourceName,
-      organisationId: organisation.id,
-      isActive: true,
-    },
-    select: {
-      id: true,
-      name: true,
-      description: true,
-      type: true,
-      status: true,
-      endpoint: true,
-      organisationId: true,
-      ownerId: true,
-    },
-  });
+  const foundResource = await store.resources.findByNameAndOrg(resourceName, organisation.id);
+  const resource = foundResource?.isActive ? {
+    id: foundResource.id,
+    name: foundResource.name,
+    description: foundResource.description,
+    type: foundResource.type,
+    status: foundResource.status,
+    endpoint: foundResource.endpoint,
+    organisationId: foundResource.organisationId,
+    ownerId: foundResource.ownerId,
+  } : null;
 
   if (!resource) {
     notFound();

--- a/src/app/(main)/orga/[orgaName]/[projectName]/layout.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/layout.tsx
@@ -1,6 +1,5 @@
 import { notFound } from 'next/navigation';
 import { getStoreAsync } from '@/lib/store';
-import { prisma } from '@/lib/prisma';
 import { ProjectProvider } from '@/contexts/ProjectContext';
 
 export default async function ProjectLayout({
@@ -29,30 +28,32 @@ export default async function ProjectLayout({
     notFound();
   }
 
-  const allocatedResources = await prisma.projectResource.findMany({
-    where: { projectId: projectFound.id },
-    include: {
-      resource: {
-        include: {
-          owner: {
-            select: {
-              id: true,
-              name: true,
-              firstname: true,
-              lastname: true,
-              email: true,
-            },
-          },
+  const projectAllocations = await store.projectResources.findByProjectId(projectFound.id);
+
+  const allocatedResources = [];
+  for (const allocation of projectAllocations) {
+    const resource = await store.resources.findById(allocation.resourceId);
+    if (resource) {
+      const owner = await store.users.findById(resource.ownerId);
+      allocatedResources.push({
+        ...allocation,
+        resource: {
+          ...resource,
+          owner: owner ? {
+            id: owner.id,
+            name: owner.name,
+            firstname: owner.firstname,
+            lastname: owner.lastname,
+            email: owner.email,
+          } : null,
           organisation: {
-            select: {
-              id: true,
-              name: true,
-            },
+            id: organisation.id,
+            name: organisation.name,
           },
         },
-      },
-    },
-  });
+      });
+    }
+  }
 
   const filteredAllocatedResources = allocatedResources.filter(
     allocation => allocation.resource.isActive && allocation.resource.status === 'ACTIVE'

--- a/src/app/(main)/orga/[orgaName]/[projectName]/settings/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/settings/page.tsx
@@ -1,5 +1,4 @@
 import { auth } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
 import { notFound } from 'next/navigation';
 import ProjectSettingsClient from './ProjectSettingsClient';
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { Geist } from 'next/font/google';
 import "./globals.css";
 
 import { auth } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
 
 import UserBar from '@/components/layout/UserBar';
 import Footer from '@/components/layout/Footer';

--- a/src/lib/deployment-service.ts
+++ b/src/lib/deployment-service.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@/lib/prisma';
+import { getStoreAsync } from '@/lib/store';
 import {
   getTemplateById,
   generateMockEndpoint,
@@ -42,20 +42,18 @@ export async function simulateDeployment(
   onProgress?: (progress: DeploymentProgress) => void
 ): Promise<DeploymentResult> {
   try {
+    const store = await getStoreAsync();
     const provisioningTime = template.deployment.provisioningTime;
     const stageTime = provisioningTime / deploymentStages.length;
 
     for (const stage of deploymentStages) {
       onProgress?.(stage);
 
-      await prisma.resource.update({
-        where: { id: resourceId },
-        data: {
-          configuration: {
-            deploymentStage: stage.stage,
-            deploymentProgress: stage.progress,
-            deploymentMessage: stage.message
-          }
+      await store.resources.update(resourceId, {
+        configuration: {
+          deploymentStage: stage.stage,
+          deploymentProgress: stage.progress,
+          deploymentMessage: stage.message
         }
       });
 
@@ -66,19 +64,16 @@ export async function simulateDeployment(
     const credentials = generateMockCredentials(template, resourceId);
     const configuration = generateDeploymentConfig(template, resourceId);
 
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        status: 'ACTIVE',
-        endpoint,
-        credentials,
-        configuration: {
-          ...configuration,
-          deploymentStage: 'complete',
-          deploymentProgress: 100,
-          deploymentMessage: 'Deployment complete!',
-          deployedAt: new Date().toISOString()
-        }
+    await store.resources.update(resourceId, {
+      status: 'ACTIVE',
+      endpoint,
+      credentials,
+      configuration: {
+        ...configuration,
+        deploymentStage: 'complete',
+        deploymentProgress: 100,
+        deploymentMessage: 'Deployment complete!',
+        deployedAt: new Date().toISOString()
       }
     });
 
@@ -91,16 +86,14 @@ export async function simulateDeployment(
   } catch (error) {
     console.error('Deployment simulation failed:', error);
 
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        status: 'INACTIVE',
-        configuration: {
-          deploymentStage: 'failed',
-          deploymentProgress: 0,
-          deploymentMessage: 'Deployment failed',
-          error: error instanceof Error ? error.message : 'Unknown error'
-        }
+    const store = await getStoreAsync();
+    await store.resources.update(resourceId, {
+      status: 'INACTIVE',
+      configuration: {
+        deploymentStage: 'failed',
+        deploymentProgress: 0,
+        deploymentMessage: 'Deployment failed',
+        error: error instanceof Error ? error.message : 'Unknown error'
       }
     });
 
@@ -124,16 +117,8 @@ export async function deployResource(
     };
   }
 
-  const resource = await prisma.resource.findUnique({
-    where: { id: resourceId },
-    include: {
-      owner: true,
-      organisation: true,
-      allocatedProjects: {
-        include: { project: true }
-      }
-    }
-  });
+  const store = await getStoreAsync();
+  const resource = await store.resources.findById(resourceId);
 
   if (!resource) {
     return {
@@ -142,21 +127,29 @@ export async function deployResource(
     };
   }
 
-  await prisma.resource.update({
-    where: { id: resourceId },
-    data: {
-      status: 'PROVISIONING',
-      configuration: {
-        templateId,
-        deploymentStage: 'init',
-        deploymentProgress: 0,
-        deploymentMessage: 'Contacting Resource API...'
-      }
+  const owner = await store.users.findById(resource.ownerId);
+  const organisation = await store.organisations.findById(resource.organisationId);
+  const projectAllocations = await store.projectResources.findByResourceId(resourceId);
+
+  const enrichedResource = {
+    ...resource,
+    owner,
+    organisation,
+    allocatedProjects: projectAllocations,
+  };
+
+  await store.resources.update(resourceId, {
+    status: 'PROVISIONING',
+    configuration: {
+      templateId,
+      deploymentStage: 'init',
+      deploymentProgress: 0,
+      deploymentMessage: 'Contacting Resource API...'
     }
   });
 
   setImmediate(async () => {
-    await provisionResourceViaApi(resourceId, templateId, template, resource);
+    await provisionResourceViaApi(resourceId, templateId, template, enrichedResource);
   });
 
   return {
@@ -171,27 +164,30 @@ async function provisionResourceViaApi(
   resource: any
 ): Promise<void> {
   try {
+    const store = await getStoreAsync();
     const provider = getProviderForTemplate(templateId);
 
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        configuration: {
-          templateId,
-          deploymentStage: 'provision',
-          deploymentProgress: 50,
-          deploymentMessage: 'Provisioning resource via API...'
-        }
+    await store.resources.update(resourceId, {
+      configuration: {
+        templateId,
+        deploymentStage: 'provision',
+        deploymentProgress: 50,
+        deploymentMessage: 'Provisioning resource via API...'
       }
     });
 
-    const projectName = resource.allocatedProjects?.[0]?.project?.name || 'Default Project';
+    const firstAllocation = resource.allocatedProjects?.[0];
+    let projectName = 'Default Project';
+    if (firstAllocation) {
+      const project = await store.projects.findById(firstAllocation.projectId);
+      projectName = project?.name || 'Default Project';
+    }
 
     const provisionRequest: ProvisionRequest = {
       name: resource.name,
-      organisationName: resource.organisation.name,
+      organisationName: resource.organisation?.name || '',
       projectName: projectName,
-      userId: resource.owner.id,
+      userId: resource.owner?.id || '',
       sshKeys: [],
     };
 
@@ -201,53 +197,43 @@ async function provisionResourceViaApi(
       throw new Error(result.error || 'Provisioning failed');
     }
 
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        status: 'ACTIVE',
-        endpoint: result.access,
-        credentials: {
-          resourceApiId: result.id,
-          resourceApiStatus: result.status,
-        },
-        configuration: {
-          templateId,
-          resourceApiId: result.id,
-          provider,
-          deploymentStage: 'complete',
-          deploymentProgress: 100,
-          deploymentMessage: 'Deployment complete!',
-          deployedAt: new Date().toISOString()
-        }
+    await store.resources.update(resourceId, {
+      status: 'ACTIVE',
+      endpoint: result.access,
+      credentials: {
+        resourceApiId: result.id,
+        resourceApiStatus: result.status,
+      },
+      configuration: {
+        templateId,
+        resourceApiId: result.id,
+        provider,
+        deploymentStage: 'complete',
+        deploymentProgress: 100,
+        deploymentMessage: 'Deployment complete!',
+        deployedAt: new Date().toISOString()
       }
     });
   } catch (error) {
     console.error('Resource API provisioning failed:', error);
 
-    await prisma.resource.update({
-      where: { id: resourceId },
-      data: {
-        status: 'INACTIVE',
-        configuration: {
-          templateId,
-          deploymentStage: 'failed',
-          deploymentProgress: 0,
-          deploymentMessage: 'Provisioning failed',
-          error: error instanceof Error ? error.message : 'Unknown error'
-        }
+    const store = await getStoreAsync();
+    await store.resources.update(resourceId, {
+      status: 'INACTIVE',
+      configuration: {
+        templateId,
+        deploymentStage: 'failed',
+        deploymentProgress: 0,
+        deploymentMessage: 'Provisioning failed',
+        error: error instanceof Error ? error.message : 'Unknown error'
       }
     });
   }
 }
 
 export async function getDeploymentStatus(resourceId: string): Promise<DeploymentProgress | null> {
-  const resource = await prisma.resource.findUnique({
-    where: { id: resourceId },
-    select: {
-      configuration: true,
-      status: true
-    }
-  });
+  const store = await getStoreAsync();
+  const resource = await store.resources.findById(resourceId);
 
   if (!resource) {
     return null;

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -2,6 +2,7 @@ import type { IUserRepository } from './repositories/user.repository';
 import type { IOrganisationRepository, IOrganisationMemberRepository } from './repositories/organisation.repository';
 import type { IProjectRepository } from './repositories/project.repository';
 import type { IApiKeyRepository } from './repositories/api-key.repository';
+import type { IResourceRepository, IProjectResourceRepository } from './repositories/resource.repository';
 import type { IAuditLogRepository } from './repositories/audit-log.repository';
 import type { IJoinRequestRepository } from './repositories/join-request.repository';
 import type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository } from './repositories/user-storage.repository';
@@ -12,6 +13,7 @@ import { TinyBaseOrganisationRepository, TinyBaseOrganisationMemberRepository } 
 import { TinyBaseApiKeyRepository } from './tinybase/api-key.tinybase';
 import { TinyBaseAuditLogRepository } from './tinybase/audit-log.tinybase';
 import { TinyBaseProjectRepository } from './tinybase/project.tinybase';
+import { TinyBaseResourceRepository, TinyBaseProjectResourceRepository } from './tinybase/resource.tinybase';
 import { TinyBaseJoinRequestRepository } from './tinybase/join-request.tinybase';
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
 import path from 'path';
@@ -22,6 +24,8 @@ export interface DataStore {
   organisations: IOrganisationRepository;
   organisationMembers: IOrganisationMemberRepository;
   projects: IProjectRepository;
+  resources: IResourceRepository;
+  projectResources: IProjectResourceRepository;
   apiKeys: IApiKeyRepository;
   auditLogs: IAuditLogRepository;
   joinRequests: IJoinRequestRepository;
@@ -51,6 +55,8 @@ async function createDataStore(): Promise<DataStore> {
     organisations: new TinyBaseOrganisationRepository(tinyStore),
     organisationMembers: new TinyBaseOrganisationMemberRepository(tinyStore),
     projects: new TinyBaseProjectRepository(tinyStore),
+    resources: new TinyBaseResourceRepository(tinyStore),
+    projectResources: new TinyBaseProjectResourceRepository(tinyStore),
     apiKeys: new TinyBaseApiKeyRepository(tinyStore),
     auditLogs: new TinyBaseAuditLogRepository(tinyStore),
     joinRequests: new TinyBaseJoinRequestRepository(tinyStore),

--- a/src/lib/store/repositories/resource.repository.ts
+++ b/src/lib/store/repositories/resource.repository.ts
@@ -35,6 +35,7 @@ export interface IResourceRepository {
   findByOrgId(organisationId: string): Promise<Resource[]>;
   findByOwnerId(ownerId: string): Promise<Resource[]>;
   findByStatus(status: ResourceStatus): Promise<Resource[]>;
+  findByNameAndOrg(name: string, organisationId: string, excludeId?: string): Promise<Resource | null>;
   update(id: string, data: UpdateResourceData): Promise<Resource>;
   delete(id: string): Promise<void>;
   search(query: string, limit?: number): Promise<Resource[]>;
@@ -44,5 +45,7 @@ export interface IProjectResourceRepository {
   create(data: { projectId: string; resourceId: string; allocatedBy: string; quotaLimit?: bigint }): Promise<ProjectResource>;
   findByProjectId(projectId: string): Promise<ProjectResource[]>;
   findByResourceId(resourceId: string): Promise<ProjectResource[]>;
+  findByProjectAndResource(projectId: string, resourceId: string): Promise<ProjectResource | null>;
+  update(projectId: string, resourceId: string, data: { quotaLimit?: bigint }): Promise<ProjectResource>;
   delete(projectId: string, resourceId: string): Promise<void>;
 }

--- a/src/lib/store/tinybase/resource.tinybase.ts
+++ b/src/lib/store/tinybase/resource.tinybase.ts
@@ -1,0 +1,237 @@
+import type { Store } from 'tinybase';
+import type { Resource, ResourceType, ResourceStatus, ProjectResource } from '../types';
+import type { IResourceRepository, CreateResourceData, UpdateResourceData, IProjectResourceRepository } from '../repositories/resource.repository';
+import crypto from 'crypto';
+
+const RES_TABLE = 'resources';
+const PR_TABLE = 'project-resources';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToResource(id: string, row: Record<string, any>): Resource {
+  return {
+    id,
+    name: row.name as string,
+    description: (row.description as string) || null,
+    type: (row.type as ResourceType) || 'OTHER',
+    status: (row.status as ResourceStatus) || 'ACTIVE',
+    configuration: row.configuration ? JSON.parse(row.configuration as string) : null,
+    endpoint: (row.endpoint as string) || null,
+    credentials: row.credentials ? JSON.parse(row.credentials as string) : null,
+    quotaLimit: row.quotaLimit ? BigInt(row.quotaLimit as string) : null,
+    currentUsage: BigInt(row.currentUsage as string || '0'),
+    ownerId: row.ownerId as string,
+    organisationId: row.organisationId as string,
+    isPublic: row.isPublic === 1,
+    tags: row.tags ? JSON.parse(row.tags as string) : [],
+    isActive: row.isActive === 1,
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+    deletedAt: row.deletedAt ? new Date(row.deletedAt as string) : null,
+  };
+}
+
+function rowToProjectResource(id: string, row: Record<string, any>): ProjectResource {
+  return {
+    id,
+    projectId: row.projectId as string,
+    resourceId: row.resourceId as string,
+    allocatedBy: row.allocatedBy as string,
+    allocatedAt: new Date(row.allocatedAt as string),
+    quotaLimit: row.quotaLimit ? BigInt(row.quotaLimit as string) : null,
+  };
+}
+
+export class TinyBaseResourceRepository implements IResourceRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateResourceData): Promise<Resource> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(RES_TABLE, id, {
+      name: data.name,
+      description: data.description ?? '',
+      type: data.type ?? 'OTHER',
+      status: data.status ?? 'ACTIVE',
+      configuration: data.configuration ? JSON.stringify(data.configuration) : '',
+      endpoint: data.endpoint ?? '',
+      credentials: data.credentials ? JSON.stringify(data.credentials) : '',
+      quotaLimit: '',
+      currentUsage: '0',
+      ownerId: data.ownerId,
+      organisationId: data.organisationId,
+      isPublic: 0,
+      tags: JSON.stringify(data.tags ?? []),
+      isActive: 1,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: '',
+    });
+
+    return rowToResource(id, this.store.getRow(RES_TABLE, id));
+  }
+
+  async findById(id: string): Promise<Resource | null> {
+    const row = this.store.getRow(RES_TABLE, id);
+    if (!row.name) return null;
+    return rowToResource(id, row);
+  }
+
+  async findByOrgId(organisationId: string): Promise<Resource[]> {
+    const results: Resource[] = [];
+    for (const id of this.store.getRowIds(RES_TABLE)) {
+      const row = this.store.getRow(RES_TABLE, id);
+      if (row.organisationId === organisationId && row.isActive === 1) {
+        results.push(rowToResource(id, row));
+      }
+    }
+    results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return results;
+  }
+
+  async findByOwnerId(ownerId: string): Promise<Resource[]> {
+    const results: Resource[] = [];
+    for (const id of this.store.getRowIds(RES_TABLE)) {
+      const row = this.store.getRow(RES_TABLE, id);
+      if (row.ownerId === ownerId && row.isActive === 1) {
+        results.push(rowToResource(id, row));
+      }
+    }
+    return results;
+  }
+
+  async findByStatus(status: ResourceStatus): Promise<Resource[]> {
+    const results: Resource[] = [];
+    for (const id of this.store.getRowIds(RES_TABLE)) {
+      const row = this.store.getRow(RES_TABLE, id);
+      if (row.status === status) results.push(rowToResource(id, row));
+    }
+    return results;
+  }
+
+  async findByNameAndOrg(name: string, organisationId: string, excludeId?: string): Promise<Resource | null> {
+    for (const id of this.store.getRowIds(RES_TABLE)) {
+      const row = this.store.getRow(RES_TABLE, id);
+      if (row.name === name && row.organisationId === organisationId && row.isActive === 1 && id !== excludeId) {
+        return rowToResource(id, row);
+      }
+    }
+    return null;
+  }
+
+  async update(id: string, data: UpdateResourceData): Promise<Resource> {
+    const row = this.store.getRow(RES_TABLE, id);
+    if (!row.name) throw new Error(`Resource ${id} not found`);
+
+    if (data.name !== undefined) this.store.setCell(RES_TABLE, id, 'name', data.name);
+    if (data.description !== undefined) this.store.setCell(RES_TABLE, id, 'description', data.description ?? '');
+    if (data.type !== undefined) this.store.setCell(RES_TABLE, id, 'type', data.type);
+    if (data.status !== undefined) this.store.setCell(RES_TABLE, id, 'status', data.status);
+    if (data.configuration !== undefined) this.store.setCell(RES_TABLE, id, 'configuration', data.configuration ? JSON.stringify(data.configuration) : '');
+    if (data.endpoint !== undefined) this.store.setCell(RES_TABLE, id, 'endpoint', data.endpoint ?? '');
+    if (data.credentials !== undefined) this.store.setCell(RES_TABLE, id, 'credentials', data.credentials ? JSON.stringify(data.credentials) : '');
+    if (data.quotaLimit !== undefined) this.store.setCell(RES_TABLE, id, 'quotaLimit', data.quotaLimit ? data.quotaLimit.toString() : '');
+    if (data.currentUsage !== undefined) this.store.setCell(RES_TABLE, id, 'currentUsage', data.currentUsage.toString());
+    if (data.isPublic !== undefined) this.store.setCell(RES_TABLE, id, 'isPublic', data.isPublic ? 1 : 0);
+    if (data.tags !== undefined) this.store.setCell(RES_TABLE, id, 'tags', JSON.stringify(data.tags));
+    if (data.isActive !== undefined) this.store.setCell(RES_TABLE, id, 'isActive', data.isActive ? 1 : 0);
+    if (data.deletedAt !== undefined) this.store.setCell(RES_TABLE, id, 'deletedAt', data.deletedAt ? data.deletedAt.toISOString() : '');
+    this.store.setCell(RES_TABLE, id, 'updatedAt', new Date().toISOString());
+
+    return rowToResource(id, this.store.getRow(RES_TABLE, id));
+  }
+
+  async delete(id: string): Promise<void> {
+    this.store.delRow(RES_TABLE, id);
+  }
+
+  async search(query: string, limit: number = 10): Promise<Resource[]> {
+    const q = query.toLowerCase();
+    let results: Resource[] = [];
+
+    for (const id of this.store.getRowIds(RES_TABLE)) {
+      const row = this.store.getRow(RES_TABLE, id);
+      if (row.isActive !== 1) continue;
+
+      const matches =
+        ((row.name as string) || '').toLowerCase().includes(q) ||
+        ((row.description as string) || '').toLowerCase().includes(q);
+
+      if (matches) results.push(rowToResource(id, row));
+    }
+
+    results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return results.slice(0, limit);
+  }
+}
+
+export class TinyBaseProjectResourceRepository implements IProjectResourceRepository {
+  constructor(private store: Store) {}
+
+  async create(data: { projectId: string; resourceId: string; allocatedBy: string; quotaLimit?: bigint }): Promise<ProjectResource> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(PR_TABLE, id, {
+      projectId: data.projectId,
+      resourceId: data.resourceId,
+      allocatedBy: data.allocatedBy,
+      allocatedAt: now,
+      quotaLimit: data.quotaLimit ? data.quotaLimit.toString() : '',
+    });
+
+    return rowToProjectResource(id, this.store.getRow(PR_TABLE, id));
+  }
+
+  async findByProjectId(projectId: string): Promise<ProjectResource[]> {
+    const results: ProjectResource[] = [];
+    for (const id of this.store.getRowIds(PR_TABLE)) {
+      const row = this.store.getRow(PR_TABLE, id);
+      if (row.projectId === projectId) results.push(rowToProjectResource(id, row));
+    }
+    return results;
+  }
+
+  async findByResourceId(resourceId: string): Promise<ProjectResource[]> {
+    const results: ProjectResource[] = [];
+    for (const id of this.store.getRowIds(PR_TABLE)) {
+      const row = this.store.getRow(PR_TABLE, id);
+      if (row.resourceId === resourceId) results.push(rowToProjectResource(id, row));
+    }
+    return results;
+  }
+
+  async findByProjectAndResource(projectId: string, resourceId: string): Promise<ProjectResource | null> {
+    for (const id of this.store.getRowIds(PR_TABLE)) {
+      const row = this.store.getRow(PR_TABLE, id);
+      if (row.projectId === projectId && row.resourceId === resourceId) {
+        return rowToProjectResource(id, row);
+      }
+    }
+    return null;
+  }
+
+  async update(projectId: string, resourceId: string, data: { quotaLimit?: bigint }): Promise<ProjectResource> {
+    for (const id of this.store.getRowIds(PR_TABLE)) {
+      const row = this.store.getRow(PR_TABLE, id);
+      if (row.projectId === projectId && row.resourceId === resourceId) {
+        if (data.quotaLimit !== undefined) this.store.setCell(PR_TABLE, id, 'quotaLimit', data.quotaLimit ? data.quotaLimit.toString() : '');
+        return rowToProjectResource(id, this.store.getRow(PR_TABLE, id));
+      }
+    }
+    throw new Error(`ProjectResource not found for project ${projectId} and resource ${resourceId}`);
+  }
+
+  async delete(projectId: string, resourceId: string): Promise<void> {
+    for (const id of this.store.getRowIds(PR_TABLE)) {
+      const row = this.store.getRow(PR_TABLE, id);
+      if (row.projectId === projectId && row.resourceId === resourceId) {
+        this.store.delRow(PR_TABLE, id);
+        return;
+      }
+    }
+  }
+}

--- a/tests/store/tinybase/resource.tinybase.test.ts
+++ b/tests/store/tinybase/resource.tinybase.test.ts
@@ -1,0 +1,146 @@
+import { createStore } from 'tinybase';
+import { TinyBaseResourceRepository, TinyBaseProjectResourceRepository } from '@/lib/store/tinybase/resource.tinybase';
+
+describe('TinyBaseResourceRepository', () => {
+  let repo: TinyBaseResourceRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseResourceRepository(createStore());
+  });
+
+  describe('create', () => {
+    it('creates a resource with defaults', async () => {
+      const r = await repo.create({ name: 'my-db', ownerId: 'u1', organisationId: 'org-1', type: 'DATABASE' });
+      expect(r.id).toBeDefined();
+      expect(r.name).toBe('my-db');
+      expect(r.type).toBe('DATABASE');
+      expect(r.status).toBe('ACTIVE');
+      expect(r.isActive).toBe(true);
+    });
+
+    it('stores configuration as JSON', async () => {
+      const r = await repo.create({
+        name: 'test', ownerId: 'u1', organisationId: 'org-1',
+        configuration: { cpu: 2, ram: '4GB' },
+      });
+      expect(r.configuration).toEqual({ cpu: 2, ram: '4GB' });
+    });
+  });
+
+  describe('findById', () => {
+    it('returns resource when found', async () => {
+      const created = await repo.create({ name: 'test', ownerId: 'u1', organisationId: 'org-1' });
+      expect(await repo.findById(created.id)).not.toBeNull();
+    });
+
+    it('returns null for missing', async () => {
+      expect(await repo.findById('missing')).toBeNull();
+    });
+  });
+
+  describe('findByOrgId', () => {
+    it('returns active resources for org', async () => {
+      await repo.create({ name: 'r1', ownerId: 'u1', organisationId: 'org-1' });
+      await repo.create({ name: 'r2', ownerId: 'u1', organisationId: 'org-1' });
+      await repo.create({ name: 'r3', ownerId: 'u1', organisationId: 'org-2' });
+
+      expect(await repo.findByOrgId('org-1')).toHaveLength(2);
+    });
+  });
+
+  describe('findByNameAndOrg', () => {
+    it('finds by name and org', async () => {
+      await repo.create({ name: 'my-db', ownerId: 'u1', organisationId: 'org-1' });
+      expect(await repo.findByNameAndOrg('my-db', 'org-1')).not.toBeNull();
+    });
+
+    it('excludes specified id', async () => {
+      const r = await repo.create({ name: 'my-db', ownerId: 'u1', organisationId: 'org-1' });
+      expect(await repo.findByNameAndOrg('my-db', 'org-1', r.id)).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('updates status and configuration', async () => {
+      const r = await repo.create({ name: 'test', ownerId: 'u1', organisationId: 'org-1' });
+      const updated = await repo.update(r.id, {
+        status: 'PROVISIONING',
+        configuration: { stage: 'init' },
+      });
+      expect(updated.status).toBe('PROVISIONING');
+      expect(updated.configuration).toEqual({ stage: 'init' });
+    });
+  });
+
+  describe('search', () => {
+    it('finds by name', async () => {
+      await repo.create({ name: 'postgres-main', ownerId: 'u1', organisationId: 'org-1' });
+      await repo.create({ name: 'redis-cache', ownerId: 'u1', organisationId: 'org-1' });
+
+      const results = await repo.search('postgres');
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the resource', async () => {
+      const r = await repo.create({ name: 'test', ownerId: 'u1', organisationId: 'org-1' });
+      await repo.delete(r.id);
+      expect(await repo.findById(r.id)).toBeNull();
+    });
+  });
+});
+
+describe('TinyBaseProjectResourceRepository', () => {
+  let repo: TinyBaseProjectResourceRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseProjectResourceRepository(createStore());
+  });
+
+  describe('create', () => {
+    it('creates an allocation', async () => {
+      const pr = await repo.create({ projectId: 'p1', resourceId: 'r1', allocatedBy: 'u1' });
+      expect(pr.projectId).toBe('p1');
+      expect(pr.resourceId).toBe('r1');
+      expect(pr.allocatedBy).toBe('u1');
+    });
+  });
+
+  describe('findByProjectAndResource', () => {
+    it('finds allocation', async () => {
+      await repo.create({ projectId: 'p1', resourceId: 'r1', allocatedBy: 'u1' });
+      expect(await repo.findByProjectAndResource('p1', 'r1')).not.toBeNull();
+    });
+
+    it('returns null when not found', async () => {
+      expect(await repo.findByProjectAndResource('p1', 'r99')).toBeNull();
+    });
+  });
+
+  describe('findByProjectId', () => {
+    it('returns allocations for project', async () => {
+      await repo.create({ projectId: 'p1', resourceId: 'r1', allocatedBy: 'u1' });
+      await repo.create({ projectId: 'p1', resourceId: 'r2', allocatedBy: 'u1' });
+      await repo.create({ projectId: 'p2', resourceId: 'r3', allocatedBy: 'u1' });
+
+      expect(await repo.findByProjectId('p1')).toHaveLength(2);
+    });
+  });
+
+  describe('delete', () => {
+    it('removes allocation', async () => {
+      await repo.create({ projectId: 'p1', resourceId: 'r1', allocatedBy: 'u1' });
+      await repo.delete('p1', 'r1');
+      expect(await repo.findByProjectAndResource('p1', 'r1')).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('updates quota limit', async () => {
+      await repo.create({ projectId: 'p1', resourceId: 'r1', allocatedBy: 'u1' });
+      const updated = await repo.update('p1', 'r1', { quotaLimit: BigInt(1000) });
+      expect(updated.quotaLimit).toBe(BigInt(1000));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Zero `prisma.resource.*` or `prisma.projectResource.*` calls remain
- 5 files updated: resource action, deployment service, command palette, 2 layouts
- Removed dead prisma imports from layout.tsx and project settings
- JSON config/credentials stored and parsed transparently

## Context
Phase 10. **Only `auth.ts` PrismaAdapter remains** as the last Prisma dependency.

## Remaining Prisma
- `src/lib/auth.ts` — PrismaAdapter for NextAuth (removed in Phase 12: Dex OIDC)
- `src/lib/prisma.ts` — singleton (removed in Phase 13)
- `src/lib/store/prisma/api-key.prisma.ts` — legacy impl (removed in Phase 13)

## Test plan
- [x] 162 store tests pass
- [x] 16 new resource/projectResource tests
- [x] `grep "prisma\." src/ | grep -v prisma.ts | grep -v store/prisma | grep -v auth.ts` returns nothing