### PR TITLE
fix(actions): revalidate name-based paths, not id-based

### DIFF
--- a/src/actions/organisation.ts
+++ b/src/actions/organisation.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
 import { organisationService } from '@/lib/services/organisation';
 import { userService } from '@/lib/services/user';
 import { validateNameFormat } from '@/lib/name-validation';
@@ -122,7 +123,7 @@ export async function updateOrganisation(
     revalidatePath('/admin/organisation');
     revalidatePath(`/admin/organisation/${organisationId}`);
     revalidatePath('/orga');
-    revalidatePath(`/orga/${organisationId}`);
+    revalidatePath(`/orga/${name.trim()}`);
 
     return { success: true };
   } catch (error) {
@@ -252,6 +253,10 @@ export async function deleteOrganisation(
 
     console.log('User attempting deletion:', session.user.id, session.user.email);
 
+    // Look up org name before deletion so we can revalidate the name-based route
+    const store = await getStoreAsync();
+    const organisation = await store.organisations.findById(organisationId);
+
     // Use service to delete organisation (soft delete)
     console.log('Calling organisationService.deleteOrganisation...');
     await organisationService.deleteOrganisation(organisationId, session.user.id);
@@ -259,7 +264,9 @@ export async function deleteOrganisation(
     console.log('Organisation deleted successfully, revalidating paths...');
     revalidatePath('/admin/organisations');
     revalidatePath('/orga');
-    revalidatePath(`/orga/${organisationId}`);
+    if (organisation?.name) {
+      revalidatePath(`/orga/${organisation.name}`);
+    }
 
     console.log('Paths revalidated, returning success');
     return { success: true };

--- a/src/actions/project.ts
+++ b/src/actions/project.ts
@@ -184,12 +184,18 @@ export async function updateProject(
     });
 
     const org = await store.organisations.findById(currentProject.organisationId);
+    const updatedProject = await store.projects.findById(projectId);
 
     revalidatePath('/admin/project');
     revalidatePath(`/admin/project/${projectId}`);
-    if (org) {
+    if (org?.name) {
       revalidatePath(`/orga/${org.name}`);
-      revalidatePath(`/orga/${org.name}/${projectId}`);
+      if (updatedProject?.name) {
+        revalidatePath(`/orga/${org.name}/${updatedProject.name}`);
+      }
+      if (currentProject.name && currentProject.name !== updatedProject?.name) {
+        revalidatePath(`/orga/${org.name}/${currentProject.name}`);
+      }
     }
 
     return { success: true };

--- a/src/actions/resource.ts
+++ b/src/actions/resource.ts
@@ -222,8 +222,12 @@ export async function createResource(
 
     revalidatePath('/main/resources');
     if (projectId) {
-      revalidatePath(`/orga/${organisationId}/projects/${projectId.trim()}`);
-      console.log(`🔄 Revalidated project path for org ${organisationId}, project ${projectId.trim()}`);
+      const trimmedProjectId = projectId.trim();
+      const project = await store.projects.findById(trimmedProjectId);
+      if (organisation?.name && project?.name) {
+        revalidatePath(`/orga/${organisation.name}/${project.name}`);
+        console.log(`🔄 Revalidated project path for org ${organisation.name}, project ${project.name}`);
+      }
     }
 
     return { success: true };
@@ -345,7 +349,23 @@ export async function updateResource(
     });
 
     revalidatePath('/main/resources');
-    revalidatePath(`/main/resources/${resourceId}`);
+
+    const organisation = await store.organisations.findById(currentResource.organisationId);
+    if (organisation?.name) {
+      const resourceName = name.trim();
+      const allocations = await store.projectResources.findByResourceId(resourceId);
+      if (allocations.length === 0) {
+        revalidatePath(`/orga/${organisation.name}`);
+      } else {
+        for (const allocation of allocations) {
+          const project = await store.projects.findById(allocation.projectId);
+          if (project?.name) {
+            revalidatePath(`/orga/${organisation.name}/${project.name}`);
+            revalidatePath(`/orga/${organisation.name}/${project.name}/${resourceName}`);
+          }
+        }
+      }
+    }
 
     return { success: true };
   } catch (error) {
@@ -359,12 +379,29 @@ export async function updateResource(
 export async function deleteResource(resourceId: string) {
   try {
     const store = await getStoreAsync();
+    const resource = await store.resources.findById(resourceId);
+
     await store.resources.update(resourceId, {
       isActive: false,
       deletedAt: new Date(),
     });
 
     revalidatePath('/main/resources');
+
+    if (resource) {
+      const organisation = await store.organisations.findById(resource.organisationId);
+      if (organisation?.name) {
+        revalidatePath(`/orga/${organisation.name}`);
+        const allocations = await store.projectResources.findByResourceId(resourceId);
+        for (const allocation of allocations) {
+          const project = await store.projects.findById(allocation.projectId);
+          if (project?.name) {
+            revalidatePath(`/orga/${organisation.name}/${project.name}`);
+          }
+        }
+      }
+    }
+
     return { success: true };
   } catch (error) {
     console.error('Failed to delete resource:', error);
@@ -420,8 +457,10 @@ export async function allocateResourceToProject(
       quotaLimit
     });
 
-    revalidatePath(`/orga/${organisation?.name}/resources/${resourceId}`);
-    revalidatePath(`/orga/${organisation?.name}/projects/${projectId}`);
+    if (organisation?.name && project.name) {
+      revalidatePath(`/orga/${organisation.name}/${project.name}/${resource.name}`);
+      revalidatePath(`/orga/${organisation.name}/${project.name}`);
+    }
 
     return { success: true };
   } catch (error) {
@@ -447,9 +486,12 @@ export async function removeResourceFromProject(
 
     const resource = await store.resources.findById(resourceId);
     const organisation = resource ? await store.organisations.findById(resource.organisationId) : null;
+    const project = await store.projects.findById(projectId);
 
-    revalidatePath(`/orga/${organisation?.name}/resources/${resourceId}`);
-    revalidatePath(`/orga/${organisation?.name}/projects/${projectId}`);
+    if (organisation?.name && project?.name && resource?.name) {
+      revalidatePath(`/orga/${organisation.name}/${project.name}/${resource.name}`);
+      revalidatePath(`/orga/${organisation.name}/${project.name}`);
+    }
 
     return { success: true };
   } catch (error) {
@@ -478,9 +520,12 @@ export async function updateResourceAllocationQuota(
 
     const resource = await store.resources.findById(resourceId);
     const organisation = resource ? await store.organisations.findById(resource.organisationId) : null;
+    const project = await store.projects.findById(projectId);
 
-    revalidatePath(`/orga/${organisation?.name}/resources/${resourceId}`);
-    revalidatePath(`/orga/${organisation?.name}/projects/${projectId}`);
+    if (organisation?.name && project?.name && resource?.name) {
+      revalidatePath(`/orga/${organisation.name}/${project.name}/${resource.name}`);
+      revalidatePath(`/orga/${organisation.name}/${project.name}`);
+    }
 
     return { success: true };
   } catch (error) {


### PR DESCRIPTION
## Summary

- `revalidatePath()` was called with TinyBase IDs in slots where the router expects org/project names (routes are name-based: `/orga/[orgaName]/[projectName]/[resourceName]`)
- As a result the cache tag hit a 404 route and the real list/detail pages kept showing stale data after create/update/delete
- Look up the org name (and project name, where relevant) before revalidating, and guard with optional chaining so a missing entity doesn't crash the action

## Files touched

- `src/actions/resource.ts` — create / update / delete / allocate / remove / quota update
- `src/actions/project.ts` — update project now revalidates `/orga/{orgName}/{projectName}` (also re-revalidates the old project name on rename)
- `src/actions/organisation.ts` — update / delete organisation now revalidate `/orga/{orgName}`

## Test plan

- [x] `npx tsc --noEmit` — no new errors introduced (baseline errors unchanged)
- [x] `npx jest --config jest.config.unified.js tests/actions` — all pass
- [ ] Manual: create a resource inside a project, verify the project page re-renders with the new resource without a hard refresh
- [ ] Manual: rename a project, verify both the old and new `/orga/{org}/{projectName}` paths invalidate