### PR TITLE
fix(email): enforce hard expiry + cleanup stale verification tokens

### DIFF
--- a/src/lib/email-verification.ts
+++ b/src/lib/email-verification.ts
@@ -51,7 +51,57 @@ export async function createVerificationToken(userId: string, email: string): Pr
   const tokenFile = path.join(tokensDir, `${token}.json`);
   fs.writeFileSync(tokenFile, JSON.stringify(tokenData, null, 2), { mode: 0o600 });
 
+  try {
+    await cleanupExpiredTokens();
+  } catch {
+    // Never let cleanup failures affect token creation
+  }
+
   return token;
+}
+
+export async function cleanupExpiredTokens(): Promise<void> {
+  const fs = await import('fs');
+  const path = await import('path');
+
+  const dataDir = process.env.DATA_DIR || path.join(process.cwd(), 'data');
+  const tokensDir = path.join(dataDir, 'verification-tokens');
+
+  if (!fs.existsSync(tokensDir)) return;
+
+  const now = new Date();
+  const entries = fs.readdirSync(tokensDir);
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+
+    const filePath = path.join(tokensDir, entry);
+    let shouldDelete = false;
+
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const data = JSON.parse(raw) as Partial<VerificationToken>;
+
+      if (typeof data.expiresAt !== 'string') {
+        shouldDelete = true;
+      } else {
+        const expiresAt = new Date(data.expiresAt);
+        if (Number.isNaN(expiresAt.getTime()) || expiresAt < now) {
+          shouldDelete = true;
+        }
+      }
+    } catch {
+      shouldDelete = true;
+    }
+
+    if (shouldDelete) {
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        // Ignore: file may have been removed concurrently
+      }
+    }
+  }
 }
 
 export async function verifyToken(token: string): Promise<{ userId: string; email: string } | null> {
@@ -66,7 +116,13 @@ export async function verifyToken(token: string): Promise<{ userId: string; emai
   try {
     const data: VerificationToken = JSON.parse(fs.readFileSync(tokenFile, 'utf-8'));
 
-    if (new Date(data.expiresAt) < new Date()) {
+    if (typeof data.expiresAt !== 'string') {
+      fs.unlinkSync(tokenFile);
+      return null;
+    }
+
+    const expiresAt = new Date(data.expiresAt);
+    if (Number.isNaN(expiresAt.getTime()) || expiresAt < new Date()) {
       fs.unlinkSync(tokenFile);
       return null;
     }


### PR DESCRIPTION
## Summary
- Harden `verifyToken()` in `src/lib/email-verification.ts`: explicitly validate `expiresAt` is a parseable string with a future date. Missing/invalid values are now treated as expired rather than crashing `new Date(undefined)`.
- Add `cleanupExpiredTokens()` helper that scans `data/verification-tokens/` and deletes any file whose `expiresAt` is in the past or whose JSON is malformed.
- Call cleanup opportunistically (wrapped in try/catch) at the end of `createVerificationToken()` so the directory self-cleans on register/resend without adding new jobs or scheduled tasks.

File-based storage is preserved; token creation and email-send flows are unchanged; no external API changes.

## Test plan
- [ ] Create a token, then manually age the JSON (`expiresAt` in past) and call `verifyToken` — returns `null` and removes the file.
- [ ] Write a token file with missing/invalid `expiresAt` — `verifyToken` returns `null` without crashing.
- [ ] Drop a malformed JSON file into `data/verification-tokens/`, then call `createVerificationToken` — stale/malformed files are removed.
- [ ] Happy path: fresh token still verifies and is consumed exactly once.