### PR TITLE
fix(account): replace org sidebar with account-specific nav

### DIFF
--- a/src/app/(main)/account/layout.tsx
+++ b/src/app/(main)/account/layout.tsx
@@ -1,68 +1,12 @@
-import { redirect } from 'next/navigation';
-import { auth } from '@/lib/auth';
-import { getStoreAsync } from '@/lib/store';
-import SidebarNavigation from '@/components/navigation/SidebarNavigation';
-import MobileNavigation from '@/components/navigation/MobileNavigation';
+import AccountSidebar from '@/components/navigation/AccountSidebar';
 
-export default async function Layout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
-  const session = await auth();
-  //if (!session) return redirect('/');
-
-  // Note: We can't extract organisationId from URL in layout
-  // The sidebar will handle organisation context detection client-side from pathname
-  // We fetch all organisations with their projects for the sidebar
-
-  let organisations: { id: string; name: string; description: string | null; _count: { projects: number; members: number } }[] = [];
-
-  if (session?.user?.id) {
-    try {
-      const store = await getStoreAsync();
-      const memberships = await store.organisationMembers.findByUserId(session.user.id);
-      const memberOrgIds = new Set(memberships.map(m => m.organisationId));
-
-      const allOrgs = await store.organisations.search('', 1000);
-      const userOrgs = allOrgs.filter(org =>
-        org.isActive && (org.ownerId === session.user.id || memberOrgIds.has(org.id))
-      );
-
-      organisations = userOrgs
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(org => {
-          const memberCount = memberships.filter(m => m.organisationId === org.id).length ||
-            (org.ownerId === session.user.id ? 1 : 0);
-          return {
-            id: org.id,
-            name: org.name,
-            description: org.description,
-            _count: { projects: 0, members: memberCount },
-          };
-        });
-    } catch (error) {
-      console.error('Error fetching sidebar data:', error);
-    }
-  }
-
+export default function AccountLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <div className="flex pt-10 lg:pt-5">
-      {/* Desktop Sidebar - Hidden on mobile */}
+    <div className="flex min-h-[calc(100vh-2.5rem)]">
       <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
-        <SidebarNavigation
-          user={session?.user}
-          organisations={organisations}
-        />
+        <AccountSidebar />
       </div>
-
-      {/* Mobile Navigation - Visible only on mobile */}
-      <MobileNavigation user={session?.user} organisations={organisations} />
-
-      {/* Main Content */}
-      <main className="flex-1 p-6 lg:p-6 pt-5 lg:pt-6">
-        {children}
-      </main>
+      <main className="flex-1 p-6 lg:p-8">{children}</main>
     </div>
   );
 }

--- a/src/components/navigation/AccountSidebar.tsx
+++ b/src/components/navigation/AccountSidebar.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { RiUserSettingsLine, RiCodeBoxLine, RiBankCardLine, RiArrowLeftLine } from '@remixicon/react';
+
+const ITEMS = [
+  { href: '/account/settings', label: 'Profile', icon: RiUserSettingsLine },
+  { href: '/account/developer', label: 'Developer', icon: RiCodeBoxLine },
+  { href: '/account/payment', label: 'Payment', icon: RiBankCardLine },
+];
+
+export default function AccountSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-64 shrink-0 border-r border-gray-200 dark:border-gray-800 min-h-screen py-8 px-4">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="inline-flex items-center text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 mb-4"
+        >
+          <RiArrowLeftLine className="h-3 w-3 mr-1" />
+          Back to app
+        </Link>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Account
+        </h2>
+      </div>
+
+      <nav className="space-y-1">
+        {ITEMS.map((item) => {
+          const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
+                active
+                  ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+              }`}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

\`/account/*\` was showing the org sidebar with the organisation dropdown — makes no sense on account-settings pages. Replace with a focused \`AccountSidebar\` (Profile / Developer / Payment, plus a "Back to app" escape hatch).

Also drops an N+1 org fetch from every /account/* render, which the old layout needed only to populate that now-removed sidebar.

## Test plan

- [ ] \`/account/settings\`, \`/account/developer\`, \`/account/payment\`: show the new sidebar with active-state highlighting
- [ ] Click "Back to app" returns to \`/\`
- [ ] On mobile: sidebar hidden (lg:block), content takes full width