### PR TITLE
feat(invitations): admin invite page + pending list in members view (#2 of 3)

### DIFF
--- a/src/app/(main)/orga/[orgaName]/members/invite/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/members/invite/page.tsx
@@ -1,0 +1,53 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import Container from '@/components/common/Container';
+import Headline from '@/components/common/Headline';
+import InviteMemberForm from '@/components/form/InviteMemberForm';
+import { RiArrowLeftLine } from '@remixicon/react';
+
+interface InviteMemberPageProps {
+  params: Promise<{ orgaName: string }>;
+}
+
+export default async function InviteMemberPage({ params }: InviteMemberPageProps) {
+  const { orgaName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) notFound();
+  if (!orgaName) notFound();
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const isAdmin = session.user.role === 'ADMIN';
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const isOwner = membership?.role === 'OWNER';
+  const isManager = membership?.role === 'MANAGER';
+
+  if (!isAdmin && !isOwner && !isManager) notFound();
+
+  return (
+    <main className="mt-4">
+      <Container>
+        <div className="mb-6">
+          <Link
+            href={`/orga/${orgaName}/members`}
+            className="inline-flex items-center text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 mb-3"
+          >
+            <RiArrowLeftLine className="h-4 w-4 mr-1" />
+            Back to members
+          </Link>
+          <Headline>Invite Member</Headline>
+        </div>
+
+        <div className="max-w-xl">
+          <InviteMemberForm organisationId={organisation.id} organisationName={organisation.name} />
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/src/app/(main)/orga/[orgaName]/members/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/members/page.tsx
@@ -39,9 +39,10 @@ export default async function MembersManagementPage({ params }: MembersManagemen
     notFound();
   }
 
-  const [storeMembers, rawJoinRequests] = await Promise.all([
+  const [storeMembers, rawJoinRequests, pendingInvitations] = await Promise.all([
     store.organisationMembers.findByOrgId(organisationId),
     store.joinRequests.findByOrgId(organisationId, 'PENDING'),
+    store.invitations.findByOrgId(organisationId, 'PENDING'),
   ]);
 
   const joinRequests = await Promise.all(
@@ -92,10 +93,23 @@ export default async function MembersManagementPage({ params }: MembersManagemen
     return a.joinedAt.getTime() - b.joinedAt.getTime();
   });
 
+  const now = new Date();
+  const invitations = pendingInvitations
+    .filter((inv) => inv.expiresAt > now)
+    .map((inv) => ({
+      id: inv.id,
+      email: inv.email,
+      role: inv.role,
+      expiresAt: inv.expiresAt,
+      createdAt: inv.createdAt,
+    }));
+
   return (
     <MembersManagementClient
       members={members}
       joinRequests={joinRequests}
+      invitations={invitations}
+      organisationName={orgaName}
       isOwner={isOwner}
       isManager={isManager}
       isAdmin={isAdmin}

--- a/src/components/MembersManagementClient.tsx
+++ b/src/components/MembersManagementClient.tsx
@@ -1,15 +1,20 @@
 'use client';
 
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 import { useOrganisation } from '@/contexts/OrganisationContext';
 import Container from '@/components/common/Container';
 import Headline from '@/components/common/Headline';
 import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
 import { Callout } from '@/components/common/Callout';
+import { Card } from '@/components/common/Card';
 import Link from 'next/link';
-import { RiUserAddLine, RiAlertLine } from '@remixicon/react';
+import { RiUserAddLine, RiAlertLine, RiMailSendLine, RiCloseLine } from '@remixicon/react';
 import Table from '@/components/GenericTable';
 import { membershipRequestColumns, type MembershipRequestWithActions } from '@/components/table/MembershipRequests';
 import { organisationMemberColumns, type OrganisationMemberWithActions } from '@/components/table/OrganisationMembers';
+import { revokeInvitation } from '@/actions/invitation';
 
 interface Member {
   id: string;
@@ -39,9 +44,19 @@ interface JoinRequest {
   };
 }
 
+interface PendingInvitation {
+  id: string;
+  email: string;
+  role: string;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
 interface MembersManagementClientProps {
   members: Member[];
   joinRequests: JoinRequest[];
+  invitations: PendingInvitation[];
+  organisationName: string;
   isOwner: boolean;
   isManager: boolean;
   isAdmin: boolean;
@@ -51,14 +66,33 @@ interface MembersManagementClientProps {
 export function MembersManagementClient({
   members,
   joinRequests,
+  invitations,
+  organisationName,
   isOwner,
   isManager,
   isAdmin,
   currentUserId
 }: MembersManagementClientProps) {
   const organisation = useOrganisation();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [revokingId, setRevokingId] = useState<string | null>(null);
   const hasNewRequests = joinRequests.length > 0;
+  const hasInvitations = invitations.length > 0;
   const canManage = isOwner || isManager || isAdmin;
+
+  const handleRevoke = (id: string) => {
+    if (!confirm('Revoke this invitation? The link will stop working immediately.')) return;
+    setRevokingId(id);
+    startTransition(async () => {
+      try {
+        await revokeInvitation(id);
+        router.refresh();
+      } finally {
+        setRevokingId(null);
+      }
+    });
+  };
 
   return (
     <main className="mt-4">
@@ -67,10 +101,12 @@ export function MembersManagementClient({
         <div className="flex items-center justify-between mb-6">
           <Headline>Members & Requests</Headline>
           {canManage && (
-            <Button>
-              <RiUserAddLine className="mr-2 h-4 w-4" />
-              Invite Member
-            </Button>
+            <Link href={`/orga/${organisationName}/members/invite`}>
+              <Button>
+                <RiUserAddLine className="mr-2 h-4 w-4" />
+                Invite Member
+              </Button>
+            </Link>
           )}
         </div>
 
@@ -105,6 +141,50 @@ export function MembersManagementClient({
               tableColumns={membershipRequestColumns}
               actions={undefined as any}
             />
+          </div>
+        )}
+
+        {/* Pending Invitations */}
+        {hasInvitations && (
+          <div className="mb-8">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+              Pending Invitations ({invitations.length})
+            </h2>
+            <Card className="divide-y divide-gray-200 dark:divide-gray-700">
+              {invitations.map((invitation) => (
+                <div key={invitation.id} className="flex items-center justify-between p-4">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="p-2 bg-gray-100 dark:bg-gray-800 rounded-full flex-shrink-0">
+                      <RiMailSendLine className="h-4 w-4 text-gray-500" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        {invitation.email}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        Invited {invitation.createdAt.toLocaleDateString('en-GB')} · expires {invitation.expiresAt.toLocaleDateString('en-GB')}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 flex-shrink-0">
+                    <Badge variant="neutral">{invitation.role}</Badge>
+                    <Badge variant="warning">Pending</Badge>
+                    {canManage && (
+                      <Button
+                        type="button"
+                        variant="light"
+                        className="text-red-600 hover:text-red-700"
+                        onClick={() => handleRevoke(invitation.id)}
+                        disabled={isPending && revokingId === invitation.id}
+                      >
+                        <RiCloseLine className="h-4 w-4 mr-1" />
+                        {isPending && revokingId === invitation.id ? 'Revoking…' : 'Revoke'}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </Card>
           </div>
         )}
 

--- a/src/components/form/InviteMemberForm.tsx
+++ b/src/components/form/InviteMemberForm.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { inviteMember, type InviteMemberState } from '@/actions/invitation';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+import { RiErrorWarningFill, RiCheckboxCircleFill } from '@remixicon/react';
+
+const initialState: InviteMemberState = {};
+
+const ROLES = [
+  { value: 'OWNER', label: 'Owner — full control' },
+  { value: 'ADMIN', label: 'Admin — manage settings and members' },
+  { value: 'MANAGER', label: 'Manager — manage projects and members' },
+  { value: 'MEMBER', label: 'Member — collaborate on projects' },
+];
+
+interface InviteMemberFormProps {
+  organisationId: string;
+  organisationName: string;
+}
+
+export default function InviteMemberForm({ organisationId, organisationName }: InviteMemberFormProps) {
+  const inviteAction = inviteMember.bind(null, organisationId);
+  const [state, formAction, pending] = useActionState(inviteAction, initialState);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state?.success) {
+      const timer = setTimeout(() => {
+        router.push(`/orga/${organisationName}/members`);
+      }, 1200);
+      return () => clearTimeout(timer);
+    }
+  }, [state?.success, organisationName, router]);
+
+  return (
+    <Card className="p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+        Invite a member to {organisationName}
+      </h2>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+        They&apos;ll receive an email with a link to join. If they don&apos;t have an Enopax account yet, they can register directly from the invite link.
+      </p>
+
+      {state?.error && !state?.fieldErrors && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningFill} className="mb-4">
+          {state.error}
+        </Callout>
+      )}
+
+      {state?.success && (
+        <Callout variant="success" title="Invitation sent" icon={RiCheckboxCircleFill} className="mb-4">
+          Redirecting back to the members list…
+        </Callout>
+      )}
+
+      <form action={formAction} className="space-y-5">
+        <div>
+          <Label htmlFor="email">Email address</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            required
+            placeholder="person@example.com"
+            hasError={!!state?.fieldErrors?.email}
+            disabled={pending || state?.success}
+          />
+          {state?.fieldErrors?.email && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.email}</p>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="role">Role</Label>
+          <Select name="role" defaultValue="MEMBER" disabled={pending || state?.success}>
+            <SelectTrigger id="role" className={state?.fieldErrors?.role ? 'border-red-500' : ''}>
+              <SelectValue placeholder="Choose a role" />
+            </SelectTrigger>
+            <SelectContent>
+              {ROLES.map((r) => (
+                <SelectItem key={r.value} value={r.value}>
+                  {r.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {state?.fieldErrors?.role && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.role}</p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="light"
+            onClick={() => router.push(`/orga/${organisationName}/members`)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={pending || state?.success}>
+            {pending ? 'Sending…' : 'Send invitation'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Part 2 of 3 — admin side of the invite flow.

Previous:
- #58 (merged): entity + repository + server action + email template

This PR:
- Creates \`/orga/{orgaName}/members/invite\` as a **dedicated page**, not a modal (per Felix's rule)
- Wires the previously-dead "Invite Member" button on \`/members\` to link to the new page
- Adds a Pending Invitations section to the members view with a Revoke action

Next (PR #3):
- \`/accept-invite?token=X\` recipient flow
- Register-with-prefill so new users can join in one click

## Repro (before)

Click "Invite Member" → nothing happens. Zero handler.

## Flow (after)

1. Admin hits "Invite Member" → navigates to \`/orga/{name}/members/invite\`
2. Fills email + role (OWNER / ADMIN / MANAGER / MEMBER)
3. Server action validates, creates invitation row, sends email
4. Redirects back to \`/members\` with the new Pending entry visible
5. Can revoke with \`Revoke\` button → status=\`REVOKED\`, row disappears

## Test plan

- [x] \`npx jest --config jest.config.unified.js tests/store\` — 183/183
- [ ] After deploy: click Invite Member → goes to /invite page
- [ ] Submit with a real email → invite email delivered, redirects to /members, row appears with Pending badge
- [ ] Revoke → confirm dialog, row disappears after transition
- [ ] Submit with an email that's already a member → error "Already a member"
- [ ] Submit twice with same email — second call should reuse the still-valid token, no duplicate email