### PR TITLE
feat: Access Control Phase 1B — Team CRUD + Project Access UI

### DIFF
--- a/src/actions/team.ts
+++ b/src/actions/team.ts
@@ -1,0 +1,462 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import type { ProjectRole } from '@/lib/store';
+import { validateNameFormat } from '@/lib/name-validation';
+import { resolveProjectPermissions } from '@/lib/permissions';
+
+const VALID_PROJECT_ROLES: ProjectRole[] = ['VIEWER', 'DEVELOPER', 'DEPLOYER', 'ADMIN'];
+
+export interface CreateTeamState {
+  success?: boolean;
+  error?: string;
+  teamName?: string;
+  fieldErrors?: { name?: string; defaultProjectRole?: string };
+}
+
+export interface UpdateTeamState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { name?: string; defaultProjectRole?: string };
+}
+
+export interface AddTeamMemberState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { userId?: string };
+}
+
+export interface GrantAccessState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { teamId?: string; role?: string };
+}
+
+export interface UpdateProjectAccessRoleState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { role?: string };
+}
+
+export async function createTeam(
+  organisationId: string,
+  prevState: CreateTeamState,
+  formData: FormData
+): Promise<CreateTeamState> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { error: 'Authentication required' };
+    }
+
+    const name = formData.get('name') as string;
+    const description = formData.get('description') as string;
+    const defaultProjectRole = formData.get('defaultProjectRole') as string;
+
+    if (!name || name.trim().length < 2) {
+      return {
+        error: 'Name must be at least 2 characters',
+        fieldErrors: { name: 'Name must be at least 2 characters' },
+      };
+    }
+
+    const nameValidation = validateNameFormat(name.trim());
+    if (!nameValidation.isValid) {
+      return {
+        error: nameValidation.error || 'Invalid team name',
+        fieldErrors: { name: nameValidation.error || 'Invalid team name' },
+      };
+    }
+
+    if (!defaultProjectRole || !VALID_PROJECT_ROLES.includes(defaultProjectRole as ProjectRole)) {
+      return {
+        error: 'Default project role must be one of VIEWER, DEVELOPER, DEPLOYER, ADMIN',
+        fieldErrors: { defaultProjectRole: 'Must be VIEWER, DEVELOPER, DEPLOYER, or ADMIN' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+    if (!membership || !['OWNER', 'ADMIN', 'MANAGER'].includes(membership.role)) {
+      return { error: 'You do not have permission to create teams in this organisation' };
+    }
+
+    const existing = await store.teams.findByNameAndOrg(name.trim(), organisationId);
+    if (existing) {
+      return {
+        error: 'A team with this name already exists in the organisation',
+        fieldErrors: { name: 'A team with this name already exists' },
+      };
+    }
+
+    const team = await store.teams.create({
+      organisationId,
+      name: name.trim(),
+      description: description?.trim() || undefined,
+      defaultProjectRole: defaultProjectRole as ProjectRole,
+    });
+
+    revalidatePath(`/orga`);
+
+    return { success: true, teamName: team.name };
+  } catch (error) {
+    return { error: 'Failed to create team. Please try again.' };
+  }
+}
+
+export async function updateTeam(
+  teamId: string,
+  prevState: UpdateTeamState,
+  formData: FormData
+): Promise<UpdateTeamState> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { error: 'Authentication required' };
+    }
+
+    const name = formData.get('name') as string;
+    const description = formData.get('description') as string;
+    const defaultProjectRole = formData.get('defaultProjectRole') as string;
+
+    if (!name || name.trim().length < 2) {
+      return {
+        error: 'Name must be at least 2 characters',
+        fieldErrors: { name: 'Name must be at least 2 characters' },
+      };
+    }
+
+    const nameValidation = validateNameFormat(name.trim());
+    if (!nameValidation.isValid) {
+      return {
+        error: nameValidation.error || 'Invalid team name',
+        fieldErrors: { name: nameValidation.error || 'Invalid team name' },
+      };
+    }
+
+    if (!defaultProjectRole || !VALID_PROJECT_ROLES.includes(defaultProjectRole as ProjectRole)) {
+      return {
+        error: 'Default project role must be one of VIEWER, DEVELOPER, DEPLOYER, ADMIN',
+        fieldErrors: { defaultProjectRole: 'Must be VIEWER, DEVELOPER, DEPLOYER, or ADMIN' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const team = await store.teams.findById(teamId);
+    if (!team) {
+      return { error: 'Team not found' };
+    }
+
+    const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, team.organisationId);
+    if (!membership || !['OWNER', 'ADMIN', 'MANAGER'].includes(membership.role)) {
+      return { error: 'You do not have permission to update this team' };
+    }
+
+    const existing = await store.teams.findByNameAndOrg(name.trim(), team.organisationId);
+    if (existing && existing.id !== teamId) {
+      return {
+        error: 'A team with this name already exists in the organisation',
+        fieldErrors: { name: 'A team with this name already exists' },
+      };
+    }
+
+    await store.teams.update(teamId, {
+      name: name.trim(),
+      description: description?.trim() || undefined,
+      defaultProjectRole: defaultProjectRole as ProjectRole,
+    });
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { error: 'Failed to update team. Please try again.' };
+  }
+}
+
+export async function deleteTeam(
+  teamId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const store = await getStoreAsync();
+
+    const team = await store.teams.findById(teamId);
+    if (!team) {
+      return { success: false, error: 'Team not found' };
+    }
+
+    const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, team.organisationId);
+    if (!membership || !['OWNER', 'ADMIN', 'MANAGER'].includes(membership.role)) {
+      return { success: false, error: 'You do not have permission to delete this team' };
+    }
+
+    await store.teamMembers.removeAllForTeam(teamId);
+    await store.projectAccess.revokeAllForTeam(teamId);
+    await store.teams.delete(teamId);
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: 'Failed to delete team. Please try again.' };
+  }
+}
+
+export async function addTeamMember(
+  teamId: string,
+  prevState: AddTeamMemberState,
+  formData: FormData
+): Promise<AddTeamMemberState> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { error: 'Authentication required' };
+    }
+
+    const userId = formData.get('userId') as string;
+    if (!userId) {
+      return {
+        error: 'User is required',
+        fieldErrors: { userId: 'User is required' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const team = await store.teams.findById(teamId);
+    if (!team) {
+      return { error: 'Team not found' };
+    }
+
+    const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, team.organisationId);
+    if (!membership || !['OWNER', 'ADMIN', 'MANAGER'].includes(membership.role)) {
+      return { error: 'You do not have permission to manage team members' };
+    }
+
+    const userOrgMembership = await store.organisationMembers.findByUserAndOrg(userId, team.organisationId);
+    if (!userOrgMembership) {
+      return {
+        error: 'User is not a member of this organisation',
+        fieldErrors: { userId: 'User is not a member of this organisation' },
+      };
+    }
+
+    await store.teamMembers.add({
+      teamId,
+      userId,
+      addedBy: session.user.id,
+    });
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { error: 'Failed to add team member. Please try again.' };
+  }
+}
+
+export async function removeTeamMember(
+  teamId: string,
+  userId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const store = await getStoreAsync();
+
+    const team = await store.teams.findById(teamId);
+    if (!team) {
+      return { success: false, error: 'Team not found' };
+    }
+
+    const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, team.organisationId);
+    if (!membership || !['OWNER', 'ADMIN', 'MANAGER'].includes(membership.role)) {
+      return { success: false, error: 'You do not have permission to manage team members' };
+    }
+
+    await store.teamMembers.remove(teamId, userId);
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: 'Failed to remove team member. Please try again.' };
+  }
+}
+
+export async function grantProjectAccess(
+  projectId: string,
+  prevState: GrantAccessState,
+  formData: FormData
+): Promise<GrantAccessState> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { error: 'Authentication required' };
+    }
+
+    const teamId = formData.get('teamId') as string;
+    const role = formData.get('role') as string;
+
+    if (!teamId) {
+      return {
+        error: 'Team is required',
+        fieldErrors: { teamId: 'Team is required' },
+      };
+    }
+
+    if (!role || !VALID_PROJECT_ROLES.includes(role as ProjectRole)) {
+      return {
+        error: 'Role must be one of VIEWER, DEVELOPER, DEPLOYER, ADMIN',
+        fieldErrors: { role: 'Must be VIEWER, DEVELOPER, DEPLOYER, or ADMIN' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const project = await store.projects.findById(projectId);
+    if (!project) {
+      return { error: 'Project not found' };
+    }
+
+    const team = await store.teams.findById(teamId);
+    if (!team) {
+      return { error: 'Team not found', fieldErrors: { teamId: 'Team not found' } };
+    }
+
+    if (team.organisationId !== project.organisationId) {
+      return {
+        error: 'Team does not belong to the same organisation as the project',
+        fieldErrors: { teamId: 'Team must belong to the same organisation' },
+      };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(session.user.id, project.organisationId);
+    const isOrgAdmin = orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role);
+
+    if (!isOrgAdmin) {
+      const projectRole = await resolveProjectPermissions(session.user.id, projectId);
+      if (projectRole !== 'ADMIN') {
+        return { error: 'You do not have permission to grant access to this project' };
+      }
+    }
+
+    await store.projectAccess.grant({
+      projectId,
+      teamId,
+      role: role as ProjectRole,
+      grantedBy: session.user.id,
+    });
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { error: 'Failed to grant project access. Please try again.' };
+  }
+}
+
+export async function revokeProjectAccess(
+  accessId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const store = await getStoreAsync();
+
+    const access = await store.projectAccess.findById(accessId);
+    if (!access) {
+      return { success: false, error: 'Access record not found' };
+    }
+
+    const project = await store.projects.findById(access.projectId);
+    if (!project) {
+      return { success: false, error: 'Project not found' };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(session.user.id, project.organisationId);
+    const isOrgAdmin = orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role);
+
+    if (!isOrgAdmin) {
+      const projectRole = await resolveProjectPermissions(session.user.id, access.projectId);
+      if (projectRole !== 'ADMIN') {
+        return { success: false, error: 'You do not have permission to revoke access to this project' };
+      }
+    }
+
+    await store.projectAccess.revoke(accessId);
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: 'Failed to revoke project access. Please try again.' };
+  }
+}
+
+export async function updateProjectAccessRole(
+  accessId: string,
+  prevState: UpdateProjectAccessRoleState,
+  formData: FormData
+): Promise<UpdateProjectAccessRoleState> {
+  try {
+    const session = await auth();
+    if (!session) {
+      return { error: 'Authentication required' };
+    }
+
+    const role = formData.get('role') as string;
+
+    if (!role || !VALID_PROJECT_ROLES.includes(role as ProjectRole)) {
+      return {
+        error: 'Role must be one of VIEWER, DEVELOPER, DEPLOYER, ADMIN',
+        fieldErrors: { role: 'Must be VIEWER, DEVELOPER, DEPLOYER, or ADMIN' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const access = await store.projectAccess.findById(accessId);
+    if (!access) {
+      return { error: 'Access record not found' };
+    }
+
+    const project = await store.projects.findById(access.projectId);
+    if (!project) {
+      return { error: 'Project not found' };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(session.user.id, project.organisationId);
+    const isOrgAdmin = orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role);
+
+    if (!isOrgAdmin) {
+      const projectRole = await resolveProjectPermissions(session.user.id, access.projectId);
+      if (projectRole !== 'ADMIN') {
+        return { error: 'You do not have permission to update access roles for this project' };
+      }
+    }
+
+    await store.projectAccess.updateRole(accessId, role as ProjectRole);
+
+    revalidatePath(`/orga`);
+
+    return { success: true };
+  } catch (error) {
+    return { error: 'Failed to update project access role. Please try again.' };
+  }
+}

--- a/src/app/(main)/orga/[orgaName]/[projectName]/access/add/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/access/add/page.tsx
@@ -1,0 +1,69 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { resolveProjectPermissions } from '@/lib/permissions';
+import { RiArrowLeftLine } from '@remixicon/react';
+import GrantProjectAccessForm from '@/components/form/GrantProjectAccessForm';
+
+interface AddProjectAccessPageProps {
+  params: Promise<{ orgaName: string; projectName: string }>;
+}
+
+export default async function AddProjectAccessPage({ params }: AddProjectAccessPageProps) {
+  const { orgaName, projectName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const project = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  if (!project) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOrgAdmin =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  if (!isOrgAdmin) {
+    const projectRole = await resolveProjectPermissions(session.user.id, project.id);
+    if (projectRole !== 'ADMIN') {
+      notFound();
+    }
+  }
+
+  const accessRows = await store.projectAccess.findByProjectId(project.id);
+  const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
+  const allTeams = await store.teams.findByOrgId(organisation.id);
+  const availableTeams = allTeams
+    .filter((t) => !grantedTeamIds.has(t.id))
+    .map((t) => ({ id: t.id, name: t.name, defaultProjectRole: t.defaultProjectRole }));
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/orga/${orgaName}/${projectName}/access`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to project access
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Add Team Access</h1>
+      </div>
+
+      <GrantProjectAccessForm
+        projectId={project.id}
+        availableTeams={availableTeams}
+        organisationName={orgaName}
+        projectName={projectName}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/orga/[orgaName]/[projectName]/access/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/access/page.tsx
@@ -1,0 +1,135 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { resolveProjectPermissions } from '@/lib/permissions';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { Callout } from '@/components/common/Callout';
+import { RiAddLine, RiTeamLine, RiInformationLine } from '@remixicon/react';
+import RevokeAccessButton from '@/components/team/RevokeAccessButton';
+import ChangeAccessRoleForm from '@/components/team/ChangeAccessRoleForm';
+
+interface ProjectAccessPageProps {
+  params: Promise<{ orgaName: string; projectName: string }>;
+}
+
+export default async function ProjectAccessPage({ params }: ProjectAccessPageProps) {
+  const { orgaName, projectName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const project = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  if (!project) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOrgAdmin =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  if (!isOrgAdmin) {
+    const projectRole = await resolveProjectPermissions(session.user.id, project.id);
+    if (projectRole !== 'ADMIN') {
+      notFound();
+    }
+  }
+
+  const accessRows = await store.projectAccess.findByProjectId(project.id);
+
+  const accessWithTeams = await Promise.all(
+    accessRows.map(async (row) => {
+      const team = await store.teams.findById(row.teamId);
+      const members = team ? await store.teamMembers.findByTeamId(team.id) : [];
+      return {
+        ...row,
+        teamName: team?.name ?? 'Unknown team',
+        memberCount: members.length,
+      };
+    })
+  );
+
+  const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
+  const allTeams = await store.teams.findByOrgId(organisation.id);
+  const availableTeams = allTeams.filter((t) => !grantedTeamIds.has(t.id));
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Project Access</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Manage which teams can access {projectName}
+          </p>
+        </div>
+        {availableTeams.length > 0 && (
+          <Link href={`/orga/${orgaName}/${projectName}/access/add`}>
+            <Button>
+              <RiAddLine className="w-4 h-4 mr-1" />
+              Add Team
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <Callout variant="default" title="Inherited access" icon={RiInformationLine} className="mb-6">
+        Organisation OWNERs and ADMINs automatically have ADMIN access to all projects.
+      </Callout>
+
+      {accessWithTeams.length === 0 ? (
+        <Card className="p-12 text-center">
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <p className="text-gray-600 dark:text-gray-400 font-medium">No teams have been granted access yet</p>
+          {availableTeams.length > 0 && (
+            <div className="mt-4">
+              <Link href={`/orga/${orgaName}/${projectName}/access/add`}>
+                <Button variant="light">
+                  <RiAddLine className="w-4 h-4 mr-1" />
+                  Add first team
+                </Button>
+              </Link>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <Card>
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {accessWithTeams.map((row) => (
+              <li key={row.id} className="flex items-center justify-between px-6 py-4 flex-wrap gap-3">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                    <RiTeamLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                  </div>
+                  <div>
+                    <Link
+                      href={`/orga/${orgaName}/teams/${row.teamName}`}
+                      className="font-semibold text-gray-900 dark:text-white hover:underline"
+                    >
+                      {row.teamName}
+                    </Link>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {row.memberCount} {row.memberCount === 1 ? 'member' : 'members'}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge variant="default">{row.role}</Badge>
+                  <ChangeAccessRoleForm accessId={row.id} currentRole={row.role} />
+                  <RevokeAccessButton accessId={row.id} teamName={row.teamName} />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/orga/[orgaName]/teams/[teamName]/add-member/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/[teamName]/add-member/page.tsx
@@ -1,0 +1,79 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { RiArrowLeftLine } from '@remixicon/react';
+import AddTeamMemberForm from '@/components/form/AddTeamMemberForm';
+
+interface AddMemberPageProps {
+  params: Promise<{ orgaName: string; teamName: string }>;
+}
+
+export default async function AddMemberPage({ params }: AddMemberPageProps) {
+  const { orgaName, teamName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const team = await store.teams.findByNameAndOrg(teamName, organisation.id);
+  if (!team) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  if (!canManage) {
+    notFound();
+  }
+
+  const orgMembers = await store.organisationMembers.findByOrgId(organisation.id);
+  const currentTeamMembers = await store.teamMembers.findByTeamId(team.id);
+  const currentTeamMemberIds = new Set(currentTeamMembers.map((m) => m.userId));
+
+  const availableMembers = await Promise.all(
+    orgMembers
+      .filter((m) => !currentTeamMemberIds.has(m.userId))
+      .map(async (m) => {
+        const user = await store.users.findById(m.userId);
+        return {
+          id: m.userId,
+          name: user?.name ?? ([user?.firstname, user?.lastname].filter(Boolean).join(' ') || null),
+          email: user?.email ?? '',
+        };
+      })
+  );
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/orga/${orgaName}/teams/${teamName}`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to {teamName}
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Add member</h1>
+      </div>
+
+      <div className="max-w-xl">
+        <AddTeamMemberForm
+          teamId={team.id}
+          organisationName={orgaName}
+          teamName={teamName}
+          availableMembers={availableMembers}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/orga/[orgaName]/teams/[teamName]/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/[teamName]/page.tsx
@@ -1,0 +1,162 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { RiArrowLeftLine, RiAddLine, RiUserLine } from '@remixicon/react';
+import DeleteTeamButton from '@/components/team/DeleteTeamButton';
+import RemoveTeamMemberButton from '@/components/team/RemoveTeamMemberButton';
+
+interface TeamDetailPageProps {
+  params: Promise<{ orgaName: string; teamName: string }>;
+}
+
+export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
+  const { orgaName, teamName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const team = await store.teams.findByNameAndOrg(teamName, organisation.id);
+  if (!team) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  if (!membership && session.user.role !== 'ADMIN') {
+    notFound();
+  }
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  const canDelete =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  const rawMembers = await store.teamMembers.findByTeamId(team.id);
+  const members = await Promise.all(
+    rawMembers.map(async (m) => {
+      const user = await store.users.findById(m.userId);
+      return {
+        ...m,
+        user: {
+          id: m.userId,
+          name: user?.name ?? null,
+          firstname: user?.firstname ?? null,
+          lastname: user?.lastname ?? null,
+          email: user?.email ?? '',
+        },
+      };
+    })
+  );
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/orga/${orgaName}/teams`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to teams
+        </Link>
+
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{team.name}</h1>
+              <Badge variant="default">{team.defaultProjectRole}</Badge>
+            </div>
+            {team.description && (
+              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{team.description}</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Card>
+        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Members ({members.length})
+          </h2>
+          {canManage && (
+            <Link href={`/orga/${orgaName}/teams/${teamName}/add-member`}>
+              <Button variant="light">
+                <RiAddLine className="w-4 h-4 mr-1" />
+                Add member
+              </Button>
+            </Link>
+          )}
+        </div>
+
+        {members.length === 0 ? (
+          <div className="p-12 text-center">
+            <RiUserLine className="mx-auto w-8 h-8 text-gray-400 mb-3" />
+            <p className="text-gray-600 dark:text-gray-400">No members in this team yet.</p>
+            {canManage && (
+              <div className="mt-4">
+                <Link href={`/orga/${orgaName}/teams/${teamName}/add-member`}>
+                  <Button variant="light">
+                    <RiAddLine className="w-4 h-4 mr-1" />
+                    Add first member
+                  </Button>
+                </Link>
+              </div>
+            )}
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {members.map((m) => {
+              const displayName = m.user.name
+                ?? ([m.user.firstname, m.user.lastname].filter(Boolean).join(' ') || m.user.email);
+              return (
+                <li key={m.id} className="flex items-center justify-between px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-9 h-9 rounded-full bg-brand-100 dark:bg-brand-900/30 flex items-center justify-center">
+                      <span className="text-sm font-medium text-brand-700 dark:text-brand-300">
+                        {displayName.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-gray-900 dark:text-white">{displayName}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{m.user.email}</p>
+                    </div>
+                  </div>
+                  {canManage && (
+                    <RemoveTeamMemberButton
+                      teamId={team.id}
+                      userId={m.userId}
+                      displayName={displayName}
+                    />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Card>
+
+      {canDelete && (
+        <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Danger zone</h3>
+          <DeleteTeamButton
+            teamId={team.id}
+            teamName={team.name}
+            organisationName={orgaName}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/orga/[orgaName]/teams/new/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/new/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { RiArrowLeftLine } from '@remixicon/react';
+import CreateTeamForm from '@/components/form/CreateTeamForm';
+
+interface NewTeamPageProps {
+  params: Promise<{ orgaName: string }>;
+}
+
+export default async function NewTeamPage({ params }: NewTeamPageProps) {
+  const { orgaName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  if (!orgaName) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  if (!canManage) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/orga/${orgaName}/teams`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to teams
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">New Team</h1>
+      </div>
+
+      <div className="max-w-xl">
+        <CreateTeamForm organisationId={organisation.id} organisationName={orgaName} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/orga/[orgaName]/teams/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/page.tsx
@@ -1,0 +1,121 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { RiTeamLine, RiAddLine, RiArrowRightLine } from '@remixicon/react';
+
+interface TeamsPageProps {
+  params: Promise<{ orgaName: string }>;
+}
+
+export default async function TeamsPage({ params }: TeamsPageProps) {
+  const { orgaName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  if (!orgaName) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(orgaName);
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  if (!membership && session.user.role !== 'ADMIN') {
+    notFound();
+  }
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  const teams = await store.teams.findByOrgId(organisation.id);
+
+  const teamsWithCounts = await Promise.all(
+    teams.map(async (team) => {
+      const members = await store.teamMembers.findByTeamId(team.id);
+      return { ...team, memberCount: members.length };
+    })
+  );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Teams</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Manage teams and their project access within {orgaName}
+          </p>
+        </div>
+        {canManage && (
+          <Link href={`/orga/${orgaName}/teams/new`}>
+            <Button>
+              <RiAddLine className="w-4 h-4 mr-1" />
+              New Team
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {teamsWithCounts.length === 0 ? (
+        <Card className="p-12 text-center">
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <p className="text-gray-600 dark:text-gray-400 font-medium">No teams yet</p>
+          {canManage && (
+            <p className="text-sm text-gray-500 dark:text-gray-500 mt-1">
+              Create a team to group members and manage project access.
+            </p>
+          )}
+          {canManage && (
+            <div className="mt-4">
+              <Link href={`/orga/${orgaName}/teams/new`}>
+                <Button variant="light">
+                  <RiAddLine className="w-4 h-4 mr-1" />
+                  Create first team
+                </Button>
+              </Link>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {teamsWithCounts.map((team) => (
+            <Link key={team.id} href={`/orga/${orgaName}/teams/${team.name}`}>
+              <Card className="p-5 hover:border-brand-300 dark:hover:border-brand-700 transition-colors cursor-pointer">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                      <RiTeamLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                    </div>
+                    <div>
+                      <p className="font-semibold text-gray-900 dark:text-white">{team.name}</p>
+                      {team.description && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{team.description}</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge variant="default">{team.defaultProjectRole}</Badge>
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      {team.memberCount} {team.memberCount === 1 ? 'member' : 'members'}
+                    </span>
+                    <RiArrowRightLine className="w-4 h-4 text-gray-400" />
+                  </div>
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OrganisationOverviewClient.tsx
+++ b/src/components/OrganisationOverviewClient.tsx
@@ -55,6 +55,12 @@ export default function OrganisationOverviewClient({
                 Members
               </Button>
             </Link>
+            <Link href={`/orga/${organisation.name}/teams`}>
+              <Button variant="light" className="text-sm px-3 py-2">
+                <RiTeamLine className="mr-2 h-4 w-4" />
+                Teams
+              </Button>
+            </Link>
             {canManage && (
               <Link href={`/orga/${organisation.name}/settings`}>
                 <Button variant="light" className="text-sm px-3 py-2">

--- a/src/components/form/AddTeamMemberForm.tsx
+++ b/src/components/form/AddTeamMemberForm.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { addTeamMember, type AddTeamMemberState } from '@/actions/team';
+import { Button } from '@/components/common/Button';
+import { Label } from '@/components/common/Label';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+import { RiErrorWarningFill, RiCheckboxCircleFill } from '@remixicon/react';
+
+const initialState: AddTeamMemberState = {};
+
+interface AvailableMember {
+  id: string;
+  name: string | null;
+  email: string;
+}
+
+interface AddTeamMemberFormProps {
+  teamId: string;
+  organisationName: string;
+  teamName: string;
+  availableMembers: AvailableMember[];
+}
+
+export default function AddTeamMemberForm({
+  teamId,
+  organisationName,
+  teamName,
+  availableMembers,
+}: AddTeamMemberFormProps) {
+  const boundAction = addTeamMember.bind(null, teamId);
+  const [state, formAction, pending] = useActionState(boundAction, initialState);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state?.success) {
+      const timer = setTimeout(() => {
+        router.push(`/orga/${organisationName}/teams/${teamName}`);
+      }, 800);
+      return () => clearTimeout(timer);
+    }
+  }, [state?.success, organisationName, teamName, router]);
+
+  return (
+    <Card className="p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+        Add a member to {teamName}
+      </h2>
+
+      {state?.error && !state?.fieldErrors && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningFill} className="mb-4">
+          {state.error}
+        </Callout>
+      )}
+
+      {state?.success && (
+        <Callout variant="success" title="Member added" icon={RiCheckboxCircleFill} className="mb-4">
+          Redirecting back to the team page…
+        </Callout>
+      )}
+
+      {availableMembers.length === 0 ? (
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          All organisation members are already in this team.
+        </p>
+      ) : (
+        <form action={formAction} className="space-y-5">
+          <div>
+            <Label htmlFor="userId">Member</Label>
+            <Select name="userId" disabled={pending || !!state?.success}>
+              <SelectTrigger id="userId" className={state?.fieldErrors?.userId ? 'border-red-500' : ''}>
+                <SelectValue placeholder="Select a member" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableMembers.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.name ? `${m.name} (${m.email})` : m.email}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {state?.fieldErrors?.userId && (
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.userId}</p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <Button
+              type="button"
+              variant="light"
+              onClick={() => router.push(`/orga/${organisationName}/teams/${teamName}`)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending || !!state?.success}>
+              {pending ? 'Adding…' : 'Add member'}
+            </Button>
+          </div>
+        </form>
+      )}
+    </Card>
+  );
+}

--- a/src/components/form/CreateTeamForm.tsx
+++ b/src/components/form/CreateTeamForm.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { createTeam, type CreateTeamState } from '@/actions/team';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+import { RiErrorWarningFill, RiCheckboxCircleFill } from '@remixicon/react';
+
+const initialState: CreateTeamState = {};
+
+const PROJECT_ROLES = [
+  { value: 'VIEWER', label: 'Viewer — read-only access' },
+  { value: 'DEVELOPER', label: 'Developer — develop and deploy' },
+  { value: 'DEPLOYER', label: 'Deployer — deploy only' },
+  { value: 'ADMIN', label: 'Admin — full project control' },
+];
+
+interface CreateTeamFormProps {
+  organisationId: string;
+  organisationName: string;
+}
+
+export default function CreateTeamForm({ organisationId, organisationName }: CreateTeamFormProps) {
+  const boundAction = createTeam.bind(null, organisationId);
+  const [state, formAction, pending] = useActionState(boundAction, initialState);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state?.success && state?.teamName) {
+      const timer = setTimeout(() => {
+        router.push(`/orga/${organisationName}/teams/${state.teamName}`);
+      }, 800);
+      return () => clearTimeout(timer);
+    }
+  }, [state?.success, state?.teamName, organisationName, router]);
+
+  return (
+    <Card className="p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+        Create a new team
+      </h2>
+
+      {state?.error && !state?.fieldErrors && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningFill} className="mb-4">
+          {state.error}
+        </Callout>
+      )}
+
+      {state?.success && (
+        <Callout variant="success" title="Team created" icon={RiCheckboxCircleFill} className="mb-4">
+          Redirecting to team page…
+        </Callout>
+      )}
+
+      <form action={formAction} className="space-y-5">
+        <div>
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            name="name"
+            type="text"
+            required
+            placeholder="e.g. frontend-engineers"
+            hasError={!!state?.fieldErrors?.name}
+            disabled={pending || !!state?.success}
+          />
+          {state?.fieldErrors?.name && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.name}</p>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="description">Description</Label>
+          <Input
+            id="description"
+            name="description"
+            type="text"
+            placeholder="Optional description"
+            disabled={pending || !!state?.success}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="defaultProjectRole">Default project role</Label>
+          <Select name="defaultProjectRole" defaultValue="DEVELOPER" disabled={pending || !!state?.success}>
+            <SelectTrigger id="defaultProjectRole" className={state?.fieldErrors?.defaultProjectRole ? 'border-red-500' : ''}>
+              <SelectValue placeholder="Choose a role" />
+            </SelectTrigger>
+            <SelectContent>
+              {PROJECT_ROLES.map((r) => (
+                <SelectItem key={r.value} value={r.value}>
+                  {r.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {state?.fieldErrors?.defaultProjectRole && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.defaultProjectRole}</p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="light"
+            onClick={() => router.push(`/orga/${organisationName}/teams`)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={pending || !!state?.success}>
+            {pending ? 'Creating…' : 'Create team'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/form/GrantProjectAccessForm.tsx
+++ b/src/components/form/GrantProjectAccessForm.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { grantProjectAccess, type GrantAccessState } from '@/actions/team';
+import { Button } from '@/components/common/Button';
+import { Label } from '@/components/common/Label';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+import { RiErrorWarningFill, RiCheckboxCircleFill } from '@remixicon/react';
+
+const initialState: GrantAccessState = {};
+
+interface AvailableTeam {
+  id: string;
+  name: string;
+  defaultProjectRole: string;
+}
+
+interface GrantProjectAccessFormProps {
+  projectId: string;
+  availableTeams: AvailableTeam[];
+  organisationName: string;
+  projectName: string;
+}
+
+export default function GrantProjectAccessForm({
+  projectId,
+  availableTeams,
+  organisationName,
+  projectName,
+}: GrantProjectAccessFormProps) {
+  const boundAction = grantProjectAccess.bind(null, projectId);
+  const [state, formAction, pending] = useActionState(boundAction, initialState);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state?.success) {
+      const timer = setTimeout(() => {
+        router.push(`/orga/${organisationName}/${projectName}/access`);
+      }, 800);
+      return () => clearTimeout(timer);
+    }
+  }, [state?.success, organisationName, projectName, router]);
+
+  return (
+    <Card className="p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+        Grant team access to {projectName}
+      </h2>
+
+      {state?.error && !state?.fieldErrors && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningFill} className="mb-4">
+          {state.error}
+        </Callout>
+      )}
+
+      {state?.success && (
+        <Callout variant="success" title="Access granted" icon={RiCheckboxCircleFill} className="mb-4">
+          Redirecting back to the access page…
+        </Callout>
+      )}
+
+      {availableTeams.length === 0 ? (
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          All organisation teams already have access to this project.
+        </p>
+      ) : (
+        <form action={formAction} className="space-y-5">
+          <div>
+            <Label htmlFor="teamId">Team</Label>
+            <Select name="teamId" disabled={pending || !!state?.success}>
+              <SelectTrigger id="teamId" className={state?.fieldErrors?.teamId ? 'border-red-500' : ''}>
+                <SelectValue placeholder="Select a team" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableTeams.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name} (default: {t.defaultProjectRole})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {state?.fieldErrors?.teamId && (
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.teamId}</p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="role">Role</Label>
+            <Select name="role" defaultValue="DEVELOPER" disabled={pending || !!state?.success}>
+              <SelectTrigger id="role" className={state?.fieldErrors?.role ? 'border-red-500' : ''}>
+                <SelectValue placeholder="Select a role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="VIEWER">VIEWER</SelectItem>
+                <SelectItem value="DEVELOPER">DEVELOPER</SelectItem>
+                <SelectItem value="DEPLOYER">DEPLOYER</SelectItem>
+                <SelectItem value="ADMIN">ADMIN</SelectItem>
+              </SelectContent>
+            </Select>
+            {state?.fieldErrors?.role && (
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.role}</p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <Button
+              type="button"
+              variant="light"
+              onClick={() => router.push(`/orga/${organisationName}/${projectName}/access`)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending || !!state?.success}>
+              {pending ? 'Granting…' : 'Grant access'}
+            </Button>
+          </div>
+        </form>
+      )}
+    </Card>
+  );
+}

--- a/src/components/team/ChangeAccessRoleForm.tsx
+++ b/src/components/team/ChangeAccessRoleForm.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useActionState } from 'react';
+import { updateProjectAccessRole, type UpdateProjectAccessRoleState } from '@/actions/team';
+import { Button } from '@/components/common/Button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+
+const initialState: UpdateProjectAccessRoleState = {};
+
+interface ChangeAccessRoleFormProps {
+  accessId: string;
+  currentRole: string;
+}
+
+export default function ChangeAccessRoleForm({ accessId, currentRole }: ChangeAccessRoleFormProps) {
+  const boundAction = updateProjectAccessRole.bind(null, accessId);
+  const [state, formAction, pending] = useActionState(boundAction, initialState);
+
+  return (
+    <form action={formAction} className="flex items-center gap-2">
+      <Select name="role" defaultValue={currentRole} disabled={pending}>
+        <SelectTrigger className="w-36 h-8 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="VIEWER">VIEWER</SelectItem>
+          <SelectItem value="DEVELOPER">DEVELOPER</SelectItem>
+          <SelectItem value="DEPLOYER">DEPLOYER</SelectItem>
+          <SelectItem value="ADMIN">ADMIN</SelectItem>
+        </SelectContent>
+      </Select>
+      <Button type="submit" variant="light" className="h-8 text-sm px-3" disabled={pending}>
+        {pending ? 'Saving…' : 'Save'}
+      </Button>
+      {state?.error && (
+        <span className="text-xs text-red-600 dark:text-red-400">{state.error}</span>
+      )}
+      {state?.success && (
+        <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
+      )}
+    </form>
+  );
+}

--- a/src/components/team/DeleteTeamButton.tsx
+++ b/src/components/team/DeleteTeamButton.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Button } from '@/components/common/Button';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+import { Callout } from '@/components/common/Callout';
+import { deleteTeam } from '@/actions/team';
+import { useConfirmAction } from '@/hooks/useConfirmAction';
+import { RiDeleteBin7Line, RiErrorWarningLine } from '@remixicon/react';
+
+interface DeleteTeamButtonProps {
+  teamId: string;
+  teamName: string;
+  organisationName: string;
+}
+
+export default function DeleteTeamButton({ teamId, teamName, organisationName }: DeleteTeamButtonProps) {
+  const { isLoading, error, executeAction } = useConfirmAction({
+    redirectTo: `/orga/${organisationName}/teams`,
+  });
+
+  const handleDelete = async () => {
+    return executeAction(async () => {
+      const result = await deleteTeam(teamId);
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      return result;
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningLine}>
+          {error}
+        </Callout>
+      )}
+      <ConfirmDialog
+        trigger={
+          <Button
+            variant="secondary"
+            className="text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 border-red-300 dark:border-red-700"
+          >
+            <RiDeleteBin7Line className="w-4 h-4 mr-1" />
+            Delete team
+          </Button>
+        }
+        title="Delete team"
+        description={`Are you sure you want to delete "${teamName}"?\n\nThis will permanently remove the team and all its member associations.\n\nThis action cannot be undone.`}
+        confirmText="Delete team"
+        requiredInput="DELETE"
+        onConfirm={handleDelete}
+        isLoading={isLoading}
+        variant="danger"
+      />
+    </div>
+  );
+}

--- a/src/components/team/RemoveTeamMemberButton.tsx
+++ b/src/components/team/RemoveTeamMemberButton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Button } from '@/components/common/Button';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+import { Callout } from '@/components/common/Callout';
+import { removeTeamMember } from '@/actions/team';
+import { useConfirmAction } from '@/hooks/useConfirmAction';
+import { RiUserUnfollowLine, RiErrorWarningLine } from '@remixicon/react';
+
+interface RemoveTeamMemberButtonProps {
+  teamId: string;
+  userId: string;
+  displayName: string;
+}
+
+export default function RemoveTeamMemberButton({ teamId, userId, displayName }: RemoveTeamMemberButtonProps) {
+  const { isLoading, error, executeAction } = useConfirmAction({
+    refreshOnSuccess: true,
+  });
+
+  const handleRemove = async () => {
+    return executeAction(async () => {
+      const result = await removeTeamMember(teamId, userId);
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      return result;
+    });
+  };
+
+  return (
+    <div>
+      {error && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningLine} className="mb-2">
+          {error}
+        </Callout>
+      )}
+      <ConfirmDialog
+        trigger={
+          <Button variant="light">
+            <RiUserUnfollowLine className="w-4 h-4 mr-1" />
+            Remove
+          </Button>
+        }
+        title="Remove member"
+        description={`Remove ${displayName} from this team? They will lose access to projects granted through this team.`}
+        confirmText="Remove"
+        onConfirm={handleRemove}
+        isLoading={isLoading}
+        variant="warning"
+      />
+    </div>
+  );
+}

--- a/src/components/team/RevokeAccessButton.tsx
+++ b/src/components/team/RevokeAccessButton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { revokeProjectAccess } from '@/actions/team';
+import { Button } from '@/components/common/Button';
+import { RiDeleteBin7Line } from '@remixicon/react';
+
+interface RevokeAccessButtonProps {
+  accessId: string;
+  teamName: string;
+}
+
+export default function RevokeAccessButton({ accessId, teamName }: RevokeAccessButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleRevoke = async () => {
+    if (!confirm(`Remove access for team "${teamName}"? This cannot be undone.`)) return;
+    setLoading(true);
+    const result = await revokeProjectAccess(accessId);
+    setLoading(false);
+    if (result.success) {
+      router.refresh();
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      className="text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 border-red-300 dark:border-red-700"
+      onClick={handleRevoke}
+      disabled={loading}
+    >
+      <RiDeleteBin7Line className="w-4 h-4 mr-1" />
+      {loading ? 'Removing…' : 'Remove'}
+    </Button>
+  );
+}

--- a/src/lib/services/organisation.ts
+++ b/src/lib/services/organisation.ts
@@ -18,6 +18,13 @@ export class OrganisationService {
         role: 'OWNER',
       });
 
+      await store.teams.create({
+        organisationId: organisation.id,
+        name: 'All Members',
+        description: 'Default team — all organisation members',
+        defaultProjectRole: 'DEVELOPER',
+      });
+
       return { ...organisation, memberCount: 1 };
     } catch (error) {
       console.error('Failed to create organisation:', error);


### PR DESCRIPTION
## Summary

UI layer for the access control system. Builds on Phase 1A data foundation (#65).

### Server actions (8)
\`src/actions/team.ts\`: createTeam, updateTeam, deleteTeam, addTeamMember, removeTeamMember, grantProjectAccess, revokeProjectAccess, updateProjectAccessRole

### Pages (6 new)
- \`/orga/{name}/teams\` — team list with member counts + role badges
- \`/orga/{name}/teams/new\` — create team form (name + description + default role)
- \`/orga/{name}/teams/{teamName}\` — team detail + member management + delete
- \`/orga/{name}/teams/{teamName}/add-member\` — add org member to team
- \`/orga/{name}/{project}/access\` — project access: teams with roles, change/revoke inline
- \`/orga/{name}/{project}/access/add\` — grant team access with role selection

### Components (6 new)
- CreateTeamForm, AddTeamMemberForm, GrantProjectAccessForm
- DeleteTeamButton, RemoveTeamMemberButton, RevokeAccessButton, ChangeAccessRoleForm

### Other
- "All Members" team auto-seeded on org creation (\`organisation.ts\` service)
- Teams link added to org overview

### Stats
- 6 commits, 16 files, ~1650 lines
- 261 existing tests still green (no UI tests in this PR — UI testing deferred)
- All pages follow CLAUDE.md rules: dedicated pages not modals, useActionState, British English

## Test plan
- [ ] Create org → "All Members" team auto-created
- [ ] /teams shows team list with counts
- [ ] Create team → appears in list
- [ ] Team detail → add/remove members
- [ ] /access → list teams with roles, add team, change role, revoke
- [ ] Permission checks: only OWNER/ADMIN/MANAGER can manage teams