### PR TITLE
fix(nav): split profile avatar from menu trigger

### DIFF
--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -29,17 +29,20 @@ export default function UserBarMenu({
   );
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="flex items-center gap-2 p-1 pr-2" aria-label="Open menu">
-          <RiMenuLine className="h-5 w-5" />
-          <Avatar
-            name={user.name || user.email}
-            image={user.image}
-            size="small"
-          />
-        </Button>
-      </DropdownMenuTrigger>
+    <div className="flex items-center gap-2">
+      <Link href="/account/settings" aria-label="Profile settings" className="inline-flex">
+        <Avatar
+          name={user.name || user.email}
+          image={user.image}
+          size="small"
+        />
+      </Link>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="p-2" aria-label="Open menu">
+            <RiMenuLine className="h-5 w-5" />
+          </Button>
+        </DropdownMenuTrigger>
 
       <DropdownMenuContent>
         {/* ----- Account ----- */}
@@ -127,6 +130,7 @@ export default function UserBarMenu({
           </button>
         </form>
       </DropdownMenuContent>
-    </DropdownMenu>
+      </DropdownMenu>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The \`UserBarMenu\` combined an avatar and a hamburger icon into a single dropdown trigger. Felix wanted them split so each has a distinct purpose:

- **Avatar** — direct link to \`/account/settings\` (profile shortcut)
- **Menu icon** (\`RiMenuLine\`) — dedicated dropdown trigger

## Test plan

- [ ] Top bar shows avatar + menu icon as two sibling controls
- [ ] Clicking avatar navigates to /account/settings
- [ ] Clicking menu icon opens the dropdown (Organisations, Developer, Settings, Sign Out, ...)