### PR TITLE
fix(store): atomic-write tmp file next to target (fix EXDEV in Docker)

### DIFF
--- a/src/lib/store/tinybase/file-record-persister.ts
+++ b/src/lib/store/tinybase/file-record-persister.ts
@@ -1,7 +1,6 @@
 import type { Store } from 'tinybase';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 
 export interface IndexDefinition {
   name: string;
@@ -87,7 +86,7 @@ export class FileRecordPersister {
   }
 
   private atomicWrite(filePath: string, content: string): void {
-    const tmpFile = path.join(os.tmpdir(), `tinybase-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const tmpFile = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     fs.writeFileSync(tmpFile, content, { mode: 0o600 });
     fs.renameSync(tmpFile, filePath);
   }


### PR DESCRIPTION
## Summary

- `FileRecordPersister.atomicWrite` wrote tmp files to `os.tmpdir()` and renamed them to `DATA_DIR`. In Docker, `/tmp` is the container rootfs while `/app/data` is a named volume — `rename(2)` across mounts fails with `EXDEV`.
- This crashed the register server action with an `uncaughtException` after the Dex user was already created, leaving inconsistent state (Dex has user, TinyBase does not) and broken UX (no success response, no redirect).
- Fix: write the tmp file next to the target (`\${filePath}.tmp-\${pid}-...`), so rename stays on the same filesystem.

## Repro (prod)

Registration attempt on enopax.com produced:
\`\`\`
Error: EXDEV: cross-device link not permitted,
rename '/tmp/tinybase-1776258105998-...' -> '/app/data/users/8b5444a4....json'
⨯ uncaughtException: ...
\`\`\`
Dex user was created, TinyBase user was not.

## Test plan

- [x] `npx jest --config jest.config.unified.js tests/store/tinybase/file-record-persister.test.ts` — 10/10 passing
- [ ] Deploy to prod, verify register flow end-to-end
- [ ] Verify felix@enopax.com (already in Dex from broken attempt) gets auto-provisioned into TinyBase on first signin

## Related

- Groundwork for #47 (Password Reset) — same persister will be used for reset tokens if we migrate from the current ad-hoc file storage