### PR TITLE
fix(store): always rebuild row indexes on startup

### DIFF
--- a/src/lib/store/tinybase/file-record-persister.ts
+++ b/src/lib/store/tinybase/file-record-persister.ts
@@ -110,22 +110,12 @@ export class FileRecordPersister {
   private loadIndexes(table: TableConfig): void {
     if (!table.indexes) return;
 
+    // Always rebuild from loaded rows. Trusting a stale on-disk index is how
+    // previous deploys ended up with users visible in /data/users/ but missing
+    // from /_index/email.json — making findByEmail return null and breaking
+    // sign-in and verification flows. Rebuild is O(N) over already-loaded rows.
     for (const idx of table.indexes) {
-      const indexFile = path.join(this.dataDir, table.tableName, '_index', `${idx.name}.json`);
-      const index = this.getIndex(table.tableName, idx.name);
-
-      if (fs.existsSync(indexFile)) {
-        try {
-          const data: Record<string, string | string[]> = JSON.parse(fs.readFileSync(indexFile, 'utf-8'));
-          for (const [key, value] of Object.entries(data)) {
-            index.set(key, Array.isArray(value) ? value : [value]);
-          }
-        } catch {
-          this.rebuildIndex(table, idx);
-        }
-      } else {
-        this.rebuildIndex(table, idx);
-      }
+      this.rebuildIndex(table, idx);
     }
   }
 


### PR DESCRIPTION
## Summary

The \`FileRecordPersister.loadIndexes()\` method preferred a cached on-disk index file over rebuilding from loaded rows. Any drift between rows and the cached index persisted across every restart.

## Observed impact in prod

- User registered → row file written → container restart before index cache flushed → row loaded on next boot but missing from the index
- Every subsequent \`findByEmail(email)\` for that user returned \`null\`
- Sign-in auto-provisioning kept creating duplicate rows (same email, different rowIds)
- Email verification failed silently (\`update(wrongRowId, ...)\` errors)
- Members / projects lookup by email cascaded into 404-ish states

Repro state we saw: \`/data/users/\` contained 4 rows, \`/data/users/_index/email.json\` mapped only 2 emails — one user was entirely invisible to the app despite their row existing on disk.

## Fix

Always rebuild each index from the rows already loaded by \`load()\`. Cost is O(N) over the row count; at our scale (small K), this is negligible. Removes the entire stale-cache failure class.

## Test plan

- [x] \`tests/store/tinybase/file-record-persister.test.ts\` — all 10 tests pass (including "index survives restart" and "lookupIndex returns correct row IDs" — these now exercise the rebuild path)
- [ ] After deploy: hit the site once, check \`/data/users/_index/email.json\` is regenerated and contains every user row that exists on disk
- [ ] Andi (amueller@enopax.com) can sign in without duplicate user rows being created