### PR TITLE
fix(middleware): exclude public /assets and /icons from auth redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,5 +6,5 @@ const { auth } = NextAuth(authConfig)
 export default auth
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|assets|icons|favicon.ico).*)"],
 }


### PR DESCRIPTION
## Summary

Broken: logo in the top bar / menu icon and avatar in settings. Root cause: NextAuth middleware matcher didn't exclude \`/assets/\` or \`/icons/\`.

## Repro

\`\`\`
$ curl -sI https://enopax.com/assets/logo.png
HTTP/2 307
location: https://enopax.com/signin?callbackUrl=...
\`\`\`

Next.js image optimiser fetched \`/assets/logo.png\` server-side (no cookies), received a redirect to \`/signin\`, and logged:
\`\`\`
The requested resource isn't a valid image for /assets/logo.png received null
\`\`\`
Browser then rendered an empty \`<img>\` — the visible "broken icon" for:

- Logo / menu icon (\`components/layout/Logo.tsx\`)
- Avatar fallback (\`components/common/Avatar.tsx\` — falls back to \`/assets/logo.png\` when \`user.image\` is null), used by UserBarMenu and settings pages.

## Fix

Add \`assets\` and \`icons\` to the middleware matcher's negative lookahead so those public folders bypass auth entirely.

## Test plan

- [ ] Deploy, then \`curl -sI https://enopax.com/assets/logo.png\` returns \`200\` with \`Content-Type: image/png\`
- [ ] Top bar logo visible (logged out and logged in)
- [ ] User dropdown avatar visible (fallback case)
- [ ] Settings avatar visible