### PR TITLE
fix(orga): load projects into context + clearer menu icon

### DIFF
--- a/src/app/(main)/orga/[orgaName]/layout.tsx
+++ b/src/app/(main)/orga/[orgaName]/layout.tsx
@@ -22,8 +22,24 @@ export default async function OrganisationLayout({
     notFound();
   }
 
+  const projects = await store.projects.findByOrgId(organisation.id, { isActive: true });
+  const members = await store.organisationMembers.findByOrgId(organisation.id);
+
   return (
-    <OrganisationProvider organisation={organisation}>
+    <OrganisationProvider
+      organisation={{
+        id: organisation.id,
+        name: organisation.name,
+        description: organisation.description,
+        ownerId: organisation.ownerId,
+        isActive: organisation.isActive,
+        projects,
+        _count: {
+          members: members.length,
+          projects: projects.length,
+        },
+      }}
+    >
       {children}
     </OrganisationProvider>
   );

--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -3,6 +3,7 @@ import { type User } from '@/lib/store';
 import Link from 'next/link';
 import { Button } from '@/components/common/Button';
 import Avatar from '@/components/common/Avatar';
+import { RiMenuLine } from '@remixicon/react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,7 +31,8 @@ export default function UserBarMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="p-1">
+        <Button variant="ghost" className="flex items-center gap-2 p-1 pr-2" aria-label="Open menu">
+          <RiMenuLine className="h-5 w-5" />
           <Avatar
             name={user.name || user.email}
             image={user.image}

--- a/src/contexts/OrganisationContext.tsx
+++ b/src/contexts/OrganisationContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext } from 'react';
+import type { Project } from '@/lib/store';
 
 export interface OrganisationContextType {
   id: string;
@@ -8,6 +9,11 @@ export interface OrganisationContextType {
   description: string | null;
   ownerId: string;
   isActive: boolean;
+  projects: Project[];
+  _count: {
+    members: number;
+    projects: number;
+  };
 }
 
 const OrganisationContext = createContext<OrganisationContextType | undefined>(


### PR DESCRIPTION
## Summary

Two related UX fixes on the organisation overview.

### 1. Projects weren't showing on \`/orga/{name}\`

Store + index were fine (2 projects for Enopax visible on disk; \`projects/_index/organisationId.json\` maps both to the org). But \`OrganisationContextType\` declared only 5 fields — no \`projects\`, no \`_count\`. \`OrganisationOverviewClient\` reads exactly those, so the page always rendered the empty state.

Extended the context type and loaded \`projects\` + member/project counts in \`/orga/[orgaName]/layout.tsx\` using the existing repository calls.

### 2. Menu trigger looked like just an avatar

Added a \`RiMenuLine\` hamburger before the avatar in the \`UserBarMenu\` trigger. The avatar still identifies who's logged in; the hamburger makes it obvious it's a menu. Added \`aria-label="Open menu"\` while I was there.

## Test plan

- [ ] \`/orga/Enopax\` lists the 2 existing projects as cards
- [ ] Top-right trigger shows a hamburger + avatar, clickable, dropdown opens with same items as before