### PR TITLE
docs: access-control design spec (Teams, Projects, Roles)

### DIFF
--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -230,7 +230,7 @@ Project(any) 0..N ProjectShare (cross-entity sharing)
 ### How it works
 
 1. Host owner shares Project X with Org B (or User C): creates a `ProjectShare` row.
-2. Recipient sees Project X in their "Shared with you" section.
+2. Recipient sees Project X in their own namespace with an "Owner: HostOrg" badge.
 3. `ProjectShare.permission` controls what the recipient can do:
 
 | Permission | What recipient can do |
@@ -347,19 +347,19 @@ On a project's access page, surface **why** each user has access:
 ### Sidebar navigation
 
 ```
-felixboehm                 ← personal namespace (user profile link)
-  └── experiment           ← personal projects
-  └── test-api
+felixboehm                 ← personal namespace
+  └── experiment            (Owner: felixboehm)
+  └── acme-project          (Owner: Acme Corp)   ← shared, owner visible
 
 Enopax                     ← organisation
-  └── platform             ← org projects (filtered by team access)
-  └── resource-api
-
-Shared with you            ← projects shared from other entities
-  └── acme/their-project
+  └── platform              (Owner: Enopax)
+  └── resource-api          (Owner: Enopax)
 ```
 
-Clean separation: personal projects, org projects, shared projects. No "my org" confusion.
+No "Shared with you" section. Shared projects appear directly in the
+recipient's namespace with the owner organisation/user shown as a badge.
+The same project appears in both the host and recipient namespaces —
+like a symlink, not a copy. The owner badge makes provenance clear.
 
 ### Key flows
 

--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -1,0 +1,245 @@
+# Access Control Design — Organisations, Teams, Projects, Roles
+
+**Date:** 2026-04-15
+**Status:** Draft, pending review
+**Author:** Felix Böhm + collaboration with Claude
+
+---
+
+## 1. Context
+
+### Current state (2026-04-15)
+
+- `Organisation` with `OrganisationMember` table. Fixed roles: `OWNER | ADMIN | MANAGER | MEMBER`.
+- `Project` belongs to a single `Organisation`. Projects have **no members of their own** — access is inherited wholesale from the parent org.
+- No `Team` entity. A legacy Teams stub from the upstream fork was removed in PR #54.
+- No custom roles. No direct project-level grants. No external users.
+
+### What we're designing
+
+A model where **Teams** are reusable groups of people defined at the Org level, assigned to Projects with per-project roles. Custom roles on Projects are possible. Cross-org collaboration is reserved as a future phase — MVP is single-org only.
+
+---
+
+## 2. Decisions
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| D1 | Team-only vs direct project members? | **Teams only** | Felix's preference: no micro-managing individual project grants. External contractors join a regular or purpose-built "External" team rather than getting ad-hoc direct grants. |
+| D2 | Scope of custom roles? | **Org-level, reused across projects** | Enforces consistency. Start with 3-5 built-in project roles; custom roles a Phase 2 feature when real demand surfaces. |
+| D3 | How do org-roles and project-team-roles combine? | **Tiered**: OWNER + ADMIN auto-admin on every project; MANAGER + MEMBER only via team assignment | Least privilege for regular members; a Trust Tier that can always rescue a project. Shown explicitly in the project member list ("Alice — Admin via Org OWNER role") so access is auditable, not hidden. |
+| D4 | External users and cross-org collaboration? | **Not in MVP.** Spec out as Phase 3. MVP is single-org with externals handled by joining a Team inside the host org. | Most mature platforms ship single-tenant first; cross-org is a large scope that deserves its own design pass. |
+
+### OWNER vs ADMIN
+
+Standard distinction:
+- **OWNER**: ultimate authority. Can delete the org. Can transfer ownership. Can grant/revoke OWNER role. Can remove other ADMINs. 1-2 per org typically.
+- **ADMIN**: can manage members and teams, change settings, admin all projects — but cannot delete the org, cannot transfer ownership, cannot demote/remove other ADMINs or OWNERs. 5-20% of members.
+
+Both are auto-admin on all projects (D3 Tiered rule).
+
+---
+
+## 3. Domain Model
+
+### Entities
+
+```
+User
+  id, email, name, password, createdAt, ...
+
+Organisation
+  id, name, ownerId, ...
+
+OrganisationMember
+  id, userId, organisationId
+  role: OWNER | ADMIN | MANAGER | MEMBER
+  joinedAt, updatedAt
+
+Team
+  id, organisationId, name, description, purpose (optional tag: Dev|Ops|FE|Marketing|...)
+  createdAt, updatedAt
+
+TeamMember
+  id, teamId, userId
+  addedAt, addedBy
+
+Project
+  id, organisationId, name, ...  (unchanged)
+
+ProjectAccess
+  id, projectId, teamId
+  role: ProjectRole (see §4)
+  grantedAt, grantedBy
+
+(Phase 2 only)
+ProjectRoleDefinition
+  id, organisationId, name, description, permissions (bitmask or JSON)
+  isBuiltIn: boolean  — built-ins aren't user-editable
+```
+
+### Relationships
+
+- `Organisation` 1..N `OrganisationMember` — standard membership
+- `Organisation` 1..N `Team` — teams live inside an org
+- `Team` 1..N `TeamMember` — users can be in multiple teams
+- `Organisation` 1..N `Project`
+- `Project` 1..N `ProjectAccess` — a project grants access to a team with a specific role
+- `Team` 1..N `ProjectAccess` — the same team can be attached to many projects, possibly with different roles per project
+
+### Invariants
+
+- A user can be a `TeamMember` without being an `OrganisationMember` (reserved for Phase 3 — not enforced in MVP). In MVP, all team members are also org members.
+- A `Team` belongs to exactly one `Organisation`. Teams are not shared across orgs.
+- A `Project` can have zero or more `ProjectAccess` rows.
+- Removing a `Team` cascades to all its `ProjectAccess` rows.
+- Removing a `Project` cascades to all its `ProjectAccess` rows (not to teams).
+
+---
+
+## 4. Permission Model
+
+### Project Roles (built-in, Phase 1)
+
+| Role | Permissions |
+|---|---|
+| `VIEWER` | Read project metadata, view resources and their status. No writes. |
+| `DEVELOPER` | VIEWER + create/edit/delete resources within the project. Cannot change project settings or members. |
+| `DEPLOYER` | DEVELOPER + trigger deployments / provisioning actions. (Split from DEVELOPER because deploy is the most sensitive IaaS operation.) |
+| `ADMIN` | DEPLOYER + manage project settings and manage team access to the project (add/remove teams, change team roles). |
+
+*Out of MVP, we may also want a `REVIEWER` role for approval flows — not needed yet.*
+
+### Permission resolution (effective permissions)
+
+For a user `U` asking "can I do action `A` on project `P`?":
+
+1. **Tiered auto-admin check:** If `U` has `OrganisationMember` role in the parent org equal to `OWNER` or `ADMIN` → `U` has `ADMIN` project permissions on `P`.
+2. **Team-based grants:** Otherwise, collect every `ProjectAccess` row where `P` is the project and `U` is a member of the referenced team. `U`'s effective project role is the **highest (most permissive)** of all those rows.
+3. **No grant found:** `U` has no access to `P`. The project doesn't appear in their navigation.
+
+**Rules:**
+- **Union-of-all-grants**. No deny rules (per research: deny-wins causes most "why can't I?" support tickets).
+- No team nesting. A team is a flat list of users.
+- Most permissive role wins when a user is in multiple teams with access to the same project.
+
+### Visibility rules
+
+- Org OWNER/ADMIN always see every project in the org (consequence of D3 tiered).
+- Org MANAGER/MEMBER only see projects where they have team-granted access.
+- On a project's member list, surface *why* each user has access:
+  - "Alice — Admin via Org OWNER role"
+  - "Bob — Developer via Team Frontend"
+  - "Charlie — Developer via Team Frontend · Deployer via Team Ops" (show highest + tooltip with all sources)
+
+---
+
+## 5. UX Implications
+
+### Org admin flows
+
+- `/orga/{name}/teams` (new) — list teams, create team, view members
+- `/orga/{name}/teams/{teamName}` — manage team members, see projects this team has access to
+- `/orga/{name}/members` (exists) — unchanged at surface level; tiered auto-admin badge for OWNER/ADMIN
+- `/orga/{name}/settings/roles` (Phase 2) — manage custom project roles
+
+### Project admin flows
+
+- `/orga/{orgName}/{projectName}/access` (new) — list teams with access + their roles, add team, change role, remove team
+- `/orga/{orgName}/{projectName}/members` (new) — read-only derived view showing effective members (sourced from teams + tiered auto-admin), with the "why" column
+
+### Member discovery
+
+- An org MEMBER who gets added to a team with project access will see that project appear in their nav on next reload.
+- No "request to join project" in MVP — only admin/manager can grant team access.
+
+---
+
+## 6. Phased Roadmap
+
+### Phase 1 — Teams Infrastructure (MVP, this work)
+
+**Scope:**
+- New entities: `Team`, `TeamMember`, `ProjectAccess`
+- Built-in project roles (VIEWER / DEVELOPER / DEPLOYER / ADMIN) hard-coded
+- Team CRUD pages under `/orga/{name}/teams`
+- Project access page under `/orga/{orgName}/{projectName}/access`
+- Derived member view on project pages
+- Permission resolution on every server-side access check (new helper: `resolveProjectPermissions(userId, projectId) → ProjectRole | null`)
+
+**Out of scope for Phase 1:**
+- Custom roles
+- External / cross-org users
+- Permission UI beyond "what role does this team have on this project"
+- Migration of existing data — currently only one org with no teams; Phase 1 can land cleanly without migration
+
+**Acceptance:**
+- An org OWNER can create a team, add members, attach to a project with a role.
+- A plain Org MEMBER assigned to a team sees only projects granted via that team.
+- An Org ADMIN sees all projects.
+- The "why this user has access" trace is visible on the project access page.
+
+### Phase 2 — Custom Roles
+
+**Scope:**
+- `ProjectRoleDefinition` entity (org-scoped)
+- Role editor UI at `/orga/{name}/settings/roles`
+- Permission primitives formalised (discrete actions: view, write-resource, deploy, manage-members, manage-settings, ...)
+- Built-in roles become seeded records in `ProjectRoleDefinition` with `isBuiltIn: true` (uneditable names, permissions editable only by forking into a new custom role)
+
+**Trigger:** when ≥2 customers ask for a role the built-ins don't cover. Until then, don't build it.
+
+### Phase 3 — Cross-Org Collaboration
+
+**Scope:** instead of external users joining a host org, Project X is jointly owned by Org A (host) and Org B (collaborator). Each org sees the project in their own org space; each assigns their own teams with their own project roles.
+
+**Entities likely added:**
+```
+ProjectCollaboration
+  id, projectId, collaboratingOrgId
+  status: INVITED | ACTIVE | REMOVED
+  invitedBy, acceptedBy, invitedAt, acceptedAt
+
+TeamProjectAccess (renamed from Phase 1's ProjectAccess)
+  id, projectId, teamId, teamOrgId  (team can now belong to host or collab org)
+  role: ProjectRole
+```
+
+**Host org has final say:** delete project, rename, change billing arrangement. Collab orgs can contribute via teams but can't transfer or delete.
+
+**Effective permissions:** same union-of-team-grants; collaboration doesn't change the resolution algorithm — just which teams can be attached.
+
+**Not MVP because:** significant scope (new invite flow for orgs, host-vs-collab permission asymmetry, shared billing unclear, auditability across orgs) and unclear demand. Revisit when first real multi-party project comes up.
+
+---
+
+## 7. Migration from current state
+
+Prod data today:
+- 1 active org (Enopax) with Felix (OWNER) and Andi (pending — will be MEMBER)
+- 2 projects (Resource-Tests, ResourceTest) — both inherit access via Felix's OWNER status
+- No teams, no custom roles
+
+**Phase 1 go-live requires no data migration** for existing projects: the tiered auto-admin rule (D3) means Felix (OWNER) keeps full access without any new records; Andi needs to be added to a team to see projects (or just use the current fallback while we're single-user-org).
+
+A one-time seed is advisable: create a default team named "All Members" per org, auto-add all current org MEMBERs to it, grant it `DEVELOPER` on all existing projects. Keeps existing member behaviour the same until admins set up proper teams.
+
+---
+
+## 8. Open Questions
+
+- **Team visibility:** should all Org members see the list of all teams (even teams they're not in) for discoverability, or only teams they belong to + teams that grant them project access? Recommend **all visible** for transparency; team membership stays gated.
+- **Can a team have zero members?** Yes — empty teams are allowed as templates. No access is granted by empty teams.
+- **Can an Org MEMBER be removed while they're in teams?** Yes, but this should cascade: removing their OrganisationMember removes all their TeamMember rows. Warn the admin in the UI before confirming.
+- **Audit log:** for Phase 1, log: team created, team member added/removed, project access granted/revoked. Use the existing `audit-logs` table.
+- **Naming collision:** the current `OrganisationMember` stays. The new `TeamMember` is a distinct concept. Consider whether to rename for clarity — probably not, since both terms match industry convention (GitHub uses the same terms).
+- **Project "owner":** do we need a concept of "project owner" separate from the creator and from org OWNERs? Recommend **no** — the creator is recorded in an audit log, ownership of a project is collective via team access + tiered auto-admin.
+
+---
+
+## 9. References
+
+- Research brief: access-control patterns across GitHub, GitLab, Notion, Linear, Figma, Jira, Azure DevOps, AWS IAM/Okta — see conversation context.
+- Felix's scope decisions (conversation, 2026-04-15): D1=A (team-only), D2=A (org-level custom roles), D3=C (tiered), D4=not-in-MVP.
+- Prior removal of legacy Teams stub: PR #54.
+- Current invitation flow (Org-level membership): PRs #58, #59, #61.

--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -57,8 +57,14 @@ OrganisationMember
   joinedAt, updatedAt
 
 Team
-  id, organisationId, name, description, purpose (optional tag: Dev|Ops|FE|Marketing|...)
+  id, organisationId, name, description
   createdAt, updatedAt
+  — Fully user-defined. No hardcoded purpose enum. Name and description
+    are free text (e.g. "Backend", "Ops", "Sprint 42 contractors", or
+    whatever makes sense for the org).
+  — On org creation, a default team "All Members" is seeded as a normal
+    Team row — not a system-level special case. Admins can rename,
+    repurpose, or delete it like any other team.
 
 TeamMember
   id, teamId, userId
@@ -222,7 +228,7 @@ Prod data today:
 
 **Phase 1 go-live requires no data migration** for existing projects: the tiered auto-admin rule (D3) means Felix (OWNER) keeps full access without any new records; Andi needs to be added to a team to see projects (or just use the current fallback while we're single-user-org).
 
-A one-time seed is advisable: create a default team named "All Members" per org, auto-add all current org MEMBERs to it, grant it `DEVELOPER` on all existing projects. Keeps existing member behaviour the same until admins set up proper teams.
+A one-time seed is advisable: the "All Members" default team (seeded on org creation as a normal team — see §3) should be created for the existing Enopax org, all current org members auto-added, and granted `DEVELOPER` on all existing projects. Keeps existing member behaviour the same until admins set up proper teams.
 
 ---
 

--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -58,13 +58,17 @@ OrganisationMember
 
 Team
   id, organisationId, name, description
+  defaultProjectRole: ProjectRole (see §4)
   createdAt, updatedAt
   — Fully user-defined. No hardcoded purpose enum. Name and description
     are free text (e.g. "Backend", "Ops", "Sprint 42 contractors", or
     whatever makes sense for the org).
-  — On org creation, a default team "All Members" is seeded as a normal
-    Team row — not a system-level special case. Admins can rename,
-    repurpose, or delete it like any other team.
+  — defaultProjectRole captures the team's natural character (Backend →
+    DEVELOPER, Ops → DEPLOYER). Used as pre-fill when assigning the team
+    to a project — admin can override per project.
+  — On org creation, a default team "All Members" (defaultRole: DEVELOPER)
+    is seeded as a normal Team row — not a system-level special case.
+    Admins can rename, repurpose, or delete it like any other team.
 
 TeamMember
   id, teamId, userId
@@ -77,11 +81,17 @@ ProjectAccess
   id, projectId, teamId
   role: ProjectRole (see §4)
   grantedAt, grantedBy
+  — role is always stored explicitly. When assigning a team to a project,
+    the UI pre-fills with team.defaultProjectRole but the admin can change
+    it. No "use default" indirection — the stored value IS the role.
 
-(Phase 2 only)
+(Phase 2)
 ProjectRoleDefinition
   id, organisationId, name, description, permissions (bitmask or JSON)
   isBuiltIn: boolean  — built-ins aren't user-editable
+  — In Phase 2, Team.defaultProjectRole and ProjectAccess.role become
+    references to ProjectRoleDefinition instead of a fixed enum.
+    Same architecture, just flexible values.
 ```
 
 ### Relationships
@@ -232,14 +242,14 @@ A one-time seed is advisable: the "All Members" default team (seeded on org crea
 
 ---
 
-## 8. Open Questions
+## 8. Resolved Questions
 
-- **Team visibility:** should all Org members see the list of all teams (even teams they're not in) for discoverability, or only teams they belong to + teams that grant them project access? Recommend **all visible** for transparency; team membership stays gated.
-- **Can a team have zero members?** Yes — empty teams are allowed as templates. No access is granted by empty teams.
-- **Can an Org MEMBER be removed while they're in teams?** Yes, but this should cascade: removing their OrganisationMember removes all their TeamMember rows. Warn the admin in the UI before confirming.
-- **Audit log:** for Phase 1, log: team created, team member added/removed, project access granted/revoked. Use the existing `audit-logs` table.
-- **Naming collision:** the current `OrganisationMember` stays. The new `TeamMember` is a distinct concept. Consider whether to rename for clarity — probably not, since both terms match industry convention (GitHub uses the same terms).
-- **Project "owner":** do we need a concept of "project owner" separate from the creator and from org OWNERs? Recommend **no** — the creator is recorded in an audit log, ownership of a project is collective via team access + tiered auto-admin.
+- **Q1 — Team visibility:** Depends on Org Role. Viewing the team list (names, descriptions) is a **permission** attached to Org Roles. OWNER/ADMIN/MANAGER see all teams. MEMBER sees only teams they belong to. This is enforced via the permission model, not a hardcoded rule — so custom org roles (if ever added) can grant or withhold team visibility.
+- **Q2 — Can a team have zero members?** Yes. Empty teams serve as templates or placeholders. They grant no access until members are added.
+- **Q3 — Can an Org MEMBER be removed while they're in teams?** Yes — removing the OrganisationMember cascades: all their TeamMember rows are deleted, which removes all their project access via those teams. The UI warns the admin before confirming, listing which teams and projects the user will lose access to.
+- **Q4 — Audit log:** Yes. For Phase 1, log: team created/updated/deleted, team member added/removed, project access granted/changed/revoked. Use the existing `audit-logs` table.
+- **Q5 — Naming collision (OrganisationMember vs TeamMember):** Keep both names. They match industry convention and are distinct concepts.
+- **Q6 — Project "owner":** No dedicated project-owner concept. Projects are administered by Org OWNER/ADMIN (tiered auto-admin, D3) and by teams with the `ADMIN` ProjectRole. The `ADMIN` ProjectRole gives a team project-level control (settings, team access management) without requiring Org-level admin privileges — so a project lead can manage their project without being an Org ADMIN.
 
 ---
 

--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -1,6 +1,6 @@
 # Access Control Design — Organisations, Teams, Projects, Roles
 
-**Date:** 2026-04-15 (updated 2026-04-16)
+**Date:** 2026-04-15 (updated 2026-04-17)
 **Status:** Draft, pending review
 **Author:** Felix Böhm
 
@@ -19,9 +19,11 @@
 
 A professional access-control model inspired by GitHub's Organisations/Repos/Teams — adapted for an IaaS platform. Key principles:
 
-- **Teams** are the single mechanism for project access (no direct individual grants)
-- **Cross-org collaboration** replaces "external members" — every user IS an org (personal namespace), sharing a project with an external person = sharing with their org
-- **Slugs + display names** everywhere, shared global namespace
+- **User and Organisation are separate entities** that share a global URL namespace — like GitHub where `github.com/felixboehm` (user) and `github.com/enopax` (org) coexist but are fundamentally different things
+- **Users own personal projects directly** — no org overhead, no teams, no settings confusion
+- **Organisations own org projects via Teams** — the single mechanism for org-level project access (D1)
+- **Cross-org sharing** replaces "external members" — share a project with another org or a user; same mechanism, no separate concept
+- **Slugs + display names** everywhere
 - **Public/private visibility** on orgs and projects
 - **Custom project roles** in a later phase, built on a solid foundation
 
@@ -39,33 +41,34 @@ Every addressable entity has both:
 | Organisation | `enopax` | Enopax GmbH |
 | Project | `platform` (unique within parent) | Enopax Platform |
 
-**Slug rules:** lowercase alphanumeric + hyphens, 2-39 chars, no leading/trailing hyphens, no consecutive hyphens. Same rules as GitHub.
+**Slug rules:** lowercase alphanumeric + hyphens, 2-39 chars, no leading/trailing hyphens, no consecutive hyphens.
 
 ### Shared global namespace
 
-User slugs and Org slugs share the same pool — like GitHub where `github.com/felixboehm` and `github.com/enopax` coexist.
+User slugs and Organisation slugs share the same pool. A global namespace table resolves which entity a slug belongs to:
 
-**URLs:**
 ```
-enopax.com/enopax/platform        ← org project
-enopax.com/felixboehm/experiment  ← personal project
-enopax.com/enopax/members         ← org members page
-enopax.com/felixboehm/settings    ← personal settings (same as account)
+Namespace
+  slug: "felixboehm" → type: USER,         entityId: user-123
+  slug: "enopax"     → type: ORGANISATION,  entityId: org-456
 ```
+
+On user registration or org creation, the slug is checked against this table. Conflict → "this name is taken."
 
 **Reserved slugs:** `account`, `admin`, `signin`, `register`, `accept-invite`, `api`, `_next`, `assets`, `icons`, `settings`, `new`, `explore`
 
-**Uniqueness:** on user registration or org creation, check the global slug table. Conflict → "this name is taken."
+### URLs
 
-### Personal namespace = auto-org
+```
+enopax.com/felixboehm              → User profile (personal projects)
+enopax.com/felixboehm/experiment   → Personal project (owned by user)
+enopax.com/enopax                  → Organisation overview (teams, projects)
+enopax.com/enopax/platform         → Org project (owned by org)
+enopax.com/enopax/members          → Org member management
+enopax.com/enopax/teams            → Org team management
+```
 
-Every user gets a personal Organisation auto-created at registration:
-- `slug` = user's slug, `name` = user's display name
-- `isPersonal: true` flag — UI shows "My Projects" instead of org chrome
-- User is auto-OWNER, cannot leave or delete (tied to account lifecycle)
-- Same entity, same permissions, same Team/Project model — just a UI distinction
-
-This means: **there is no concept of "external user."** An external person is just another org (their personal namespace or their company org) that gets cross-org project access. One mechanism for everything.
+Routing: `/{slug}` → namespace lookup → render User profile or Org overview depending on entity type.
 
 ---
 
@@ -73,12 +76,13 @@ This means: **there is no concept of "external user."** An external person is ju
 
 | # | Question | Decision | Rationale |
 |---|---|---|---|
-| D1 | Team-only vs direct project members? | **Teams only** | No micro-managing. External access = cross-org sharing (see §6). |
+| D1 | Team-only vs direct project members? | **Teams only** (within orgs) | No micro-managing within orgs. Cross-org sharing is a separate mechanism (see §6). |
 | D2 | Scope of custom roles? | **Org-level, reused across projects** | Start with built-in project roles; custom roles Phase 2. |
 | D3 | How do org-roles and project-team-roles combine? | **Tiered**: OWNER + ADMIN auto-admin on every project; MANAGER + MEMBER only via team | Least privilege + trust tier. Explicit in UI. |
-| D5 | Namespace model? | **Shared global namespace**, user = personal org | GitHub model. One URL space, one mechanism for personal + org projects. |
+| D5 | Namespace model? | **Shared global namespace**, User and Org are separate entities | No `isPersonal` hack. User ≠ Org. They share a URL space but are conceptually different. |
 | D6 | Default org visibility? | **Public** | Discoverable by default. Admins can switch to private. |
-| D7 | Cross-org = external members? | **Yes** | `felixboehm` user = `felixboehm` org. Sharing with a person = sharing with their org. No separate external-member concept. |
+| D7 | Cross-org sharing model? | Share with Org or User — same `ProjectShare` entity | No separate "external member" concept. Share with user = share with a person. Share with org = share with a company. One mechanism. |
+| D8 | User = Org? | **No.** Separate entities. | Mixing them creates settings confusion, meaningless teams-of-one, billing ambiguity, and a conceptual lie ("I'm in my own org"). Clean separation, shared namespace. |
 
 ### OWNER vs ADMIN
 
@@ -102,9 +106,9 @@ Both are auto-admin on all projects (D3).
 
 | Visibility | Behaviour |
 |---|---|
-| `PUBLIC` | Anyone (even unauthenticated) can see description + resource status. Write/deploy still requires team access. |
-| `INTERNAL` | All org members can view (regardless of team assignment). Write/deploy requires team access. |
-| `PRIVATE` | Only teams with ProjectAccess + tiered auto-admin (OWNER/ADMIN) can see it. Default for new projects. |
+| `PUBLIC` | Anyone (even unauthenticated) can see description + resource status. Write/deploy still requires team access (org projects) or ownership (personal projects). |
+| `INTERNAL` | All org members can view regardless of team assignment (org projects only). |
+| `PRIVATE` | Only teams with ProjectAccess + tiered auto-admin can see it (org projects). Only owner can see it (personal projects). Default for new projects. |
 
 **Org-level default:** setting on Organisation: `defaultProjectVisibility: PRIVATE | INTERNAL | PUBLIC`.
 
@@ -115,18 +119,25 @@ Both are auto-admin on all projects (D3).
 ### Entities
 
 ```
+Namespace (global slug registry)
+  slug, entityType: USER | ORGANISATION, entityId
+  — Enforces global uniqueness across users and orgs
+
 User
   id, slug, name, email, password, createdAt, ...
-  — slug is globally unique (shared namespace with orgs)
+  — slug registered in Namespace table
+  — Can own personal projects directly (no org needed)
+  — Has account settings (profile, password, email)
+  — No teams, no members, no org-level settings
 
 Organisation
   id, slug, name, description
   visibility: PUBLIC | PRIVATE
   defaultProjectVisibility: PRIVATE | INTERNAL | PUBLIC
-  isPersonal: boolean  — true for auto-created personal namespaces
   ownerId
   createdAt, updatedAt
-  — slug is globally unique (shared namespace with users)
+  — slug registered in Namespace table
+  — Has members, teams, org-level settings
 
 OrganisationMember
   id, userId, organisationId
@@ -150,28 +161,31 @@ TeamMember
   addedAt, addedBy
 
 Project
-  id, organisationId, slug, name, description
+  id, slug, name, description
+  ownerType: USER | ORGANISATION
+  ownerId: (userId or organisationId)
   visibility: PUBLIC | INTERNAL | PRIVATE
   status, isActive, ...
-  — slug unique within parent org
+  — slug unique within parent (owner)
 
-ProjectAccess
+ProjectAccess (org projects only)
   id, projectId, teamId
   role: ProjectRole (see §7)
   grantedAt, grantedBy
   — role stored explicitly. UI pre-fills from team.defaultProjectRole;
     admin can change. No "use default" indirection.
+  — Only applies to org-owned projects. Personal projects don't need
+    this — the owning user has full access inherently.
 
-ProjectShare (Phase 1.5 — cross-org)
+ProjectShare (Phase 1.5 — cross-entity sharing)
   id, projectId
-  sharedWithOrgId
+  sharedWithType: USER | ORGANISATION
+  sharedWithId: (userId or orgId)
   permission: VIEW | CONTRIBUTE | MANAGE
   sharedBy, sharedAt
-  — Simple sharing: host org shares project with another org.
-  — Collab org sees it in a "Shared with you" section.
-  — Permission controls what the collab org's teams can do (see §6).
-  — No invite/accept flow initially — admin shares directly.
-    Later: invite + accept UX.
+  — Works for both: share with an org (their members get access)
+    or share with a user (they get personal access).
+  — Host owner (user or org) has final say.
 
 (Phase 2)
 ProjectRoleDefinition
@@ -184,24 +198,26 @@ ProjectRoleDefinition
 ### Relationships
 
 ```
-User ←slug→ global namespace ←slug→ Organisation
+Namespace ← slug → User
+Namespace ← slug → Organisation
+User 1..N Project (personal, ownerType=USER)
+Organisation 1..N Project (org, ownerType=ORGANISATION)
 Organisation 1..N OrganisationMember
 Organisation 1..N Team
 Team 1..N TeamMember (users)
-Organisation 1..N Project
-Project 1..N ProjectAccess (team + role)
-Project 0..N ProjectShare (cross-org, Phase 1.5)
+Project(org) 1..N ProjectAccess (team + role)
+Project(any) 0..N ProjectShare (cross-entity sharing)
 ```
 
 ### Invariants
 
-- User.slug and Organisation.slug share the same uniqueness constraint (global slug table).
+- Namespace table enforces: no two entities (user or org) share the same slug.
 - A Team belongs to exactly one Organisation.
-- In MVP, all TeamMembers must also be OrganisationMembers of the same org.
-- Removing an OrganisationMember cascades: deletes all their TeamMember rows (and thus all project access). UI warns before confirming.
+- All TeamMembers must also be OrganisationMembers of the same org.
+- ProjectAccess only applies to org-owned projects. Personal projects have no ProjectAccess rows — the owner always has full access.
+- Removing an OrganisationMember cascades: deletes all their TeamMember rows → removes all project access. UI warns before confirming.
 - Removing a Team cascades to its ProjectAccess rows.
 - Removing a Project cascades to its ProjectAccess + ProjectShare rows.
-- Personal orgs (isPersonal: true) cannot be deleted independently — tied to user account lifecycle.
 
 ---
 
@@ -209,33 +225,32 @@ Project 0..N ProjectShare (cross-org, Phase 1.5)
 
 ### Core insight
 
-**There are no "external members."** Every user has a personal org. Sharing a project with external person Felix = sharing with org `felixboehm`. Sharing with company Acme = sharing with org `acme`. Same mechanism.
+**There are no "external members."** Sharing a project with external person Felix = sharing with user `felixboehm`. Sharing with company Acme = sharing with org `acme`. The `ProjectShare` entity handles both — `sharedWithType` distinguishes.
 
 ### How it works
 
-1. Host org admin shares Project X with Org B: creates a `ProjectShare` row.
-2. Org B sees Project X in their "Shared with you" section.
-3. `ProjectShare.permission` controls what Org B can do:
+1. Host owner shares Project X with Org B (or User C): creates a `ProjectShare` row.
+2. Recipient sees Project X in their "Shared with you" section.
+3. `ProjectShare.permission` controls what the recipient can do:
 
-| Permission | What collab org can do |
+| Permission | What recipient can do |
 |---|---|
 | `VIEW` | See project metadata + resource status. Read-only. |
-| `CONTRIBUTE` | VIEW + use/manage resources within the project. Cannot change project settings or team access. |
-| `MANAGE` | CONTRIBUTE + manage project settings and share with other orgs (but cannot delete project — only host org can). |
+| `CONTRIBUTE` | VIEW + use/manage resources within the project. Cannot change project settings or sharing. |
+| `MANAGE` | CONTRIBUTE + manage project settings and re-share (but cannot delete project — only host can). |
 
-4. **Host org has final say:** delete, rename, change billing, revoke shares.
+4. **Host has final say:** delete, rename, change billing, revoke shares.
 
-### What collab org CANNOT do (Phase 1.5)
+### Sharing with User vs Org
 
-- Cannot assign their own teams to the shared project (that's Phase 2+)
-- Cannot change the share permission level (only host org admin can)
-- Cannot re-share with a third org (unless permission = MANAGE)
+- **Share with User:** that specific person gets the permission level directly. Simple — they're one person.
+- **Share with Org:** all members of that org get the permission level. Within the collab org, the tiered rule applies (OWNER/ADMIN see shared projects; MANAGER/MEMBER see them if granted visibility — initially all org members see shared projects).
 
-### Later improvements
+### Later improvements (Phase 3)
 
+- Collab org assigns their own teams with per-project roles on shared projects
 - Invite + accept flow (instead of direct share)
-- Collab org assigns their own teams with per-project roles
-- Configurable fine-grained permissions per share
+- Fine-grained per-share permission configuration
 
 ---
 
@@ -254,10 +269,17 @@ Project 0..N ProjectShare (cross-org, Phase 1.5)
 
 For user `U` on project `P`:
 
+**Personal project (ownerType = USER):**
+1. If `U` is the owner → full access.
+2. If `U` has a `ProjectShare` on `P` → share's permission level.
+3. Visibility fallback: if PUBLIC → implicit VIEWER for everyone.
+4. Otherwise → no access.
+
+**Org project (ownerType = ORGANISATION):**
 1. **Tiered auto-admin:** If `U` is OWNER or ADMIN in the parent org → ADMIN on `P`.
 2. **Team grants:** Collect every ProjectAccess where `P` = project and `U` ∈ team. Effective role = highest of all.
-3. **Cross-org share (Phase 1.5):** If `U` is a member of a collab org that has a ProjectShare on `P`, effective permission = the share's permission level (VIEW / CONTRIBUTE / MANAGE), mapped to the closest ProjectRole.
-4. **Visibility fallback:** If `P` is INTERNAL and `U` is an org member → implicit VIEWER. If `P` is PUBLIC → implicit VIEWER for everyone.
+3. **Cross-org share:** If `U` is a member of a collab org (or is the shared-with user) that has a ProjectShare on `P` → share's permission level, mapped to closest ProjectRole.
+4. **Visibility fallback:** If `P` is INTERNAL and `U` is an org member → implicit VIEWER. If PUBLIC → implicit VIEWER for everyone.
 5. **No grant:** `P` doesn't appear in `U`'s navigation.
 
 **Rules:** Union-of-all-grants. No deny. No team nesting. Most permissive wins.
@@ -267,7 +289,8 @@ For user `U` on project `P`:
 On a project's access page, surface **why** each user has access:
 - "Alice — Admin via Org OWNER role"
 - "Bob — Developer via Team Backend"
-- "Charlie — Viewer via Org Acme (shared)"
+- "Charlie — Viewer via shared with Org Acme"
+- "Dave — Contributor via shared with user dave"
 
 ---
 
@@ -277,61 +300,74 @@ On a project's access page, surface **why** each user has access:
 
 | GitHub concept | Enopax equivalent |
 |---|---|
-| User + personal repos | User + personal org (auto-created) |
+| User + personal repos | User + personal projects (ownerType=USER) |
 | Organisation | Organisation |
 | Repository | Project |
 | Team → repo permission | Team → ProjectAccess(role) |
 | Org Owner / Member | OWNER / ADMIN / MANAGER / MEMBER |
 | Public / private repos | Public / internal / private projects |
-| Public / hidden org membership | Public / private orgs |
-| Slug-based URLs | `enopax.com/{slug}/{project}` |
-| Slug + display name | Same — both everywhere |
-| Reserved paths | Same approach |
+| Public / hidden org | Public / private orgs |
+| Slug-based URLs, shared namespace | Same — `/{slug}/{project}` |
+| Slug + display name | Same |
+| User and Org are separate entities | Same — no `isPersonal` hack |
 
 ### Where we improve on GitHub
 
-1. **One access path** — GitHub has Teams AND direct collaborators. Confusing. We have Teams only (D1).
+1. **One access path within orgs** — GitHub has Teams AND direct collaborators. Enopax has Teams only (D1). Cleaner within orgs.
 2. **Team character** — `defaultProjectRole` on Team. GitHub teams are generic.
-3. **Real cross-org** — GitHub can't share a repo between two orgs. Only fork (copy) or transfer (move). We support true shared projects.
+3. **Real cross-org sharing** — GitHub can't share a repo between two orgs. Only fork (copy that diverges) or transfer (one org loses it). Enopax supports true shared projects — the same project, jointly accessible.
 4. **Transparent access traces** — "Admin via Org OWNER" in the project member view. GitHub hides implicit permissions.
 5. **INTERNAL visibility** — all org members can read without explicit team assignment. GitHub Enterprise has this but it's buried.
+6. **Cross-entity sharing** — share with a user OR an org via the same mechanism. GitHub has no clean equivalent.
 
 ### What we consciously skip
 
-- **Nested teams** — GitHub supports parent/child teams. Adds complexity, rarely used. We keep teams flat.
-- **Template projects** — Not in scope. May revisit later.
-- **Forking** — Our cross-org model is sharing (same project), not copying. Forking may come later if use cases emerge.
+- **Nested teams** — adds complexity, rarely used. Teams are flat.
+- **Forking** — our cross-org model is sharing (same project), not copying.
+- **Template projects** — not in scope.
 
 ---
 
 ## 9. UX Implications
 
-### URL structure (flat namespace)
+### URL structure
 
 ```
-/{slug}                      → org or personal namespace overview
-/{slug}/{project}            → project overview
-/{slug}/members              → org member management
-/{slug}/teams                → team management
-/{slug}/teams/{teamSlug}     → team detail + members
-/{slug}/{project}/access     → project team access management
-/{slug}/{project}/members    → derived effective member view
-/{slug}/{project}/settings   → project settings
-/{slug}/settings             → org settings
+/{slug}                      → User profile or Org overview (namespace lookup)
+/{slug}/{project}            → Project overview
+/{slug}/members              → Org member management (org only)
+/{slug}/teams                → Org team management (org only)
+/{slug}/teams/{teamSlug}     → Team detail + members (org only)
+/{slug}/{project}/access     → Project team access (org projects)
+/{slug}/{project}/members    → Derived effective member view
+/{slug}/{project}/settings   → Project settings
+/{slug}/settings             → Org settings (org) or account settings (user)
 ```
 
-### Navigation
+### Sidebar navigation
 
-- Left sidebar shows: personal namespace ("My Projects") + all orgs the user is a member of + "Shared with you" section (Phase 1.5)
-- Within an org: projects list filtered by team access (unless OWNER/ADMIN → see all)
-- Project detail: tabs for Overview, Resources, Access, Members, Settings
+```
+felixboehm                 ← personal namespace (user profile link)
+  └── experiment           ← personal projects
+  └── test-api
+
+Enopax                     ← organisation
+  └── platform             ← org projects (filtered by team access)
+  └── resource-api
+
+Shared with you            ← projects shared from other entities
+  └── acme/their-project
+```
+
+Clean separation: personal projects, org projects, shared projects. No "my org" confusion.
 
 ### Key flows
 
-- **Create team:** `/enopax/teams` → "New Team" → name + description + default role → done
-- **Add team to project:** `/enopax/platform/access` → "Add Team" → pick team → role pre-filled from team default → confirm
-- **Share project cross-org:** `/enopax/platform/settings` → "Share with Organisation" → enter org slug → pick permission (VIEW/CONTRIBUTE/MANAGE) → done
-- **Accept shared project:** appears in collab org's "Shared with you" automatically (no invite flow in Phase 1.5)
+- **Create personal project:** `/{userSlug}` → "New Project" → name + visibility → done. No org, no teams.
+- **Create org project:** `/{orgSlug}` → "New Project" → same, but project lives in org context.
+- **Create team:** `/{orgSlug}/teams` → "New Team" → name + description + default role → done.
+- **Add team to project:** `/{orgSlug}/{project}/access` → "Add Team" → pick team → role pre-filled → confirm.
+- **Share project:** `/{slug}/{project}/settings` → "Share" → enter user slug or org slug → pick permission → done.
 
 ---
 
@@ -339,32 +375,33 @@ On a project's access page, surface **why** each user has access:
 
 ### Phase 1 — Teams + Visibility + Slugs (MVP)
 
-- Entities: `Team`, `TeamMember`, `ProjectAccess`
+- Entities: `Namespace`, `Team`, `TeamMember`, `ProjectAccess`
 - `slug` + `name` on User, Organisation, Project
-- Global slug uniqueness (shared namespace)
+- `Namespace` table for global slug uniqueness
+- `ownerType` + `ownerId` on Project (USER or ORGANISATION)
 - `visibility` on Organisation (PUBLIC/PRIVATE, default PUBLIC) and Project (PUBLIC/INTERNAL/PRIVATE)
-- `isPersonal` on Organisation + auto-create on user registration
 - Built-in project roles (VIEWER / DEVELOPER / DEPLOYER / ADMIN)
 - Team CRUD pages, project access page, derived member view
-- Permission resolution helper
-- Flat URL routing (`/{slug}/{project}`)
+- Permission resolution helper: `resolveProjectPermissions(userId, projectId)`
+- Flat URL routing (`/{slug}/{project}`) with namespace-based entity resolution
+- Personal projects for users (no org overhead)
 - Archive project (`status: ARCHIVED` — read-only, preserved)
 
-### Phase 1.5 — Cross-Org Sharing
+### Phase 1.5 — Cross-Entity Sharing
 
-- `ProjectShare` entity
-- Simple sharing: admin shares project with another org, picks permission level
-- Collab org sees shared projects in "Shared with you" section
-- No invite/accept flow — direct share (admin to admin)
-- Later: invite + accept UX, collab org assigns own teams
+- `ProjectShare` entity (sharedWithType: USER | ORGANISATION)
+- Simple sharing: host shares project, picks permission level (VIEW/CONTRIBUTE/MANAGE)
+- Recipient sees shared projects in "Shared with you" section
+- No invite/accept flow initially — direct share
+- Later: invite + accept UX
 
 ### Phase 2 — Custom Roles
 
 - `ProjectRoleDefinition` entity (org-scoped)
-- Role editor UI
+- Role editor UI at `/{orgSlug}/settings/roles`
 - Permission primitives formalised
 - Built-in roles become seeded, uneditable records
-- Transfer project ownership between orgs
+- Transfer project ownership between entities
 
 ### Phase 3 — Advanced Collaboration
 
@@ -380,12 +417,12 @@ On a project's access page, surface **why** each user has access:
 Prod data today: 1 org (Enopax), Felix (OWNER), Andi (MEMBER), 2 projects, no teams.
 
 **Phase 1 migration:**
-- Add `slug` field to existing User, Organisation, Project records (derive from current `name`, validate uniqueness)
-- Add `visibility` to Organisation (set PUBLIC) and Project (set PRIVATE)
-- Add `isPersonal: false` to existing Enopax org
-- Create personal orgs for Felix and Andi (`isPersonal: true`)
-- Create default "All Members" team for Enopax, add Felix + Andi, grant DEVELOPER on both existing projects
-- Tiered auto-admin means Felix (OWNER) keeps full access without additional records
+- Create `Namespace` table. Register existing org slug "Enopax" → ORGANISATION. Register user slugs for Felix and Andi → USER.
+- Add `slug` field to existing User, Organisation, Project records (derive from current `name`, validate uniqueness).
+- Add `ownerType: ORGANISATION` + `ownerId` to existing projects (they're all org-owned today).
+- Add `visibility` to Organisation (set PUBLIC) and Project (set PRIVATE).
+- Create default "All Members" team for Enopax, add Felix + Andi, grant DEVELOPER on both existing projects.
+- Tiered auto-admin means Felix (OWNER) keeps full access without additional records.
 
 **Phase 1.5 migration:** No migration — new entity, no existing data.
 
@@ -396,14 +433,15 @@ Prod data today: 1 org (Enopax), Felix (OWNER), Andi (MEMBER), 2 projects, no te
 - **Q1 — Team visibility:** Permission-based. OWNER/ADMIN/MANAGER see all teams. MEMBER sees only their own teams.
 - **Q2 — Empty teams:** Allowed as placeholders. No access granted.
 - **Q3 — Org member removal cascade:** Deletes all TeamMember rows → removes all project access. UI warns with list of affected teams/projects.
-- **Q4 — Audit log:** Log team CRUD, member add/remove, project access grant/change/revoke.
+- **Q4 — Audit log:** Log team CRUD, member add/remove, project access grant/change/revoke, project share grant/revoke.
 - **Q5 — Naming (OrganisationMember vs TeamMember):** Keep both. Industry convention.
 - **Q6 — Project "owner":** No separate concept. Org OWNER/ADMIN + ADMIN ProjectRole covers it.
+- **Q7 — User = Org?** No. Separate entities. Shared namespace but different concepts. Users own personal projects; Orgs own org projects with teams. No `isPersonal` hack. No settings confusion.
 
 ---
 
 ## 13. References
 
 - Research: access-control patterns across GitHub, GitLab, Notion, Linear, Figma, Jira, Azure DevOps, AWS IAM/Okta.
-- Felix's scope decisions: D1=A, D2=A, D3=C, D5=shared-namespace, D6=public-default, D7=cross-org-is-external.
+- Felix's scope decisions: D1=A, D2=A, D3=C, D5=shared-namespace, D6=public-default, D7=cross-entity-sharing, D8=user≠org.
 - Prior: Teams stub removal (PR #54), invitation flow (PRs #58, #59, #61).

--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -1,55 +1,132 @@
 # Access Control Design — Organisations, Teams, Projects, Roles
 
-**Date:** 2026-04-15
+**Date:** 2026-04-15 (updated 2026-04-16)
 **Status:** Draft, pending review
 **Author:** Felix Böhm
 
 ---
 
-## 1. Context
+## 1. Context & Vision
 
-### Current state (2026-04-15)
+### Current state
 
-- `Organisation` with `OrganisationMember` table. Fixed roles: `OWNER | ADMIN | MANAGER | MEMBER`.
-- `Project` belongs to a single `Organisation`. Projects have **no members of their own** — access is inherited wholesale from the parent org.
-- No `Team` entity. A legacy Teams stub from the upstream fork was removed in PR #54.
-- No custom roles. No direct project-level grants. No external users.
+- `Organisation` with `OrganisationMember`. Fixed roles: `OWNER | ADMIN | MANAGER | MEMBER`.
+- `Project` belongs to one `Organisation`. No project-level access control — inherited wholesale from org.
+- No Teams, no custom roles, no visibility controls, no cross-org sharing, no personal namespace.
+- Org and project names are URL slugs but have no separate display name.
 
 ### What we're designing
 
-A model where **Teams** are reusable groups of people defined at the Org level, assigned to Projects with per-project roles. Custom roles on Projects are possible. Cross-org collaboration is reserved as a future phase — MVP is single-org only.
+A professional access-control model inspired by GitHub's Organisations/Repos/Teams — adapted for an IaaS platform. Key principles:
+
+- **Teams** are the single mechanism for project access (no direct individual grants)
+- **Cross-org collaboration** replaces "external members" — every user IS an org (personal namespace), sharing a project with an external person = sharing with their org
+- **Slugs + display names** everywhere, shared global namespace
+- **Public/private visibility** on orgs and projects
+- **Custom project roles** in a later phase, built on a solid foundation
 
 ---
 
-## 2. Decisions
+## 2. Namespacing & Slugs
+
+### Slug + Display Name
+
+Every addressable entity has both:
+
+| Entity | Slug (URL-safe, unique) | Display Name (free text) |
+|---|---|---|
+| User | `felixboehm` | Felix Böhm |
+| Organisation | `enopax` | Enopax GmbH |
+| Project | `platform` (unique within parent) | Enopax Platform |
+
+**Slug rules:** lowercase alphanumeric + hyphens, 2-39 chars, no leading/trailing hyphens, no consecutive hyphens. Same rules as GitHub.
+
+### Shared global namespace
+
+User slugs and Org slugs share the same pool — like GitHub where `github.com/felixboehm` and `github.com/enopax` coexist.
+
+**URLs:**
+```
+enopax.com/enopax/platform        ← org project
+enopax.com/felixboehm/experiment  ← personal project
+enopax.com/enopax/members         ← org members page
+enopax.com/felixboehm/settings    ← personal settings (same as account)
+```
+
+**Reserved slugs:** `account`, `admin`, `signin`, `register`, `accept-invite`, `api`, `_next`, `assets`, `icons`, `settings`, `new`, `explore`
+
+**Uniqueness:** on user registration or org creation, check the global slug table. Conflict → "this name is taken."
+
+### Personal namespace = auto-org
+
+Every user gets a personal Organisation auto-created at registration:
+- `slug` = user's slug, `name` = user's display name
+- `isPersonal: true` flag — UI shows "My Projects" instead of org chrome
+- User is auto-OWNER, cannot leave or delete (tied to account lifecycle)
+- Same entity, same permissions, same Team/Project model — just a UI distinction
+
+This means: **there is no concept of "external user."** An external person is just another org (their personal namespace or their company org) that gets cross-org project access. One mechanism for everything.
+
+---
+
+## 3. Decisions
 
 | # | Question | Decision | Rationale |
 |---|---|---|---|
-| D1 | Team-only vs direct project members? | **Teams only** | Felix's preference: no micro-managing individual project grants. External contractors join a regular or purpose-built "External" team rather than getting ad-hoc direct grants. |
-| D2 | Scope of custom roles? | **Org-level, reused across projects** | Enforces consistency. Start with 3-5 built-in project roles; custom roles a Phase 2 feature when real demand surfaces. |
-| D3 | How do org-roles and project-team-roles combine? | **Tiered**: OWNER + ADMIN auto-admin on every project; MANAGER + MEMBER only via team assignment | Least privilege for regular members; a Trust Tier that can always rescue a project. Shown explicitly in the project member list ("Alice — Admin via Org OWNER role") so access is auditable, not hidden. |
-| D4 | External users and cross-org collaboration? | **Not in MVP.** Spec out as Phase 3. MVP is single-org with externals handled by joining a Team inside the host org. | Most mature platforms ship single-tenant first; cross-org is a large scope that deserves its own design pass. |
+| D1 | Team-only vs direct project members? | **Teams only** | No micro-managing. External access = cross-org sharing (see §6). |
+| D2 | Scope of custom roles? | **Org-level, reused across projects** | Start with built-in project roles; custom roles Phase 2. |
+| D3 | How do org-roles and project-team-roles combine? | **Tiered**: OWNER + ADMIN auto-admin on every project; MANAGER + MEMBER only via team | Least privilege + trust tier. Explicit in UI. |
+| D5 | Namespace model? | **Shared global namespace**, user = personal org | GitHub model. One URL space, one mechanism for personal + org projects. |
+| D6 | Default org visibility? | **Public** | Discoverable by default. Admins can switch to private. |
+| D7 | Cross-org = external members? | **Yes** | `felixboehm` user = `felixboehm` org. Sharing with a person = sharing with their org. No separate external-member concept. |
 
 ### OWNER vs ADMIN
 
-Standard distinction:
-- **OWNER**: ultimate authority. Can delete the org. Can transfer ownership. Can grant/revoke OWNER role. Can remove other ADMINs. 1-2 per org typically.
-- **ADMIN**: can manage members and teams, change settings, admin all projects — but cannot delete the org, cannot transfer ownership, cannot demote/remove other ADMINs or OWNERs. 5-20% of members.
+- **OWNER**: ultimate authority. Delete org. Transfer ownership. Grant/revoke OWNER. Remove ADMINs. 1-2 per org.
+- **ADMIN**: manage members, teams, settings, admin all projects. Cannot delete org, transfer ownership, or remove OWNERs.
 
-Both are auto-admin on all projects (D3 Tiered rule).
+Both are auto-admin on all projects (D3).
 
 ---
 
-## 3. Domain Model
+## 4. Visibility
+
+### Organisation visibility
+
+| Visibility | Behaviour |
+|---|---|
+| `PUBLIC` (default) | Visible in platform search. Profile page accessible. JoinRequest flow available. |
+| `PRIVATE` | Only members see it. Join only via invitation. Not in search results. |
+
+### Project visibility
+
+| Visibility | Behaviour |
+|---|---|
+| `PUBLIC` | Anyone (even unauthenticated) can see description + resource status. Write/deploy still requires team access. |
+| `INTERNAL` | All org members can view (regardless of team assignment). Write/deploy requires team access. |
+| `PRIVATE` | Only teams with ProjectAccess + tiered auto-admin (OWNER/ADMIN) can see it. Default for new projects. |
+
+**Org-level default:** setting on Organisation: `defaultProjectVisibility: PRIVATE | INTERNAL | PUBLIC`.
+
+---
+
+## 5. Domain Model
 
 ### Entities
 
 ```
 User
-  id, email, name, password, createdAt, ...
+  id, slug, name, email, password, createdAt, ...
+  — slug is globally unique (shared namespace with orgs)
 
 Organisation
-  id, name, ownerId, ...
+  id, slug, name, description
+  visibility: PUBLIC | PRIVATE
+  defaultProjectVisibility: PRIVATE | INTERNAL | PUBLIC
+  isPersonal: boolean  — true for auto-created personal namespaces
+  ownerId
+  createdAt, updatedAt
+  — slug is globally unique (shared namespace with users)
 
 OrganisationMember
   id, userId, organisationId
@@ -58,204 +135,275 @@ OrganisationMember
 
 Team
   id, organisationId, name, description
-  defaultProjectRole: ProjectRole (see §4)
+  defaultProjectRole: ProjectRole (see §7)
   createdAt, updatedAt
-  — Fully user-defined. No hardcoded purpose enum. Name and description
-    are free text (e.g. "Backend", "Ops", "Sprint 42 contractors", or
-    whatever makes sense for the org).
-  — defaultProjectRole captures the team's natural character (Backend →
-    DEVELOPER, Ops → DEPLOYER). Used as pre-fill when assigning the team
-    to a project — admin can override per project.
-  — On org creation, a default team "All Members" (defaultRole: DEVELOPER)
-    is seeded as a normal Team row — not a system-level special case.
-    Admins can rename, repurpose, or delete it like any other team.
+  — Fully user-defined. Name and description are free text.
+  — defaultProjectRole captures the team's character (Backend →
+    DEVELOPER, Ops → DEPLOYER). Pre-fills when assigning to a project;
+    admin can override per project.
+  — On org creation, a default team "All Members" (defaultRole:
+    DEVELOPER) is seeded as a normal Team row. Admins can rename,
+    repurpose, or delete it.
 
 TeamMember
   id, teamId, userId
   addedAt, addedBy
 
 Project
-  id, organisationId, name, ...  (unchanged)
+  id, organisationId, slug, name, description
+  visibility: PUBLIC | INTERNAL | PRIVATE
+  status, isActive, ...
+  — slug unique within parent org
 
 ProjectAccess
   id, projectId, teamId
-  role: ProjectRole (see §4)
+  role: ProjectRole (see §7)
   grantedAt, grantedBy
-  — role is always stored explicitly. When assigning a team to a project,
-    the UI pre-fills with team.defaultProjectRole but the admin can change
-    it. No "use default" indirection — the stored value IS the role.
+  — role stored explicitly. UI pre-fills from team.defaultProjectRole;
+    admin can change. No "use default" indirection.
+
+ProjectShare (Phase 1.5 — cross-org)
+  id, projectId
+  sharedWithOrgId
+  permission: VIEW | CONTRIBUTE | MANAGE
+  sharedBy, sharedAt
+  — Simple sharing: host org shares project with another org.
+  — Collab org sees it in a "Shared with you" section.
+  — Permission controls what the collab org's teams can do (see §6).
+  — No invite/accept flow initially — admin shares directly.
+    Later: invite + accept UX.
 
 (Phase 2)
 ProjectRoleDefinition
-  id, organisationId, name, description, permissions (bitmask or JSON)
-  isBuiltIn: boolean  — built-ins aren't user-editable
-  — In Phase 2, Team.defaultProjectRole and ProjectAccess.role become
-    references to ProjectRoleDefinition instead of a fixed enum.
-    Same architecture, just flexible values.
+  id, organisationId, name, description, permissions
+  isBuiltIn: boolean
+  — Team.defaultProjectRole and ProjectAccess.role become references
+    to this entity instead of a fixed enum.
 ```
 
 ### Relationships
 
-- `Organisation` 1..N `OrganisationMember` — standard membership
-- `Organisation` 1..N `Team` — teams live inside an org
-- `Team` 1..N `TeamMember` — users can be in multiple teams
-- `Organisation` 1..N `Project`
-- `Project` 1..N `ProjectAccess` — a project grants access to a team with a specific role
-- `Team` 1..N `ProjectAccess` — the same team can be attached to many projects, possibly with different roles per project
+```
+User ←slug→ global namespace ←slug→ Organisation
+Organisation 1..N OrganisationMember
+Organisation 1..N Team
+Team 1..N TeamMember (users)
+Organisation 1..N Project
+Project 1..N ProjectAccess (team + role)
+Project 0..N ProjectShare (cross-org, Phase 1.5)
+```
 
 ### Invariants
 
-- A user can be a `TeamMember` without being an `OrganisationMember` (reserved for Phase 3 — not enforced in MVP). In MVP, all team members are also org members.
-- A `Team` belongs to exactly one `Organisation`. Teams are not shared across orgs.
-- A `Project` can have zero or more `ProjectAccess` rows.
-- Removing a `Team` cascades to all its `ProjectAccess` rows.
-- Removing a `Project` cascades to all its `ProjectAccess` rows (not to teams).
+- User.slug and Organisation.slug share the same uniqueness constraint (global slug table).
+- A Team belongs to exactly one Organisation.
+- In MVP, all TeamMembers must also be OrganisationMembers of the same org.
+- Removing an OrganisationMember cascades: deletes all their TeamMember rows (and thus all project access). UI warns before confirming.
+- Removing a Team cascades to its ProjectAccess rows.
+- Removing a Project cascades to its ProjectAccess + ProjectShare rows.
+- Personal orgs (isPersonal: true) cannot be deleted independently — tied to user account lifecycle.
 
 ---
 
-## 4. Permission Model
+## 6. Cross-Org Collaboration (Phase 1.5)
+
+### Core insight
+
+**There are no "external members."** Every user has a personal org. Sharing a project with external person Felix = sharing with org `felixboehm`. Sharing with company Acme = sharing with org `acme`. Same mechanism.
+
+### How it works
+
+1. Host org admin shares Project X with Org B: creates a `ProjectShare` row.
+2. Org B sees Project X in their "Shared with you" section.
+3. `ProjectShare.permission` controls what Org B can do:
+
+| Permission | What collab org can do |
+|---|---|
+| `VIEW` | See project metadata + resource status. Read-only. |
+| `CONTRIBUTE` | VIEW + use/manage resources within the project. Cannot change project settings or team access. |
+| `MANAGE` | CONTRIBUTE + manage project settings and share with other orgs (but cannot delete project — only host org can). |
+
+4. **Host org has final say:** delete, rename, change billing, revoke shares.
+
+### What collab org CANNOT do (Phase 1.5)
+
+- Cannot assign their own teams to the shared project (that's Phase 2+)
+- Cannot change the share permission level (only host org admin can)
+- Cannot re-share with a third org (unless permission = MANAGE)
+
+### Later improvements
+
+- Invite + accept flow (instead of direct share)
+- Collab org assigns their own teams with per-project roles
+- Configurable fine-grained permissions per share
+
+---
+
+## 7. Permission Model
 
 ### Project Roles (built-in, Phase 1)
 
 | Role | Permissions |
 |---|---|
-| `VIEWER` | Read project metadata, view resources and their status. No writes. |
-| `DEVELOPER` | VIEWER + create/edit/delete resources within the project. Cannot change project settings or members. |
-| `DEPLOYER` | DEVELOPER + trigger deployments / provisioning actions. (Split from DEVELOPER because deploy is the most sensitive IaaS operation.) |
-| `ADMIN` | DEPLOYER + manage project settings and manage team access to the project (add/remove teams, change team roles). |
+| `VIEWER` | Read project metadata, view resources and their status. |
+| `DEVELOPER` | VIEWER + create/edit/delete resources. Cannot change project settings or access. |
+| `DEPLOYER` | DEVELOPER + trigger deployments/provisioning. Separated because deploy is the most sensitive IaaS action. |
+| `ADMIN` | DEPLOYER + manage project settings + manage team access (add/remove teams, change roles). |
 
-*Out of MVP, we may also want a `REVIEWER` role for approval flows — not needed yet.*
+### Permission resolution
 
-### Permission resolution (effective permissions)
+For user `U` on project `P`:
 
-For a user `U` asking "can I do action `A` on project `P`?":
+1. **Tiered auto-admin:** If `U` is OWNER or ADMIN in the parent org → ADMIN on `P`.
+2. **Team grants:** Collect every ProjectAccess where `P` = project and `U` ∈ team. Effective role = highest of all.
+3. **Cross-org share (Phase 1.5):** If `U` is a member of a collab org that has a ProjectShare on `P`, effective permission = the share's permission level (VIEW / CONTRIBUTE / MANAGE), mapped to the closest ProjectRole.
+4. **Visibility fallback:** If `P` is INTERNAL and `U` is an org member → implicit VIEWER. If `P` is PUBLIC → implicit VIEWER for everyone.
+5. **No grant:** `P` doesn't appear in `U`'s navigation.
 
-1. **Tiered auto-admin check:** If `U` has `OrganisationMember` role in the parent org equal to `OWNER` or `ADMIN` → `U` has `ADMIN` project permissions on `P`.
-2. **Team-based grants:** Otherwise, collect every `ProjectAccess` row where `P` is the project and `U` is a member of the referenced team. `U`'s effective project role is the **highest (most permissive)** of all those rows.
-3. **No grant found:** `U` has no access to `P`. The project doesn't appear in their navigation.
+**Rules:** Union-of-all-grants. No deny. No team nesting. Most permissive wins.
 
-**Rules:**
-- **Union-of-all-grants**. No deny rules (per research: deny-wins causes most "why can't I?" support tickets).
-- No team nesting. A team is a flat list of users.
-- Most permissive role wins when a user is in multiple teams with access to the same project.
+### Visibility in UI
 
-### Visibility rules
-
-- Org OWNER/ADMIN always see every project in the org (consequence of D3 tiered).
-- Org MANAGER/MEMBER only see projects where they have team-granted access.
-- On a project's member list, surface *why* each user has access:
-  - "Alice — Admin via Org OWNER role"
-  - "Bob — Developer via Team Frontend"
-  - "Charlie — Developer via Team Frontend · Deployer via Team Ops" (show highest + tooltip with all sources)
+On a project's access page, surface **why** each user has access:
+- "Alice — Admin via Org OWNER role"
+- "Bob — Developer via Team Backend"
+- "Charlie — Viewer via Org Acme (shared)"
 
 ---
 
-## 5. UX Implications
+## 8. GitHub Comparison
 
-### Org admin flows
+### What we adopt from GitHub
 
-- `/orga/{name}/teams` (new) — list teams, create team, view members
-- `/orga/{name}/teams/{teamName}` — manage team members, see projects this team has access to
-- `/orga/{name}/members` (exists) — unchanged at surface level; tiered auto-admin badge for OWNER/ADMIN
-- `/orga/{name}/settings/roles` (Phase 2) — manage custom project roles
+| GitHub concept | Enopax equivalent |
+|---|---|
+| User + personal repos | User + personal org (auto-created) |
+| Organisation | Organisation |
+| Repository | Project |
+| Team → repo permission | Team → ProjectAccess(role) |
+| Org Owner / Member | OWNER / ADMIN / MANAGER / MEMBER |
+| Public / private repos | Public / internal / private projects |
+| Public / hidden org membership | Public / private orgs |
+| Slug-based URLs | `enopax.com/{slug}/{project}` |
+| Slug + display name | Same — both everywhere |
+| Reserved paths | Same approach |
 
-### Project admin flows
+### Where we improve on GitHub
 
-- `/orga/{orgName}/{projectName}/access` (new) — list teams with access + their roles, add team, change role, remove team
-- `/orga/{orgName}/{projectName}/members` (new) — read-only derived view showing effective members (sourced from teams + tiered auto-admin), with the "why" column
+1. **One access path** — GitHub has Teams AND direct collaborators. Confusing. We have Teams only (D1).
+2. **Team character** — `defaultProjectRole` on Team. GitHub teams are generic.
+3. **Real cross-org** — GitHub can't share a repo between two orgs. Only fork (copy) or transfer (move). We support true shared projects.
+4. **Transparent access traces** — "Admin via Org OWNER" in the project member view. GitHub hides implicit permissions.
+5. **INTERNAL visibility** — all org members can read without explicit team assignment. GitHub Enterprise has this but it's buried.
 
-### Member discovery
+### What we consciously skip
 
-- An org MEMBER who gets added to a team with project access will see that project appear in their nav on next reload.
-- No "request to join project" in MVP — only admin/manager can grant team access.
+- **Nested teams** — GitHub supports parent/child teams. Adds complexity, rarely used. We keep teams flat.
+- **Template projects** — Not in scope. May revisit later.
+- **Forking** — Our cross-org model is sharing (same project), not copying. Forking may come later if use cases emerge.
 
 ---
 
-## 6. Phased Roadmap
+## 9. UX Implications
 
-### Phase 1 — Teams Infrastructure (MVP, this work)
+### URL structure (flat namespace)
 
-**Scope:**
-- New entities: `Team`, `TeamMember`, `ProjectAccess`
-- Built-in project roles (VIEWER / DEVELOPER / DEPLOYER / ADMIN) hard-coded
-- Team CRUD pages under `/orga/{name}/teams`
-- Project access page under `/orga/{orgName}/{projectName}/access`
-- Derived member view on project pages
-- Permission resolution on every server-side access check (new helper: `resolveProjectPermissions(userId, projectId) → ProjectRole | null`)
+```
+/{slug}                      → org or personal namespace overview
+/{slug}/{project}            → project overview
+/{slug}/members              → org member management
+/{slug}/teams                → team management
+/{slug}/teams/{teamSlug}     → team detail + members
+/{slug}/{project}/access     → project team access management
+/{slug}/{project}/members    → derived effective member view
+/{slug}/{project}/settings   → project settings
+/{slug}/settings             → org settings
+```
 
-**Out of scope for Phase 1:**
-- Custom roles
-- External / cross-org users
-- Permission UI beyond "what role does this team have on this project"
-- Migration of existing data — currently only one org with no teams; Phase 1 can land cleanly without migration
+### Navigation
 
-**Acceptance:**
-- An org OWNER can create a team, add members, attach to a project with a role.
-- A plain Org MEMBER assigned to a team sees only projects granted via that team.
-- An Org ADMIN sees all projects.
-- The "why this user has access" trace is visible on the project access page.
+- Left sidebar shows: personal namespace ("My Projects") + all orgs the user is a member of + "Shared with you" section (Phase 1.5)
+- Within an org: projects list filtered by team access (unless OWNER/ADMIN → see all)
+- Project detail: tabs for Overview, Resources, Access, Members, Settings
+
+### Key flows
+
+- **Create team:** `/enopax/teams` → "New Team" → name + description + default role → done
+- **Add team to project:** `/enopax/platform/access` → "Add Team" → pick team → role pre-filled from team default → confirm
+- **Share project cross-org:** `/enopax/platform/settings` → "Share with Organisation" → enter org slug → pick permission (VIEW/CONTRIBUTE/MANAGE) → done
+- **Accept shared project:** appears in collab org's "Shared with you" automatically (no invite flow in Phase 1.5)
+
+---
+
+## 10. Phased Roadmap
+
+### Phase 1 — Teams + Visibility + Slugs (MVP)
+
+- Entities: `Team`, `TeamMember`, `ProjectAccess`
+- `slug` + `name` on User, Organisation, Project
+- Global slug uniqueness (shared namespace)
+- `visibility` on Organisation (PUBLIC/PRIVATE, default PUBLIC) and Project (PUBLIC/INTERNAL/PRIVATE)
+- `isPersonal` on Organisation + auto-create on user registration
+- Built-in project roles (VIEWER / DEVELOPER / DEPLOYER / ADMIN)
+- Team CRUD pages, project access page, derived member view
+- Permission resolution helper
+- Flat URL routing (`/{slug}/{project}`)
+- Archive project (`status: ARCHIVED` — read-only, preserved)
+
+### Phase 1.5 — Cross-Org Sharing
+
+- `ProjectShare` entity
+- Simple sharing: admin shares project with another org, picks permission level
+- Collab org sees shared projects in "Shared with you" section
+- No invite/accept flow — direct share (admin to admin)
+- Later: invite + accept UX, collab org assigns own teams
 
 ### Phase 2 — Custom Roles
 
-**Scope:**
 - `ProjectRoleDefinition` entity (org-scoped)
-- Role editor UI at `/orga/{name}/settings/roles`
-- Permission primitives formalised (discrete actions: view, write-resource, deploy, manage-members, manage-settings, ...)
-- Built-in roles become seeded records in `ProjectRoleDefinition` with `isBuiltIn: true` (uneditable names, permissions editable only by forking into a new custom role)
+- Role editor UI
+- Permission primitives formalised
+- Built-in roles become seeded, uneditable records
+- Transfer project ownership between orgs
 
-**Trigger:** when ≥2 customers ask for a role the built-ins don't cover. Until then, don't build it.
+### Phase 3 — Advanced Collaboration
 
-### Phase 3 — Cross-Org Collaboration
-
-**Scope:** instead of external users joining a host org, Project X is jointly owned by Org A (host) and Org B (collaborator). Each org sees the project in their own org space; each assigns their own teams with their own project roles.
-
-**Entities likely added:**
-```
-ProjectCollaboration
-  id, projectId, collaboratingOrgId
-  status: INVITED | ACTIVE | REMOVED
-  invitedBy, acceptedBy, invitedAt, acceptedAt
-
-TeamProjectAccess (renamed from Phase 1's ProjectAccess)
-  id, projectId, teamId, teamOrgId  (team can now belong to host or collab org)
-  role: ProjectRole
-```
-
-**Host org has final say:** delete project, rename, change billing arrangement. Collab orgs can contribute via teams but can't transfer or delete.
-
-**Effective permissions:** same union-of-team-grants; collaboration doesn't change the resolution algorithm — just which teams can be attached.
-
-**Not MVP because:** significant scope (new invite flow for orgs, host-vs-collab permission asymmetry, shared billing unclear, auditability across orgs) and unclear demand. Revisit when first real multi-party project comes up.
+- Collab org assigns own teams to shared projects with per-project roles
+- Fine-grained permission configuration per share
+- Invite + accept flow for project sharing
+- Cross-org audit trail
 
 ---
 
-## 7. Migration from current state
+## 11. Migration
 
-Prod data today:
-- 1 active org (Enopax) with Felix (OWNER) and Andi (pending — will be MEMBER)
-- 2 projects (Resource-Tests, ResourceTest) — both inherit access via Felix's OWNER status
-- No teams, no custom roles
+Prod data today: 1 org (Enopax), Felix (OWNER), Andi (MEMBER), 2 projects, no teams.
 
-**Phase 1 go-live requires no data migration** for existing projects: the tiered auto-admin rule (D3) means Felix (OWNER) keeps full access without any new records; Andi needs to be added to a team to see projects (or just use the current fallback while we're single-user-org).
+**Phase 1 migration:**
+- Add `slug` field to existing User, Organisation, Project records (derive from current `name`, validate uniqueness)
+- Add `visibility` to Organisation (set PUBLIC) and Project (set PRIVATE)
+- Add `isPersonal: false` to existing Enopax org
+- Create personal orgs for Felix and Andi (`isPersonal: true`)
+- Create default "All Members" team for Enopax, add Felix + Andi, grant DEVELOPER on both existing projects
+- Tiered auto-admin means Felix (OWNER) keeps full access without additional records
 
-A one-time seed is advisable: the "All Members" default team (seeded on org creation as a normal team — see §3) should be created for the existing Enopax org, all current org members auto-added, and granted `DEVELOPER` on all existing projects. Keeps existing member behaviour the same until admins set up proper teams.
-
----
-
-## 8. Resolved Questions
-
-- **Q1 — Team visibility:** Depends on Org Role. Viewing the team list (names, descriptions) is a **permission** attached to Org Roles. OWNER/ADMIN/MANAGER see all teams. MEMBER sees only teams they belong to. This is enforced via the permission model, not a hardcoded rule — so custom org roles (if ever added) can grant or withhold team visibility.
-- **Q2 — Can a team have zero members?** Yes. Empty teams serve as templates or placeholders. They grant no access until members are added.
-- **Q3 — Can an Org MEMBER be removed while they're in teams?** Yes — removing the OrganisationMember cascades: all their TeamMember rows are deleted, which removes all their project access via those teams. The UI warns the admin before confirming, listing which teams and projects the user will lose access to.
-- **Q4 — Audit log:** Yes. For Phase 1, log: team created/updated/deleted, team member added/removed, project access granted/changed/revoked. Use the existing `audit-logs` table.
-- **Q5 — Naming collision (OrganisationMember vs TeamMember):** Keep both names. They match industry convention and are distinct concepts.
-- **Q6 — Project "owner":** No dedicated project-owner concept. Projects are administered by Org OWNER/ADMIN (tiered auto-admin, D3) and by teams with the `ADMIN` ProjectRole. The `ADMIN` ProjectRole gives a team project-level control (settings, team access management) without requiring Org-level admin privileges — so a project lead can manage their project without being an Org ADMIN.
+**Phase 1.5 migration:** No migration — new entity, no existing data.
 
 ---
 
-## 9. References
+## 12. Resolved Questions
 
-- Research brief: access-control patterns across GitHub, GitLab, Notion, Linear, Figma, Jira, Azure DevOps, AWS IAM/Okta — see conversation context.
-- Felix's scope decisions (conversation, 2026-04-15): D1=A (team-only), D2=A (org-level custom roles), D3=C (tiered), D4=not-in-MVP.
-- Prior removal of legacy Teams stub: PR #54.
-- Current invitation flow (Org-level membership): PRs #58, #59, #61.
+- **Q1 — Team visibility:** Permission-based. OWNER/ADMIN/MANAGER see all teams. MEMBER sees only their own teams.
+- **Q2 — Empty teams:** Allowed as placeholders. No access granted.
+- **Q3 — Org member removal cascade:** Deletes all TeamMember rows → removes all project access. UI warns with list of affected teams/projects.
+- **Q4 — Audit log:** Log team CRUD, member add/remove, project access grant/change/revoke.
+- **Q5 — Naming (OrganisationMember vs TeamMember):** Keep both. Industry convention.
+- **Q6 — Project "owner":** No separate concept. Org OWNER/ADMIN + ADMIN ProjectRole covers it.
+
+---
+
+## 13. References
+
+- Research: access-control patterns across GitHub, GitLab, Notion, Linear, Figma, Jira, Azure DevOps, AWS IAM/Okta.
+- Felix's scope decisions: D1=A, D2=A, D3=C, D5=shared-namespace, D6=public-default, D7=cross-org-is-external.
+- Prior: Teams stub removal (PR #54), invitation flow (PRs #58, #59, #61).

--- a/docs/specs/2026-04-15-access-control-design.md
+++ b/docs/specs/2026-04-15-access-control-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-15
 **Status:** Draft, pending review
-**Author:** Felix Böhm + collaboration with Claude
+**Author:** Felix Böhm
 
 ---
 


### PR DESCRIPTION
## Summary

Design spec for the future access-control model — Teams as reusable groups at org level, attached to Projects with per-project roles. Covers Felix's scope decisions and phases the work so we can ship MVP without committing to the whole vision day 1.

**Document:** \`docs/specs/2026-04-15-access-control-design.md\`

## Scope recap

- **D1 = A** — teams only (no direct project grants, externals join a team)
- **D2 = A** — custom roles org-scoped, Phase 2
- **D3 = C** — tiered (OWNER/ADMIN auto-admin every project; MANAGER/MEMBER only via team)
- **D4 = not in MVP** — cross-org collaboration = Phase 3

## Phases

1. Teams infrastructure + built-in project roles (MVP — next implementation cycle)
2. Custom role definitions per org
3. Cross-org collaboration (shared projects across orgs)

## What I need from you

Review the spec — especially the **Open Questions** (§8) and the migration plan (§7). Flag anything that doesn't feel right or that you'd scope differently.

Once approved, next step is \`superpowers:writing-plans\` to turn Phase 1 into an ordered implementation plan (entities first → pages → permission resolution → audit).