### PR TITLE
feat: migrate UserFile to TinyBase data store

### DIFF
--- a/docs/migrate-tiny-plan.md
+++ b/docs/migrate-tiny-plan.md
@@ -124,7 +124,7 @@ User (root — no dependencies, everything depends on it)
 | 8 | OrganisationJoinRequest | `feat/migrate-join-request` | #38 | ✅ Done |
 | 9 | Project | `feat/migrate-project` | #39 | ✅ Done |
 | 10 | Resource + ProjectResource | `feat/migrate-resource` | #40 | ✅ Done |
-| 11 | UserFile | `feat/migrate-user-file` | — | ⬜ |
+| 11 | UserFile | `feat/migrate-user-file` | #41 | ✅ Done |
 | 12 | Switch auth to Dex OIDC | `feat/dex-oidc-auth` | — | ⬜ |
 | 13 | Remove Prisma + PostgreSQL | `chore/remove-prisma` | — | ⬜ |
 

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -3,6 +3,7 @@ import type { IOrganisationRepository, IOrganisationMemberRepository } from './r
 import type { IProjectRepository } from './repositories/project.repository';
 import type { IApiKeyRepository } from './repositories/api-key.repository';
 import type { IResourceRepository, IProjectResourceRepository } from './repositories/resource.repository';
+import type { IUserFileRepository } from './repositories/user-file.repository';
 import type { IAuditLogRepository } from './repositories/audit-log.repository';
 import type { IJoinRequestRepository } from './repositories/join-request.repository';
 import type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository } from './repositories/user-storage.repository';
@@ -14,6 +15,7 @@ import { TinyBaseApiKeyRepository } from './tinybase/api-key.tinybase';
 import { TinyBaseAuditLogRepository } from './tinybase/audit-log.tinybase';
 import { TinyBaseProjectRepository } from './tinybase/project.tinybase';
 import { TinyBaseResourceRepository, TinyBaseProjectResourceRepository } from './tinybase/resource.tinybase';
+import { TinyBaseUserFileRepository } from './tinybase/user-file.tinybase';
 import { TinyBaseJoinRequestRepository } from './tinybase/join-request.tinybase';
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
 import path from 'path';
@@ -26,6 +28,7 @@ export interface DataStore {
   projects: IProjectRepository;
   resources: IResourceRepository;
   projectResources: IProjectResourceRepository;
+  userFiles: IUserFileRepository;
   apiKeys: IApiKeyRepository;
   auditLogs: IAuditLogRepository;
   joinRequests: IJoinRequestRepository;
@@ -57,6 +60,7 @@ async function createDataStore(): Promise<DataStore> {
     projects: new TinyBaseProjectRepository(tinyStore),
     resources: new TinyBaseResourceRepository(tinyStore),
     projectResources: new TinyBaseProjectResourceRepository(tinyStore),
+    userFiles: new TinyBaseUserFileRepository(tinyStore),
     apiKeys: new TinyBaseApiKeyRepository(tinyStore),
     auditLogs: new TinyBaseAuditLogRepository(tinyStore),
     joinRequests: new TinyBaseJoinRequestRepository(tinyStore),

--- a/src/lib/store/tinybase/user-file.tinybase.ts
+++ b/src/lib/store/tinybase/user-file.tinybase.ts
@@ -1,0 +1,129 @@
+import type { Store } from 'tinybase';
+import type { UserFile } from '../types';
+import type { IUserFileRepository, CreateUserFileData } from '../repositories/user-file.repository';
+import crypto from 'crypto';
+
+const TABLE = 'user-files';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToUserFile(id: string, row: Record<string, any>): UserFile {
+  return {
+    id,
+    userId: row.userId as string,
+    projectId: (row.projectId as string) || null,
+    ipfsHash: row.ipfsHash as string,
+    fileName: row.fileName as string,
+    fileSize: BigInt(row.fileSize as string),
+    fileType: row.fileType as string,
+    uploadedAt: new Date(row.uploadedAt as string),
+    isPinned: row.isPinned === 1,
+    replicationCount: (row.replicationCount as number) || 0,
+    nodeLocations: row.nodeLocations ? JSON.parse(row.nodeLocations as string) : [],
+    metadata: row.metadata ? JSON.parse(row.metadata as string) : null,
+    lastSyncAt: new Date(row.lastSyncAt as string),
+  };
+}
+
+export class TinyBaseUserFileRepository implements IUserFileRepository {
+  constructor(private store: Store) {}
+
+  async create(data: CreateUserFileData): Promise<UserFile> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(TABLE, id, {
+      userId: data.userId,
+      projectId: data.projectId ?? '',
+      ipfsHash: data.ipfsHash,
+      fileName: data.fileName,
+      fileSize: data.fileSize.toString(),
+      fileType: data.fileType,
+      uploadedAt: now,
+      isPinned: 1,
+      replicationCount: 0,
+      nodeLocations: JSON.stringify(data.nodeLocations ?? []),
+      metadata: data.metadata ? JSON.stringify(data.metadata) : '',
+      lastSyncAt: now,
+    });
+
+    return rowToUserFile(id, this.store.getRow(TABLE, id));
+  }
+
+  async findById(id: string): Promise<UserFile | null> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.userId) return null;
+    return rowToUserFile(id, row);
+  }
+
+  async findByUserId(
+    userId: string,
+    options?: { skip?: number; take?: number; orderBy?: 'uploadedAt' }
+  ): Promise<UserFile[]> {
+    let results: UserFile[] = [];
+
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.userId === userId) results.push(rowToUserFile(id, row));
+    }
+
+    if (options?.orderBy === 'uploadedAt') {
+      results.sort((a, b) => b.uploadedAt.getTime() - a.uploadedAt.getTime());
+    }
+
+    if (options?.skip) results = results.slice(options.skip);
+    if (options?.take) results = results.slice(0, options.take);
+    return results;
+  }
+
+  async findByProjectId(projectId: string): Promise<UserFile[]> {
+    const results: UserFile[] = [];
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.projectId === projectId) results.push(rowToUserFile(id, row));
+    }
+    results.sort((a, b) => b.uploadedAt.getTime() - a.uploadedAt.getTime());
+    return results;
+  }
+
+  async findByUserAndHash(userId: string, ipfsHash: string): Promise<UserFile | null> {
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.userId === userId && row.ipfsHash === ipfsHash) {
+        return rowToUserFile(id, row);
+      }
+    }
+    return null;
+  }
+
+  async update(
+    id: string,
+    data: Partial<Pick<UserFile, 'isPinned' | 'replicationCount' | 'nodeLocations' | 'metadata' | 'lastSyncAt' | 'projectId'>>
+  ): Promise<UserFile> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.userId) throw new Error(`UserFile ${id} not found`);
+
+    if (data.isPinned !== undefined) this.store.setCell(TABLE, id, 'isPinned', data.isPinned ? 1 : 0);
+    if (data.replicationCount !== undefined) this.store.setCell(TABLE, id, 'replicationCount', data.replicationCount);
+    if (data.nodeLocations !== undefined) this.store.setCell(TABLE, id, 'nodeLocations', JSON.stringify(data.nodeLocations));
+    if (data.metadata !== undefined) this.store.setCell(TABLE, id, 'metadata', data.metadata ? JSON.stringify(data.metadata) : '');
+    if (data.lastSyncAt !== undefined) this.store.setCell(TABLE, id, 'lastSyncAt', data.lastSyncAt.toISOString());
+    if (data.projectId !== undefined) this.store.setCell(TABLE, id, 'projectId', data.projectId ?? '');
+
+    return rowToUserFile(id, this.store.getRow(TABLE, id));
+  }
+
+  async delete(id: string): Promise<void> {
+    this.store.delRow(TABLE, id);
+  }
+
+  async countByUserId(userId: string): Promise<number> {
+    let count = 0;
+    for (const id of this.store.getRowIds(TABLE)) {
+      if (this.store.getRow(TABLE, id).userId === userId) count++;
+    }
+    return count;
+  }
+}

--- a/tests/store/tinybase/user-file.tinybase.test.ts
+++ b/tests/store/tinybase/user-file.tinybase.test.ts
@@ -1,0 +1,106 @@
+import { createStore } from 'tinybase';
+import { TinyBaseUserFileRepository } from '@/lib/store/tinybase/user-file.tinybase';
+
+describe('TinyBaseUserFileRepository', () => {
+  let repo: TinyBaseUserFileRepository;
+
+  beforeEach(() => {
+    repo = new TinyBaseUserFileRepository(createStore());
+  });
+
+  describe('create', () => {
+    it('creates a file with defaults', async () => {
+      const f = await repo.create({
+        userId: 'u1',
+        ipfsHash: 'QmTest123',
+        fileName: 'test.txt',
+        fileSize: BigInt(1024),
+        fileType: 'text/plain',
+      });
+      expect(f.id).toBeDefined();
+      expect(f.userId).toBe('u1');
+      expect(f.ipfsHash).toBe('QmTest123');
+      expect(f.fileSize).toBe(BigInt(1024));
+      expect(f.isPinned).toBe(true);
+      expect(f.replicationCount).toBe(0);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns file when found', async () => {
+      const created = await repo.create({
+        userId: 'u1', ipfsHash: 'Qm1', fileName: 'a.txt',
+        fileSize: BigInt(100), fileType: 'text/plain',
+      });
+      expect(await repo.findById(created.id)).not.toBeNull();
+    });
+
+    it('returns null for missing', async () => {
+      expect(await repo.findById('missing')).toBeNull();
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('returns files for user', async () => {
+      await repo.create({ userId: 'u1', ipfsHash: 'Qm1', fileName: 'a.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      await repo.create({ userId: 'u1', ipfsHash: 'Qm2', fileName: 'b.txt', fileSize: BigInt(200), fileType: 'text/plain' });
+      await repo.create({ userId: 'u2', ipfsHash: 'Qm3', fileName: 'c.txt', fileSize: BigInt(300), fileType: 'text/plain' });
+
+      expect(await repo.findByUserId('u1')).toHaveLength(2);
+    });
+
+    it('supports pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await repo.create({ userId: 'u1', ipfsHash: `Qm${i}`, fileName: `f${i}.txt`, fileSize: BigInt(100), fileType: 'text/plain' });
+      }
+      expect(await repo.findByUserId('u1', { skip: 1, take: 2 })).toHaveLength(2);
+    });
+  });
+
+  describe('findByProjectId', () => {
+    it('returns files for project', async () => {
+      await repo.create({ userId: 'u1', projectId: 'p1', ipfsHash: 'Qm1', fileName: 'a.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      await repo.create({ userId: 'u1', projectId: 'p1', ipfsHash: 'Qm2', fileName: 'b.txt', fileSize: BigInt(200), fileType: 'text/plain' });
+      await repo.create({ userId: 'u1', projectId: 'p2', ipfsHash: 'Qm3', fileName: 'c.txt', fileSize: BigInt(300), fileType: 'text/plain' });
+
+      expect(await repo.findByProjectId('p1')).toHaveLength(2);
+    });
+  });
+
+  describe('findByUserAndHash', () => {
+    it('finds by user + hash', async () => {
+      await repo.create({ userId: 'u1', ipfsHash: 'QmUnique', fileName: 'test.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      expect(await repo.findByUserAndHash('u1', 'QmUnique')).not.toBeNull();
+    });
+
+    it('returns null for different user', async () => {
+      await repo.create({ userId: 'u1', ipfsHash: 'QmUnique', fileName: 'test.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      expect(await repo.findByUserAndHash('u2', 'QmUnique')).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('updates pin status', async () => {
+      const f = await repo.create({ userId: 'u1', ipfsHash: 'Qm1', fileName: 'a.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      const updated = await repo.update(f.id, { isPinned: false, replicationCount: 0 });
+      expect(updated.isPinned).toBe(false);
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the file', async () => {
+      const f = await repo.create({ userId: 'u1', ipfsHash: 'Qm1', fileName: 'a.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      await repo.delete(f.id);
+      expect(await repo.findById(f.id)).toBeNull();
+    });
+  });
+
+  describe('countByUserId', () => {
+    it('counts files for user', async () => {
+      await repo.create({ userId: 'u1', ipfsHash: 'Qm1', fileName: 'a.txt', fileSize: BigInt(100), fileType: 'text/plain' });
+      await repo.create({ userId: 'u1', ipfsHash: 'Qm2', fileName: 'b.txt', fileSize: BigInt(200), fileType: 'text/plain' });
+      expect(await repo.countByUserId('u1')).toBe(2);
+      expect(await repo.countByUserId('u2')).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- TinyBase UserFile repository with full CRUD + search by user/project/hash
- 11 new tests, 173 total store tests passing
- All 15 business models now have TinyBase implementations

## Context
Phase 11. All business data models are now on TinyBase. Remaining phases:
- Phase 12: Switch auth from NextAuth to Dex OIDC
- Phase 13: Remove Prisma + PostgreSQL entirely

## Test plan
- [x] 173 store tests pass
- [x] 11 new UserFile tests