### PR TITLE
feat: Access Control Phase 1C — flat /{slug}/ routing + namespace seeding

### DIFF
--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -62,6 +62,11 @@ export async function register(
       });
     }
 
+    try {
+      const userSlug = user.slug || email.split('@')[0].toLowerCase().replace(/[^a-z0-9-]/g, '-');
+      await store.namespaces.register({ slug: userSlug, entityType: 'USER', entityId: user.id });
+    } catch {}
+
     // Send verification email
     const token = await createVerificationToken(user.id, email);
     await sendVerificationEmail(email, token);

--- a/src/app/(main)/[slug]/(project)/new/page.tsx
+++ b/src/app/(main)/[slug]/(project)/new/page.tsx
@@ -1,0 +1,94 @@
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import Breadcrumbs from '@/components/common/Breadcrumbs';
+import { RiProjectorLine } from '@remixicon/react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import ProjectForm from '@/components/form/ProjectForm';
+
+interface CreateProjectPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function CreateProjectPage({ params }: CreateProjectPageProps) {
+  const { slug } = await params;
+
+  if (!slug) {
+    notFound();
+  }
+
+  const session = await auth();
+  const store = await getStoreAsync();
+
+  const orgLookup = await store.organisations.findByName(slug);
+  if (!orgLookup) {
+    return (
+      <div className="max-w-2xl mx-auto text-center py-12">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+          Organisation Not Found
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mb-6">
+          The organisation you're looking for doesn't exist.
+        </p>
+        <Link href="/orga/organisations">
+          <Button>View Organisations</Button>
+        </Link>
+      </div>
+    );
+  }
+  const organisationId = orgLookup.id;
+
+  const isAdmin = session.user.role === 'ADMIN';
+  const membership = isAdmin ? true : await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+
+  if (!membership) {
+    return (
+      <div className="max-w-2xl mx-auto text-center py-12">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+          Access Denied
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mb-6">
+          You don't have access to this organisation.
+        </p>
+        <Link href="/main/select-organisation">
+          <Button>Select Organisation</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const organisation = orgLookup;
+
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Breadcrumbs */}
+      <div className="mb-6">
+        <Breadcrumbs />
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          Create New Project
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mt-2">
+          Create a project in {organisation?.name}. You can assign teams and resources later.
+        </p>
+      </div>
+
+      {/* Form */}
+      <div className="max-w-4xl">
+        <Card>
+          <ProjectForm
+            redirectUrl={`/${slug}`}
+            currentUserId={session.user.id}
+            organisationId={organisationId}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/(resource)/new/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/(resource)/new/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card } from '@/components/common/Card';
+import Breadcrumbs from '@/components/common/Breadcrumbs';
+import {
+  RiAddLine,
+  RiServerLine,
+  RiProjectorLine
+} from '@remixicon/react';
+import { useRouter } from 'next/navigation';
+import CreateResourceForm from '@/components/form/CreateResourceForm';
+import { useOrganisation } from '@/contexts/OrganisationContext';
+import { useProject } from '@/contexts/ProjectContext';
+
+export default function AddResourcePage() {
+  const router = useRouter();
+  const organisation = useOrganisation();
+  const project = useProject();
+  const [session, setSession] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        // Fetch session data
+        const sessionResponse = await fetch('/api/auth/session');
+        if (sessionResponse.ok) {
+          const sessionData = await sessionResponse.json();
+          setSession(sessionData);
+        }
+      } catch (error) {
+        console.error('Failed to load session:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-6">
+          <div className="h-6 w-64 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+        <div className="mb-8">
+          <div className="h-8 w-96 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-2" />
+          <div className="h-4 w-full max-w-md bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+        <Card className="p-8">
+          <div className="space-y-4">
+            <div className="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+            <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+            <div className="h-4 w-1/2 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!session || !session.user?.id) {
+    return (
+      <div className="max-w-7xl mx-auto">
+        <Card className="p-8 text-center">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            Authentication Required
+          </h2>
+          <p className="text-gray-600 dark:text-gray-300">
+            Please sign in to continue.
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Breadcrumbs */}
+      <div className="mb-6">
+        <Breadcrumbs
+          items={[
+            { label: organisation.name, href: `/${organisation.name}` },
+            { label: project.name, href: `/${organisation.name}/${project.name}` },
+            { label: 'Add Resource' }
+          ]}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center">
+          <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg mr-3">
+            <RiServerLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              Add Resource to {project.name}
+            </h1>
+            <p className="text-gray-600 dark:text-gray-300 mt-2">
+              Create a new resource that will be assigned to this project
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-6">
+        {/* Main Content - Resource Creation Form */}
+        <div className="xl:col-span-3">
+          <Card>
+            <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+              <div className="flex items-center">
+                <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg mr-3">
+                  <RiAddLine className="w-5 h-5 text-green-600 dark:text-green-400" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    Create New Resource
+                  </h2>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    Configure your new resource
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="p-6">
+              <CreateResourceForm
+                currentUserId={session.user.id}
+                projectId={project.id}
+                projectName={project.name}
+                organisationName={organisation.name}
+              />
+            </div>
+          </Card>
+        </div>
+
+        {/* Sidebar - Project Overview */}
+        <div className="xl:col-span-1 space-y-6">
+          <Card className="p-6">
+            <div className="flex items-center mb-4">
+              <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg mr-3">
+                <RiProjectorLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+              </div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Project Details
+              </h2>
+            </div>
+
+            <div className="space-y-3 text-sm">
+              <div>
+                <span className="text-gray-500">Project Name:</span>
+                <span className="ml-2 font-medium text-gray-900 dark:text-white">
+                  {project.name}
+                </span>
+              </div>
+
+              <div>
+                <span className="text-gray-500">Organisation:</span>
+                <span className="ml-2 font-medium text-gray-900 dark:text-white">
+                  {organisation.name}
+                </span>
+              </div>
+
+              {project.description && (
+                <div>
+                  <span className="text-gray-500">Description:</span>
+                  <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm">
+                    {project.description}
+                  </p>
+                </div>
+              )}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/[resourceName]/layout.tsx
+++ b/src/app/(main)/[slug]/[projectName]/[resourceName]/layout.tsx
@@ -1,0 +1,54 @@
+import { notFound } from 'next/navigation';
+import { getStoreAsync } from '@/lib/store';
+import { ResourceProvider } from '@/contexts/ResourceContext';
+
+export default async function ResourceLayout({
+  children,
+  params,
+}: Readonly<{
+  children: React.ReactNode;
+  params: Promise<{ slug: string; projectName: string; resourceName: string }>;
+}>) {
+  const { slug, projectName, resourceName } = await params;
+
+  if (!slug || !projectName || !resourceName) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+
+  if (!organisation) {
+    notFound();
+  }
+
+  const projectFound = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  const project = projectFound?.isActive ? projectFound : null;
+
+  if (!project) {
+    notFound();
+  }
+
+  // Fetch the resource by name and organisation
+  const foundResource = await store.resources.findByNameAndOrg(resourceName, organisation.id);
+  const resource = foundResource?.isActive ? {
+    id: foundResource.id,
+    name: foundResource.name,
+    description: foundResource.description,
+    type: foundResource.type,
+    status: foundResource.status,
+    endpoint: foundResource.endpoint,
+    organisationId: foundResource.organisationId,
+    ownerId: foundResource.ownerId,
+  } : null;
+
+  if (!resource) {
+    notFound();
+  }
+
+  return (
+    <ResourceProvider resource={resource}>
+      {children}
+    </ResourceProvider>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/[resourceName]/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/[resourceName]/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useOrganisation } from '@/contexts/OrganisationContext';
+import { useProject } from '@/contexts/ProjectContext';
+import { useResource } from '@/contexts/ResourceContext';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import Breadcrumbs from '@/components/common/Breadcrumbs';
+import DeploymentStatus from '@/components/resource/DeploymentStatus';
+import ResourceApiTestPanel from '@/components/resource-api/ResourceApiTestPanel';
+import ResourcesHealthDashboard from '@/components/dashboard/ResourcesHealthDashboard';
+import {
+  RiServerLine,
+  RiDatabaseLine,
+  RiHardDriveLine,
+  RiGlobalLine,
+  RiCodeLine,
+  RiMoreLine,
+  RiInformationLine
+} from '@remixicon/react';
+
+const RESOURCE_TYPE_CONFIG = {
+  COMPUTE: { icon: RiServerLine, color: 'text-blue-500', bgColor: 'bg-blue-50 dark:bg-blue-900/20' },
+  STORAGE: { icon: RiHardDriveLine, color: 'text-purple-500', bgColor: 'bg-purple-50 dark:bg-purple-900/20' },
+  NETWORK: { icon: RiGlobalLine, color: 'text-green-500', bgColor: 'bg-green-50 dark:bg-green-900/20' },
+  DATABASE: { icon: RiDatabaseLine, color: 'text-orange-500', bgColor: 'bg-orange-50 dark:bg-orange-900/20' },
+  API: { icon: RiCodeLine, color: 'text-pink-500', bgColor: 'bg-pink-50 dark:bg-pink-900/20' },
+  OTHER: { icon: RiMoreLine, color: 'text-gray-500', bgColor: 'bg-gray-50 dark:bg-gray-900/20' }
+} as const;
+
+const STATUS_CONFIG = {
+  PROVISIONING: { variant: 'warning' as const, label: 'Provisioning' },
+  ACTIVE: { variant: 'success' as const, label: 'Active' },
+  INACTIVE: { variant: 'outline' as const, label: 'Inactive' },
+  MAINTENANCE: { variant: 'warning' as const, label: 'Maintenance' },
+  DELETED: { variant: 'outline' as const, label: 'Deleted' }
+} as const;
+
+export default function ResourceDetailPage() {
+  const organisation = useOrganisation();
+  const project = useProject();
+  const resource = useResource();
+
+  const typeConfig = RESOURCE_TYPE_CONFIG[resource.type as keyof typeof RESOURCE_TYPE_CONFIG] || RESOURCE_TYPE_CONFIG.OTHER;
+  const statusConfig = STATUS_CONFIG[resource.status as keyof typeof STATUS_CONFIG] || STATUS_CONFIG.INACTIVE;
+  const IconComponent = typeConfig.icon;
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Breadcrumbs */}
+      <div className="mb-6">
+        <Breadcrumbs
+          items={[
+            { label: organisation.name, href: `/${organisation.name}` },
+            { label: project.name, href: `/${organisation.name}/${project.name}` },
+            { label: resource.name }
+          ]}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-start justify-between">
+          <div className="flex items-start gap-4">
+            <div className={`p-3 rounded-lg ${typeConfig.bgColor}`}>
+              <IconComponent className={`w-8 h-8 ${typeConfig.color}`} />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+                {resource.name}
+              </h1>
+              <div className="flex items-center gap-2">
+                <Badge variant={statusConfig.variant}>
+                  {statusConfig.label}
+                </Badge>
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                  {resource.type}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Deployment Status */}
+      <DeploymentStatus
+        resourceId={resource.id}
+        status={resource.status}
+        configuration={resource.configuration}
+        endpoint={resource.endpoint}
+        credentials={resource.credentials}
+      />
+
+      {/* Health Dashboard Section */}
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Resource Health
+        </h2>
+        <ResourcesHealthDashboard
+          resources={[
+            {
+              id: resource.id,
+              name: resource.name,
+              type: (resource.type as 'STORAGE' | 'COMPUTE' | 'DATABASE' | 'NETWORK') || 'DATABASE',
+              status: 'HEALTHY',
+              projectId: project.id,
+              projectName: project.name,
+              lastChecked: new Date(),
+            }
+          ]}
+        />
+      </div>
+
+      {/* API Test Section */}
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          API Testing
+        </h2>
+        <Card className="p-6">
+          <ResourceApiTestPanel
+            organisationName={organisation.name}
+            projects={[{ id: project.id, name: project.name }]}
+            userId={resource.ownerId}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
@@ -1,0 +1,69 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { resolveProjectPermissions } from '@/lib/permissions';
+import { RiArrowLeftLine } from '@remixicon/react';
+import GrantProjectAccessForm from '@/components/form/GrantProjectAccessForm';
+
+interface AddProjectAccessPageProps {
+  params: Promise<{ slug: string; projectName: string }>;
+}
+
+export default async function AddProjectAccessPage({ params }: AddProjectAccessPageProps) {
+  const { slug, projectName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const project = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  if (!project) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOrgAdmin =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  if (!isOrgAdmin) {
+    const projectRole = await resolveProjectPermissions(session.user.id, project.id);
+    if (projectRole !== 'ADMIN') {
+      notFound();
+    }
+  }
+
+  const accessRows = await store.projectAccess.findByProjectId(project.id);
+  const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
+  const allTeams = await store.teams.findByOrgId(organisation.id);
+  const availableTeams = allTeams
+    .filter((t) => !grantedTeamIds.has(t.id))
+    .map((t) => ({ id: t.id, name: t.name, defaultProjectRole: t.defaultProjectRole }));
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/${slug}/${projectName}/access`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to project access
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Add Team Access</h1>
+      </div>
+
+      <GrantProjectAccessForm
+        projectId={project.id}
+        availableTeams={availableTeams}
+        organisationName={slug}
+        projectName={projectName}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/access/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/page.tsx
@@ -1,0 +1,135 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { resolveProjectPermissions } from '@/lib/permissions';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { Callout } from '@/components/common/Callout';
+import { RiAddLine, RiTeamLine, RiInformationLine } from '@remixicon/react';
+import RevokeAccessButton from '@/components/team/RevokeAccessButton';
+import ChangeAccessRoleForm from '@/components/team/ChangeAccessRoleForm';
+
+interface ProjectAccessPageProps {
+  params: Promise<{ slug: string; projectName: string }>;
+}
+
+export default async function ProjectAccessPage({ params }: ProjectAccessPageProps) {
+  const { slug, projectName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const project = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  if (!project) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOrgAdmin =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  if (!isOrgAdmin) {
+    const projectRole = await resolveProjectPermissions(session.user.id, project.id);
+    if (projectRole !== 'ADMIN') {
+      notFound();
+    }
+  }
+
+  const accessRows = await store.projectAccess.findByProjectId(project.id);
+
+  const accessWithTeams = await Promise.all(
+    accessRows.map(async (row) => {
+      const team = await store.teams.findById(row.teamId);
+      const members = team ? await store.teamMembers.findByTeamId(team.id) : [];
+      return {
+        ...row,
+        teamName: team?.name ?? 'Unknown team',
+        memberCount: members.length,
+      };
+    })
+  );
+
+  const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
+  const allTeams = await store.teams.findByOrgId(organisation.id);
+  const availableTeams = allTeams.filter((t) => !grantedTeamIds.has(t.id));
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Project Access</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Manage which teams can access {projectName}
+          </p>
+        </div>
+        {availableTeams.length > 0 && (
+          <Link href={`/${slug}/${projectName}/access/add`}>
+            <Button>
+              <RiAddLine className="w-4 h-4 mr-1" />
+              Add Team
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <Callout variant="default" title="Inherited access" icon={RiInformationLine} className="mb-6">
+        Organisation OWNERs and ADMINs automatically have ADMIN access to all projects.
+      </Callout>
+
+      {accessWithTeams.length === 0 ? (
+        <Card className="p-12 text-center">
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <p className="text-gray-600 dark:text-gray-400 font-medium">No teams have been granted access yet</p>
+          {availableTeams.length > 0 && (
+            <div className="mt-4">
+              <Link href={`/${slug}/${projectName}/access/add`}>
+                <Button variant="light">
+                  <RiAddLine className="w-4 h-4 mr-1" />
+                  Add first team
+                </Button>
+              </Link>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <Card>
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {accessWithTeams.map((row) => (
+              <li key={row.id} className="flex items-center justify-between px-6 py-4 flex-wrap gap-3">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                    <RiTeamLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                  </div>
+                  <div>
+                    <Link
+                      href={`/${slug}/teams/${row.teamName}`}
+                      className="font-semibold text-gray-900 dark:text-white hover:underline"
+                    >
+                      {row.teamName}
+                    </Link>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {row.memberCount} {row.memberCount === 1 ? 'member' : 'members'}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge variant="default">{row.role}</Badge>
+                  <ChangeAccessRoleForm accessId={row.id} currentRole={row.role} />
+                  <RevokeAccessButton accessId={row.id} teamName={row.teamName} />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/layout.tsx
+++ b/src/app/(main)/[slug]/[projectName]/layout.tsx
@@ -1,0 +1,75 @@
+import { notFound } from 'next/navigation';
+import { getStoreAsync } from '@/lib/store';
+import { ProjectProvider } from '@/contexts/ProjectContext';
+
+export default async function ProjectLayout({
+  children,
+  params,
+}: Readonly<{
+  children: React.ReactNode;
+  params: Promise<{ slug: string; projectName: string }>;
+}>) {
+  const { slug, projectName } = await params;
+
+  if (!slug || !projectName) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+
+  if (!organisation) {
+    notFound();
+  }
+
+  const projectFound = await store.projects.findByNameAndOrg(projectName, organisation.id);
+
+  if (!projectFound || !projectFound.isActive) {
+    notFound();
+  }
+
+  const projectAllocations = await store.projectResources.findByProjectId(projectFound.id);
+
+  const allocatedResources = [];
+  for (const allocation of projectAllocations) {
+    const resource = await store.resources.findById(allocation.resourceId);
+    if (resource) {
+      const owner = await store.users.findById(resource.ownerId);
+      allocatedResources.push({
+        ...allocation,
+        resource: {
+          ...resource,
+          owner: owner ? {
+            id: owner.id,
+            name: owner.name,
+            firstname: owner.firstname,
+            lastname: owner.lastname,
+            email: owner.email,
+          } : null,
+          organisation: {
+            id: organisation.id,
+            name: organisation.name,
+          },
+        },
+      });
+    }
+  }
+
+  const filteredAllocatedResources = allocatedResources.filter(
+    allocation => allocation.resource.isActive && allocation.resource.status === 'ACTIVE'
+  );
+
+  const project = {
+    ...projectFound,
+    budget: projectFound.budget?.toString() || null,
+    organisation: { id: organisation.id, name: organisation.name },
+    allocatedResources: filteredAllocatedResources,
+    _count: { allocatedResources: allocatedResources.length },
+  };
+
+  return (
+    <ProjectProvider project={project}>
+      {children}
+    </ProjectProvider>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/loading.tsx
+++ b/src/app/(main)/[slug]/[projectName]/loading.tsx
@@ -1,0 +1,82 @@
+import { Card } from '@/components/common/Card';
+import { Skeleton, SkeletonButton } from '@/components/common/Skeleton';
+
+export default function ProjectDetailsLoading() {
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Header Section */}
+      <div className="mb-8">
+        <div className="flex items-start justify-between gap-6 mb-6">
+          <div className="flex-1">
+            <div className="flex items-center gap-3 mb-3">
+              <Skeleton className="h-14 w-14 rounded-xl" />
+              <div className="flex-1">
+                <Skeleton className="h-8 w-48 mb-2" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+            </div>
+            <Skeleton className="h-4 w-full max-w-2xl" />
+          </div>
+          <div className="flex flex-col gap-2 items-end">
+            <div className="flex gap-2">
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+            <div className="flex gap-2 mt-2">
+              <SkeletonButton />
+              <SkeletonButton />
+            </div>
+          </div>
+        </div>
+
+        {/* Overview Stats */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-8 mt-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i}>
+              <div className="flex items-center gap-2 mb-2">
+                <Skeleton className="h-4 w-4 rounded" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+              <Skeleton className="h-10 w-16 mb-3" />
+              <Skeleton className="h-2 w-full rounded-full mb-2" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div className="my-16 h-px bg-gray-200 dark:bg-gray-700" />
+
+      {/* Main Content */}
+      <div className="space-y-8">
+        {/* Resource Section */}
+        <div>
+          <div className="flex items-center justify-between mb-6">
+            <Skeleton className="h-7 w-40" />
+            <SkeletonButton />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Card key={i} className="p-6">
+                <div className="flex items-start justify-between mb-4">
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+                <Skeleton className="h-4 w-full mb-4" />
+                <div className="space-y-3">
+                  <div className="flex justify-between">
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                  <Skeleton className="h-2 w-full rounded-full" />
+                </div>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/page.tsx
@@ -1,0 +1,26 @@
+import { auth } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import ProjectDetailsClient from '@/components/ProjectDetailsClient';
+
+interface ProjectDetailsPageProps {
+  params: Promise<{ slug: string; projectName: string }>;
+}
+
+export default async function ProjectDetailsPage({ params }: ProjectDetailsPageProps) {
+  const session = await auth();
+
+  if (!session) {
+    notFound();
+  }
+
+  const { slug, projectName } = await params;
+
+  // Validate that parameters are provided
+  if (!slug || !projectName) {
+    notFound();
+  }
+
+  // Permission checks and data loading happen in layouts via context
+  // This page just validates the session and renders the client component
+  return <ProjectDetailsClient />;
+}

--- a/src/app/(main)/[slug]/[projectName]/settings/ProjectSettingsClient.tsx
+++ b/src/app/(main)/[slug]/[projectName]/settings/ProjectSettingsClient.tsx
@@ -56,8 +56,8 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
       <div className="mb-6">
         <Breadcrumbs
           items={[
-            { label: organisation.name, href: `/orga/${organisation.name}` },
-            { label: project.name, href: `/orga/${organisation.name}/${project.name}` },
+            { label: organisation.name, href: `/${organisation.name}` },
+            { label: project.name, href: `/${organisation.name}/${project.name}` },
             { label: 'Settings' }
           ]}
         />
@@ -100,7 +100,7 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
                 project={project}
                 successMessage="Project updated successfully!"
                 currentUserId={currentUserId}
-                redirectUrl={`/orga/${orgName}/${project.name}`}
+                redirectUrl={`/${orgName}/${project.name}`}
               />
             </div>
           </Card>
@@ -162,13 +162,13 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
           <Card className="p-6">
             <h3 className="font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h3>
             <div className="space-y-2">
-              <Link href={`/orga/${orgName}/${project.name}`} className="block">
+              <Link href={`/${orgName}/${project.name}`} className="block">
                 <Button variant="outline" size="sm" className="w-full justify-start">
                   <RiProjectorLine className="mr-2 h-4 w-4" />
                   View Project Details
                 </Button>
               </Link>
-              <Link href={`/orga/${orgName}/${project.name}/add-resource`} className="block">
+              <Link href={`/${orgName}/${project.name}/add-resource`} className="block">
                 <Button variant="outline" size="sm" className="w-full justify-start">
                   <RiProjectorLine className="mr-2 h-4 w-4" />
                   Add Resource

--- a/src/app/(main)/[slug]/[projectName]/settings/ProjectSettingsClient.tsx
+++ b/src/app/(main)/[slug]/[projectName]/settings/ProjectSettingsClient.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { Card } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import Breadcrumbs from '@/components/common/Breadcrumbs';
+import ProjectForm from '@/components/form/ProjectForm';
+import { useProject } from '@/contexts/ProjectContext';
+import { useOrganisation } from '@/contexts/OrganisationContext';
+import { RiSettingsLine, RiProjectorLine } from '@remixicon/react';
+import Link from 'next/link';
+
+interface ProjectSettingsClientProps {
+  currentUserId: string;
+}
+
+export default function ProjectSettingsClient({ currentUserId }: ProjectSettingsClientProps) {
+  const project = useProject();
+  const organisation = useOrganisation();
+  const orgName = organisation.name;
+
+  const getStatusBadgeVariant = (status: string) => {
+    switch (status) {
+      case 'ACTIVE':
+        return 'default';
+      case 'COMPLETED':
+        return 'secondary';
+      case 'PLANNING':
+        return 'outline';
+      case 'ON_HOLD':
+        return 'outline';
+      case 'CANCELLED':
+        return 'outline';
+      default:
+        return 'outline';
+    }
+  };
+
+  const getPriorityBadgeVariant = (priority: string) => {
+    switch (priority) {
+      case 'URGENT':
+        return 'default';
+      case 'HIGH':
+        return 'secondary';
+      case 'MEDIUM':
+        return 'outline';
+      case 'LOW':
+        return 'outline';
+      default:
+        return 'outline';
+    }
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Breadcrumbs */}
+      <div className="mb-6">
+        <Breadcrumbs
+          items={[
+            { label: organisation.name, href: `/orga/${organisation.name}` },
+            { label: project.name, href: `/orga/${organisation.name}/${project.name}` },
+            { label: 'Settings' }
+          ]}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+            <RiSettingsLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Project Settings</h1>
+        </div>
+        <p className="text-gray-600 dark:text-gray-300 mt-2">
+          Manage settings and configuration for {project.name}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-6">
+        {/* Main Content - Project Settings Form */}
+        <div className="xl:col-span-3">
+          <Card>
+            <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+              <div className="flex items-center">
+                <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg mr-3">
+                  <RiProjectorLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    Project Configuration
+                  </h2>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    Update project information and settings
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="p-6">
+              <ProjectForm
+                project={project}
+                successMessage="Project updated successfully!"
+                currentUserId={currentUserId}
+                redirectUrl={`/orga/${orgName}/${project.name}`}
+              />
+            </div>
+          </Card>
+        </div>
+
+        {/* Sidebar - Project Overview */}
+        <div className="xl:col-span-1 space-y-6">
+          <Card className="p-6">
+            <div className="flex items-center mb-4">
+              <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg mr-3">
+                <RiProjectorLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+              </div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Project Overview</h2>
+            </div>
+
+            <div className="space-y-3 text-sm">
+              <div>
+                <span className="text-gray-500">Organisation:</span>
+                <span className="ml-2 font-medium text-gray-900 dark:text-white">{organisation.name}</span>
+              </div>
+
+              <div>
+                <span className="text-gray-500">Progress:</span>
+                <span className="ml-2 font-medium text-gray-900 dark:text-white">{project.progress}%</span>
+              </div>
+
+              <div>
+                <span className="text-gray-500">Created:</span>
+                <span className="ml-2 font-medium text-gray-900 dark:text-white">
+                  {new Date(project.createdAt).toLocaleDateString('en-GB', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+              </div>
+
+              <div>
+                <span className="text-gray-500">Last Updated:</span>
+                <span className="ml-2 font-medium text-gray-900 dark:text-white">
+                  {new Date(project.updatedAt).toLocaleDateString('en-GB', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+              </div>
+
+              {project.description && (
+                <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+                  <span className="text-gray-500">Description:</span>
+                  <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm">{project.description}</p>
+                </div>
+              )}
+            </div>
+          </Card>
+
+          {/* Navigation */}
+          <Card className="p-6">
+            <h3 className="font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h3>
+            <div className="space-y-2">
+              <Link href={`/orga/${orgName}/${project.name}`} className="block">
+                <Button variant="outline" size="sm" className="w-full justify-start">
+                  <RiProjectorLine className="mr-2 h-4 w-4" />
+                  View Project Details
+                </Button>
+              </Link>
+              <Link href={`/orga/${orgName}/${project.name}/add-resource`} className="block">
+                <Button variant="outline" size="sm" className="w-full justify-start">
+                  <RiProjectorLine className="mr-2 h-4 w-4" />
+                  Add Resource
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/[projectName]/settings/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/settings/page.tsx
@@ -1,0 +1,24 @@
+import { auth } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import ProjectSettingsClient from './ProjectSettingsClient';
+
+interface ProjectSettingsPageProps {
+  params: Promise<{ slug: string; projectName: string }>;
+}
+
+export default async function ProjectSettingsPage({ params }: ProjectSettingsPageProps) {
+  const session = await auth();
+
+  if (!session) {
+    notFound();
+  }
+
+  const { slug, projectName } = await params;
+
+  // Validate that parameters are provided
+  if (!slug || !projectName) {
+    notFound();
+  }
+
+  return <ProjectSettingsClient currentUserId={session.user.id} />;
+}

--- a/src/app/(main)/[slug]/layout.tsx
+++ b/src/app/(main)/[slug]/layout.tsx
@@ -1,0 +1,81 @@
+import { notFound } from 'next/navigation';
+import { getStoreAsync } from '@/lib/store';
+import { OrganisationProvider } from '@/contexts/OrganisationContext';
+
+export default async function NamespaceLayout({
+  children,
+  params,
+}: Readonly<{
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+}>) {
+  const { slug } = await params;
+
+  if (!slug) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+
+  const namespace = await store.namespaces.findBySlug(slug);
+
+  if (namespace?.entityType === 'ORGANISATION') {
+    const organisation = await store.organisations.findById(namespace.entityId);
+    if (!organisation || !organisation.isActive) notFound();
+
+    const projects = await store.projects.findByOrgId(organisation.id, { isActive: true });
+    const members = await store.organisationMembers.findByOrgId(organisation.id);
+
+    return (
+      <OrganisationProvider
+        organisation={{
+          id: organisation.id,
+          name: organisation.name,
+          description: organisation.description,
+          ownerId: organisation.ownerId,
+          isActive: organisation.isActive,
+          projects,
+          _count: {
+            members: members.length,
+            projects: projects.length,
+          },
+        }}
+      >
+        {children}
+      </OrganisationProvider>
+    );
+  }
+
+  if (namespace?.entityType === 'USER') {
+    const user = await store.users.findById(namespace.entityId);
+    if (!user) notFound();
+    return <>{children}</>;
+  }
+
+  const orgByName = await store.organisations.findByName(slug);
+  if (orgByName && orgByName.isActive) {
+    const projects = await store.projects.findByOrgId(orgByName.id, { isActive: true });
+    const members = await store.organisationMembers.findByOrgId(orgByName.id);
+
+    return (
+      <OrganisationProvider
+        organisation={{
+          id: orgByName.id,
+          name: orgByName.name,
+          description: orgByName.description,
+          ownerId: orgByName.ownerId,
+          isActive: orgByName.isActive,
+          projects,
+          _count: {
+            members: members.length,
+            projects: projects.length,
+          },
+        }}
+      >
+        {children}
+      </OrganisationProvider>
+    );
+  }
+
+  notFound();
+}

--- a/src/app/(main)/[slug]/loading.tsx
+++ b/src/app/(main)/[slug]/loading.tsx
@@ -1,0 +1,76 @@
+import Container from '@/components/common/Container';
+import { Card } from '@/components/common/Card';
+import { Skeleton, SkeletonButton } from '@/components/common/Skeleton';
+
+export default function OrganisationDetailsLoading() {
+  return (
+    <main className="mt-4">
+      <Container>
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex-1">
+            <Skeleton className="h-10 w-48 mb-3" />
+            <div className="flex items-center gap-4 mb-3">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <SkeletonButton />
+            <SkeletonButton />
+          </div>
+        </div>
+
+        {/* Projects Section */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-6">
+            <Skeleton className="h-8 w-40" />
+            <SkeletonButton />
+          </div>
+
+          {/* Project Cards Grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Card key={i} className="p-6">
+                {/* Project Header */}
+                <div className="flex items-start justify-between mb-3">
+                  <Skeleton className="h-6 w-40" />
+                  <Skeleton className="h-5 w-20 rounded-full" />
+                </div>
+
+                {/* Project Description */}
+                <Skeleton className="h-4 w-full mb-4" />
+
+                {/* Resource Types */}
+                <div className="flex flex-wrap gap-2 mb-3">
+                  {Array.from({ length: 3 }).map((_, j) => (
+                    <Skeleton key={j} className="h-5 w-24 rounded" />
+                  ))}
+                </div>
+
+                {/* Resource Usage Progress */}
+                <div className="mb-4">
+                  <div className="flex items-center justify-between mb-1">
+                    <Skeleton className="h-3 w-24" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                  <Skeleton className="h-1.5 w-full rounded-full" />
+                </div>
+
+                {/* Progress Bar */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-4 w-16" />
+                  </div>
+                  <Skeleton className="h-2 w-full rounded-full" />
+                </div>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/src/app/(main)/[slug]/members/invite/page.tsx
+++ b/src/app/(main)/[slug]/members/invite/page.tsx
@@ -1,0 +1,53 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import Container from '@/components/common/Container';
+import Headline from '@/components/common/Headline';
+import InviteMemberForm from '@/components/form/InviteMemberForm';
+import { RiArrowLeftLine } from '@remixicon/react';
+
+interface InviteMemberPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function InviteMemberPage({ params }: InviteMemberPageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) notFound();
+  if (!slug) notFound();
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const isAdmin = session.user.role === 'ADMIN';
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const isOwner = membership?.role === 'OWNER';
+  const isManager = membership?.role === 'MANAGER';
+
+  if (!isAdmin && !isOwner && !isManager) notFound();
+
+  return (
+    <main className="mt-4">
+      <Container>
+        <div className="mb-6">
+          <Link
+            href={`/${slug}/members`}
+            className="inline-flex items-center text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 mb-3"
+          >
+            <RiArrowLeftLine className="h-4 w-4 mr-1" />
+            Back to members
+          </Link>
+          <Headline>Invite Member</Headline>
+        </div>
+
+        <div className="max-w-xl">
+          <InviteMemberForm organisationId={organisation.id} organisationName={organisation.name} />
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/src/app/(main)/[slug]/members/page.tsx
+++ b/src/app/(main)/[slug]/members/page.tsx
@@ -1,0 +1,119 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { MembersManagementClient } from '@/components/MembersManagementClient';
+
+interface MembersManagementPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function MembersManagementPage({ params }: MembersManagementPageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  if (!slug) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+  const organisationId = organisation.id;
+
+  const isAdmin = session.user.role === 'ADMIN';
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+
+  const isOwner = membership?.role === 'OWNER';
+  const isManager = membership?.role === 'MANAGER';
+
+  if (!membership && !isAdmin) {
+    notFound();
+  }
+
+  if (!isOwner && !isManager && !isAdmin) {
+    notFound();
+  }
+
+  const [storeMembers, rawJoinRequests, pendingInvitations] = await Promise.all([
+    store.organisationMembers.findByOrgId(organisationId),
+    store.joinRequests.findByOrgId(organisationId, 'PENDING'),
+    store.invitations.findByOrgId(organisationId, 'PENDING'),
+  ]);
+
+  const joinRequests = await Promise.all(
+    rawJoinRequests.map(async (req) => {
+      const user = await store.users.findById(req.userId);
+      return {
+        ...req,
+        user: {
+          id: req.userId,
+          name: user?.name ?? null,
+          firstname: user?.firstname ?? null,
+          lastname: user?.lastname ?? null,
+          email: user?.email ?? '',
+          image: user?.image ?? null,
+        },
+      };
+    })
+  );
+
+  joinRequests.sort((a, b) => b.requestedAt.getTime() - a.requestedAt.getTime());
+
+  const members = await Promise.all(
+    storeMembers.map(async (m) => {
+      const user = await store.users.findById(m.userId);
+      return {
+        id: m.id,
+        userId: m.userId,
+        organisationId: m.organisationId,
+        role: m.role,
+        joinedAt: m.joinedAt,
+        updatedAt: m.updatedAt,
+        user: {
+          id: m.userId,
+          name: user?.name ?? null,
+          firstname: user?.firstname ?? null,
+          lastname: user?.lastname ?? null,
+          email: user?.email ?? '',
+          image: user?.image ?? null,
+        },
+      };
+    })
+  );
+
+  const roleOrder = { OWNER: 0, MANAGER: 1, MEMBER: 2 };
+  members.sort((a, b) => {
+    const roleCompare = (roleOrder[a.role as keyof typeof roleOrder] ?? 3) - (roleOrder[b.role as keyof typeof roleOrder] ?? 3);
+    if (roleCompare !== 0) return roleCompare;
+    return a.joinedAt.getTime() - b.joinedAt.getTime();
+  });
+
+  const now = new Date();
+  const invitations = pendingInvitations
+    .filter((inv) => inv.expiresAt > now)
+    .map((inv) => ({
+      id: inv.id,
+      email: inv.email,
+      role: inv.role,
+      expiresAt: inv.expiresAt,
+      createdAt: inv.createdAt,
+    }));
+
+  return (
+    <MembersManagementClient
+      members={members}
+      joinRequests={joinRequests}
+      invitations={invitations}
+      organisationName={slug}
+      isOwner={isOwner}
+      isManager={isManager}
+      isAdmin={isAdmin}
+      currentUserId={session.user.id}
+    />
+  );
+}

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -1,0 +1,60 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { checkOrganisationPermissions } from '@/lib/permissions';
+import OrganisationOverviewClient from '@/components/OrganisationOverviewClient';
+
+interface NamespacePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function NamespacePage({ params }: NamespacePageProps) {
+  const { slug } = await params;
+  const store = await getStoreAsync();
+
+  const namespace = await store.namespaces.findBySlug(slug);
+
+  if (namespace?.entityType === 'ORGANISATION') {
+    const organisation = await store.organisations.findById(namespace.entityId);
+    if (!organisation || !organisation.isActive) notFound();
+
+    const session = await auth();
+    const permissions = await checkOrganisationPermissions(
+      session.user.id,
+      session.user.role,
+      organisation.id
+    );
+
+    if (!permissions.isMember && !permissions.isAdmin) notFound();
+
+    return <OrganisationOverviewClient canManage={permissions.canManage} />;
+  }
+
+  if (namespace?.entityType === 'USER') {
+    const user = await store.users.findById(namespace.entityId);
+    if (!user) notFound();
+
+    return (
+      <main className="p-8">
+        <h1 className="text-2xl font-bold">{user.name || user.slug}</h1>
+        <p className="text-gray-500 mt-2">Personal projects coming soon</p>
+      </main>
+    );
+  }
+
+  const orgByName = await store.organisations.findByName(slug);
+  if (orgByName && orgByName.isActive) {
+    const session = await auth();
+    const permissions = await checkOrganisationPermissions(
+      session.user.id,
+      session.user.role,
+      orgByName.id
+    );
+
+    if (!permissions.isMember && !permissions.isAdmin) notFound();
+
+    return <OrganisationOverviewClient canManage={permissions.canManage} />;
+  }
+
+  notFound();
+}

--- a/src/app/(main)/[slug]/roles/page.tsx
+++ b/src/app/(main)/[slug]/roles/page.tsx
@@ -1,0 +1,77 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { RolesManagementClient } from '@/components/RolesManagementClient';
+
+interface RolesPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function RolesPage({ params }: RolesPageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  if (!slug) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const orgLookup = await store.organisations.findByName(slug);
+  if (!orgLookup) notFound();
+  const organisationId = orgLookup.id;
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+
+  const isAdmin = session.user.role === 'ADMIN';
+  const isOwner = membership?.role === 'OWNER';
+  const isManager = membership?.role === 'MANAGER';
+
+  if (!membership && !isAdmin) {
+    notFound();
+  }
+
+  const storeMembers = await store.organisationMembers.findByOrgId(organisationId);
+
+  const members = await Promise.all(
+    storeMembers.map(async (m) => {
+      const user = await store.users.findById(m.userId);
+      return {
+        id: m.id,
+        userId: m.userId,
+        organisationId: m.organisationId,
+        role: m.role,
+        joinedAt: m.joinedAt,
+        updatedAt: m.updatedAt,
+        user: {
+          id: m.userId,
+          name: user?.name ?? null,
+          firstname: user?.firstname ?? null,
+          lastname: user?.lastname ?? null,
+          email: user?.email ?? '',
+          image: user?.image ?? null,
+        },
+      };
+    })
+  );
+
+  const roleOrder = { OWNER: 0, MANAGER: 1, MEMBER: 2 };
+  members.sort((a, b) => {
+    const roleCompare = (roleOrder[a.role as keyof typeof roleOrder] ?? 3) - (roleOrder[b.role as keyof typeof roleOrder] ?? 3);
+    if (roleCompare !== 0) return roleCompare;
+    return a.joinedAt.getTime() - b.joinedAt.getTime();
+  });
+
+  if (!members) {
+    notFound();
+  }
+
+  return (
+    <RolesManagementClient
+      members={members as { id: string; role: 'OWNER' | 'MANAGER' | 'MEMBER'; joinedAt: Date; updatedAt: Date; user: { id: string; name: string | null; firstname: string | null; lastname: string | null; email: string; image: string | null } }[]}
+    />
+  );
+}

--- a/src/app/(main)/[slug]/settings/page.tsx
+++ b/src/app/(main)/[slug]/settings/page.tsx
@@ -1,0 +1,225 @@
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Button } from '@/components/common/Button';
+import { Badge } from '@/components/common/Badge';
+import OrganisationSettingsForm from '@/components/form/OrganisationSettingsForm';
+import { OrganisationSettingsOverviewClient } from '@/components/OrganisationSettingsOverviewClient';
+import {
+  RiArrowLeftLine,
+  RiSettingsLine,
+  RiUserLine,
+  RiTeamLine,
+} from '@remixicon/react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+interface OrganisationSettingsPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function OrganisationSettingsPage({ params }: OrganisationSettingsPageProps) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const { slug } = await params;
+
+  // Validate that slug is provided
+  if (!slug) {
+    notFound();
+  }
+
+  // Get organisation by name
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+  const organisationId = organisation.id;
+
+  // Check if user is a member of this organisation
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+
+  const isAdmin = session.user.role === 'ADMIN';
+  const isOwner = membership?.role === 'OWNER';
+  const isManager = membership?.role === 'MANAGER';
+  const isMember = !!membership;
+
+  // Check permissions
+  if (!isMember && !isAdmin) {
+    notFound();
+  }
+
+  // Only owners, managers, and admins can access settings
+  const canManageSettings = isOwner || isManager || isAdmin;
+  if (!canManageSettings) {
+    notFound();
+  }
+
+  // Fetch counts needed for display
+  const orgMembers = await store.organisationMembers.findByOrgId(organisationId);
+  const organisationCounts = {
+    _count: {
+      members: orgMembers.length,
+      joinRequests: 0,
+    }
+  };
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                <RiSettingsLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+              </div>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                Organisation Settings
+              </h1>
+            </div>
+            <p className="text-gray-600 dark:text-gray-300">
+              Manage settings and configuration for {slug}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">
+              {membership?.role || 'Admin'}
+            </Badge>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-6">
+        {/* Main Content - Organisation Settings Form */}
+        <div className="xl:col-span-3">
+          <Card>
+            <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+              <div className="flex items-center">
+                <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg mr-3">
+                  <RiSettingsLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    Organisation Configuration
+                  </h2>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    Update organisation information and settings
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="p-6">
+              <OrganisationSettingsFormWrapper
+                organisationId={organisationId}
+                organisationName={slug}
+                redirectUrl={`/${slug}`}
+              />
+            </div>
+          </Card>
+
+          {/* Additional Settings */}
+          <Card className="mt-6">
+            <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+              <div className="flex items-center">
+                <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg mr-3">
+                  <RiSettingsLine className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                    Advanced Settings
+                  </h2>
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    Additional configuration options
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="p-6">
+              <div className="space-y-4">
+                <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                  <div>
+                    <h3 className="font-medium text-gray-900 dark:text-white">
+                      Member Invitations
+                    </h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      Control who can invite new members to the organisation
+                    </p>
+                  </div>
+                  <Badge variant="outline">Coming Soon</Badge>
+                </div>
+
+                <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                  <div>
+                    <h3 className="font-medium text-gray-900 dark:text-white">
+                      Resource Limits
+                    </h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      Set limits for resource usage across the organisation
+                    </p>
+                  </div>
+                  <Badge variant="outline">Coming Soon</Badge>
+                </div>
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        {/* Sidebar - Organisation Overview */}
+        <div className="xl:col-span-1 space-y-6">
+          <OrganisationSettingsOverviewClient
+            memberCount={organisationCounts._count.members}
+            pendingRequests={organisationCounts._count.joinRequests}
+          />
+
+          {/* Navigation */}
+          <Card className="p-6">
+            <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+              Quick Actions
+            </h3>
+            <div className="space-y-2">
+              <Link href={`/${slug}`} className="block">
+                <Button variant="light" className="w-full justify-start text-sm px-3 py-2">
+                  <RiUserLine className="mr-2 h-4 w-4" />
+                  View Organisation
+                </Button>
+              </Link>
+              <Link href={`/${slug}/members`} className="block">
+                <Button variant="light" className="w-full justify-start text-sm px-3 py-2">
+                  <RiUserLine className="mr-2 h-4 w-4" />
+                  Manage Members
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+async function OrganisationSettingsFormWrapper({
+  organisationId,
+  organisationName,
+  redirectUrl
+}: {
+  organisationId: string;
+  organisationName: string;
+  redirectUrl: string;
+}) {
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findById(organisationId);
+
+  if (!organisation) {
+    notFound();
+  }
+
+  return (
+    <OrganisationSettingsForm
+      organisation={organisation}
+      redirectUrl={redirectUrl}
+    />
+  );
+}

--- a/src/app/(main)/[slug]/settings/test-resource-api/page.tsx
+++ b/src/app/(main)/[slug]/settings/test-resource-api/page.tsx
@@ -1,0 +1,85 @@
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { RiArrowLeftLine } from '@remixicon/react';
+import { Card } from '@/components/common/Card';
+import ResourceApiTestPanel from '@/components/resource-api/ResourceApiTestPanel';
+
+interface TestResourceApiPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function TestResourceApiPage({ params }: TestResourceApiPageProps) {
+  const session = await auth();
+
+  const { slug } = await params;
+
+  if (!slug) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const isAdmin = session.user.role === 'ADMIN';
+  const isOwner = membership?.role === 'OWNER';
+  const canAccess = isAdmin || isOwner;
+
+  if (!canAccess) {
+    return (
+      <div className="p-8">
+        <Card className="p-8 text-center">
+          <p className="text-gray-600">You do not have permission to access this page.</p>
+          <p className="text-sm text-gray-500 mt-2">Only organisation owners can test Resource API integration.</p>
+        </Card>
+      </div>
+    );
+  }
+
+  const allProjects = await store.projects.findByOrgId(organisation.id);
+  const projects = allProjects.slice(0, 10).map(p => ({ id: p.id, name: p.name }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <Link
+              href={`/${slug}/settings`}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <RiArrowLeftLine className="w-5 h-5" />
+            </Link>
+            <h1 className="text-3xl font-semibold text-gray-900">
+              Resource API Test
+            </h1>
+          </div>
+          <p className="text-gray-600">
+            Test connectivity and integration with the Resource API
+          </p>
+        </div>
+      </div>
+
+      <Card className="p-6">
+        <div className="mb-4">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Resource API Testing</h2>
+          <p className="text-sm text-gray-600">
+            This page allows you to test the connection between the Platform and the Resource API.
+            You can discover available providers, provision test resources, check their status, and clean up test resources.
+          </p>
+        </div>
+
+        <ResourceApiTestPanel
+          organisationName={organisation.name}
+          projects={projects}
+          userId={session.user.id}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/teams/[teamName]/add-member/page.tsx
+++ b/src/app/(main)/[slug]/teams/[teamName]/add-member/page.tsx
@@ -1,0 +1,79 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { RiArrowLeftLine } from '@remixicon/react';
+import AddTeamMemberForm from '@/components/form/AddTeamMemberForm';
+
+interface AddMemberPageProps {
+  params: Promise<{ slug: string; teamName: string }>;
+}
+
+export default async function AddMemberPage({ params }: AddMemberPageProps) {
+  const { slug, teamName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const team = await store.teams.findByNameAndOrg(teamName, organisation.id);
+  if (!team) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  if (!canManage) {
+    notFound();
+  }
+
+  const orgMembers = await store.organisationMembers.findByOrgId(organisation.id);
+  const currentTeamMembers = await store.teamMembers.findByTeamId(team.id);
+  const currentTeamMemberIds = new Set(currentTeamMembers.map((m) => m.userId));
+
+  const availableMembers = await Promise.all(
+    orgMembers
+      .filter((m) => !currentTeamMemberIds.has(m.userId))
+      .map(async (m) => {
+        const user = await store.users.findById(m.userId);
+        return {
+          id: m.userId,
+          name: user?.name ?? ([user?.firstname, user?.lastname].filter(Boolean).join(' ') || null),
+          email: user?.email ?? '',
+        };
+      })
+  );
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/${slug}/teams/${teamName}`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to {teamName}
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Add member</h1>
+      </div>
+
+      <div className="max-w-xl">
+        <AddTeamMemberForm
+          teamId={team.id}
+          organisationName={slug}
+          teamName={teamName}
+          availableMembers={availableMembers}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/teams/[teamName]/page.tsx
+++ b/src/app/(main)/[slug]/teams/[teamName]/page.tsx
@@ -1,0 +1,162 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { RiArrowLeftLine, RiAddLine, RiUserLine } from '@remixicon/react';
+import DeleteTeamButton from '@/components/team/DeleteTeamButton';
+import RemoveTeamMemberButton from '@/components/team/RemoveTeamMemberButton';
+
+interface TeamDetailPageProps {
+  params: Promise<{ slug: string; teamName: string }>;
+}
+
+export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
+  const { slug, teamName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const team = await store.teams.findByNameAndOrg(teamName, organisation.id);
+  if (!team) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  if (!membership && session.user.role !== 'ADMIN') {
+    notFound();
+  }
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  const canDelete =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  const rawMembers = await store.teamMembers.findByTeamId(team.id);
+  const members = await Promise.all(
+    rawMembers.map(async (m) => {
+      const user = await store.users.findById(m.userId);
+      return {
+        ...m,
+        user: {
+          id: m.userId,
+          name: user?.name ?? null,
+          firstname: user?.firstname ?? null,
+          lastname: user?.lastname ?? null,
+          email: user?.email ?? '',
+        },
+      };
+    })
+  );
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/${slug}/teams`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to teams
+        </Link>
+
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{team.name}</h1>
+              <Badge variant="default">{team.defaultProjectRole}</Badge>
+            </div>
+            {team.description && (
+              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{team.description}</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Card>
+        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Members ({members.length})
+          </h2>
+          {canManage && (
+            <Link href={`/${slug}/teams/${teamName}/add-member`}>
+              <Button variant="light">
+                <RiAddLine className="w-4 h-4 mr-1" />
+                Add member
+              </Button>
+            </Link>
+          )}
+        </div>
+
+        {members.length === 0 ? (
+          <div className="p-12 text-center">
+            <RiUserLine className="mx-auto w-8 h-8 text-gray-400 mb-3" />
+            <p className="text-gray-600 dark:text-gray-400">No members in this team yet.</p>
+            {canManage && (
+              <div className="mt-4">
+                <Link href={`/${slug}/teams/${teamName}/add-member`}>
+                  <Button variant="light">
+                    <RiAddLine className="w-4 h-4 mr-1" />
+                    Add first member
+                  </Button>
+                </Link>
+              </div>
+            )}
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {members.map((m) => {
+              const displayName = m.user.name
+                ?? ([m.user.firstname, m.user.lastname].filter(Boolean).join(' ') || m.user.email);
+              return (
+                <li key={m.id} className="flex items-center justify-between px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-9 h-9 rounded-full bg-brand-100 dark:bg-brand-900/30 flex items-center justify-center">
+                      <span className="text-sm font-medium text-brand-700 dark:text-brand-300">
+                        {displayName.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-gray-900 dark:text-white">{displayName}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{m.user.email}</p>
+                    </div>
+                  </div>
+                  {canManage && (
+                    <RemoveTeamMemberButton
+                      teamId={team.id}
+                      userId={m.userId}
+                      displayName={displayName}
+                    />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Card>
+
+      {canDelete && (
+        <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Danger zone</h3>
+          <DeleteTeamButton
+            teamId={team.id}
+            teamName={team.name}
+            organisationName={slug}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/teams/new/page.tsx
+++ b/src/app/(main)/[slug]/teams/new/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { RiArrowLeftLine } from '@remixicon/react';
+import CreateTeamForm from '@/components/form/CreateTeamForm';
+
+interface NewTeamPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function NewTeamPage({ params }: NewTeamPageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  if (!slug) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  if (!canManage) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/${slug}/teams`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to teams
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">New Team</h1>
+      </div>
+
+      <div className="max-w-xl">
+        <CreateTeamForm organisationId={organisation.id} organisationName={slug} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/teams/page.tsx
+++ b/src/app/(main)/[slug]/teams/page.tsx
@@ -1,0 +1,121 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { RiTeamLine, RiAddLine, RiArrowRightLine } from '@remixicon/react';
+
+interface TeamsPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function TeamsPage({ params }: TeamsPageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  if (!slug) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  if (!membership && session.user.role !== 'ADMIN') {
+    notFound();
+  }
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN' ||
+    membership?.role === 'MANAGER';
+
+  const teams = await store.teams.findByOrgId(organisation.id);
+
+  const teamsWithCounts = await Promise.all(
+    teams.map(async (team) => {
+      const members = await store.teamMembers.findByTeamId(team.id);
+      return { ...team, memberCount: members.length };
+    })
+  );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Teams</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Manage teams and their project access within {slug}
+          </p>
+        </div>
+        {canManage && (
+          <Link href={`/${slug}/teams/new`}>
+            <Button>
+              <RiAddLine className="w-4 h-4 mr-1" />
+              New Team
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {teamsWithCounts.length === 0 ? (
+        <Card className="p-12 text-center">
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <p className="text-gray-600 dark:text-gray-400 font-medium">No teams yet</p>
+          {canManage && (
+            <p className="text-sm text-gray-500 dark:text-gray-500 mt-1">
+              Create a team to group members and manage project access.
+            </p>
+          )}
+          {canManage && (
+            <div className="mt-4">
+              <Link href={`/${slug}/teams/new`}>
+                <Button variant="light">
+                  <RiAddLine className="w-4 h-4 mr-1" />
+                  Create first team
+                </Button>
+              </Link>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {teamsWithCounts.map((team) => (
+            <Link key={team.id} href={`/${slug}/teams/${team.name}`}>
+              <Card className="p-5 hover:border-brand-300 dark:hover:border-brand-700 transition-colors cursor-pointer">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                      <RiTeamLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                    </div>
+                    <div>
+                      <p className="font-semibold text-gray-900 dark:text-white">{team.name}</p>
+                      {team.description && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{team.description}</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge variant="default">{team.defaultProjectRole}</Badge>
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      {team.memberCount} {team.memberCount === 1 ? 'member' : 'members'}
+                    </span>
+                    <RiArrowRightLine className="w-4 h-4 text-gray-400" />
+                  </div>
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/orga/(organisation)/new/NewOrganisationForm.tsx
+++ b/src/app/(main)/orga/(organisation)/new/NewOrganisationForm.tsx
@@ -27,7 +27,7 @@ export default function NewOrganisationForm({ userId }: NewOrganisationFormProps
   // Redirect to newly created organisation page on success
   useEffect(() => {
     if (state?.success && state?.organisationName) {
-      router.push(`/orga/${encodeURIComponent(state.organisationName)}`);
+      router.push(`/${encodeURIComponent(state.organisationName)}`);
     }
   }, [state?.success, state?.organisationName, router]);
 

--- a/src/app/accept-invite/page.tsx
+++ b/src/app/accept-invite/page.tsx
@@ -33,7 +33,7 @@ export default async function AcceptInvitePage({ searchParams }: AcceptInvitePag
         title="Already accepted"
         message={`This invitation has already been used.${organisation ? ` Go to ${organisation.name}.` : ''}`}
         actionLabel={organisation ? `Open ${organisation.name}` : undefined}
-        actionHref={organisation ? `/orga/${organisation.name}` : undefined}
+        actionHref={organisation ? `/${organisation.name}` : undefined}
       />
     );
   }

--- a/src/app/api/admin/seed-namespaces/route.ts
+++ b/src/app/api/admin/seed-namespaces/route.ts
@@ -1,0 +1,13 @@
+import { auth } from '@/lib/auth';
+import { seedNamespaces } from '@/lib/seed-namespaces';
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const session = await auth();
+  if (!session?.user?.id || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorised' }, { status: 403 });
+  }
+
+  const result = await seedNamespaces();
+  return NextResponse.json(result);
+}

--- a/src/components/MembersManagementClient.tsx
+++ b/src/components/MembersManagementClient.tsx
@@ -101,7 +101,7 @@ export function MembersManagementClient({
         <div className="flex items-center justify-between mb-6">
           <Headline>Members & Requests</Headline>
           {canManage && (
-            <Link href={`/orga/${organisationName}/members/invite`}>
+            <Link href={`/${organisationName}/members/invite`}>
               <Button>
                 <RiUserAddLine className="mr-2 h-4 w-4" />
                 Invite Member

--- a/src/components/OrganisationCard.tsx
+++ b/src/components/OrganisationCard.tsx
@@ -45,7 +45,7 @@ export function OrganisationCard({
 }: OrganisationCardProps) {
   return (
     <Card className="p-6 hover:shadow-lg transition-all group cursor-pointer flex flex-col h-full">
-      <Link href={`/orga/${name}`} className="flex flex-col h-full">
+      <Link href={`/${name}`} className="flex flex-col h-full">
         {/* Content */}
         <div className="flex-1">
           {/* Header */}

--- a/src/components/OrganisationOverviewClient.tsx
+++ b/src/components/OrganisationOverviewClient.tsx
@@ -49,20 +49,20 @@ export default function OrganisationOverviewClient({
             </div>
           </div>
           <div className="flex items-center gap-3">
-            <Link href={`/orga/${organisation.name}/members`}>
+            <Link href={`/${organisation.name}/members`}>
               <Button variant="light" className="text-sm px-3 py-2">
                 <RiUserLine className="mr-2 h-4 w-4" />
                 Members
               </Button>
             </Link>
-            <Link href={`/orga/${organisation.name}/teams`}>
+            <Link href={`/${organisation.name}/teams`}>
               <Button variant="light" className="text-sm px-3 py-2">
                 <RiTeamLine className="mr-2 h-4 w-4" />
                 Teams
               </Button>
             </Link>
             {canManage && (
-              <Link href={`/orga/${organisation.name}/settings`}>
+              <Link href={`/${organisation.name}/settings`}>
                 <Button variant="light" className="text-sm px-3 py-2">
                   <RiSettings3Line className="mr-2 h-4 w-4" />
                   Settings
@@ -80,7 +80,7 @@ export default function OrganisationOverviewClient({
               Projects
             </h2>
             {canManage && (
-              <Link href={`/orga/${organisation.name}/new`}>
+              <Link href={`/${organisation.name}/new`}>
                 <Button>
                   <RiAddLine className="mr-2 h-4 w-4" />
                   New Project
@@ -104,7 +104,7 @@ export default function OrganisationOverviewClient({
               <RiProjectorLine className="mx-auto h-16 w-16 text-gray-400 mb-4" />
               <p className="text-gray-500 dark:text-gray-400 mb-6 text-lg">No projects yet</p>
               {canManage && (
-                <Link href={`/orga/${organisation.name}/new`}>
+                <Link href={`/${organisation.name}/new`}>
                   <Button>
                     <RiAddLine className="mr-2 h-4 w-4" />
                     Create First Project

--- a/src/components/ProjectDetailsClient.tsx
+++ b/src/components/ProjectDetailsClient.tsx
@@ -130,13 +130,13 @@ export default function ProjectDetailsClient() {
               </Badge>
             </div>
             <div className="flex gap-2 mt-2">
-              <Link href={`/orga/${orgName}/${project.name}/settings`}>
+              <Link href={`/${orgName}/${project.name}/settings`}>
                 <Button variant="outline" size="sm">
                   <RiSettings3Line className="mr-2 h-4 w-4" />
                   Settings
                 </Button>
               </Link>
-              <Link href={`/orga/${orgName}/${project.name}/new`}>
+              <Link href={`/${orgName}/${project.name}/new`}>
                 <Button size="sm">
                   <RiAddLine className="mr-2 h-4 w-4" />
                   Add Resource

--- a/src/components/common/Breadcrumbs.tsx
+++ b/src/components/common/Breadcrumbs.tsx
@@ -25,7 +25,7 @@ export default function Breadcrumbs({ items }: BreadcrumbsProps) {
 
   return (
     <nav className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
-      <Link href="/orga" className="hover:text-gray-900 dark:hover:text-gray-100">
+      <Link href="/" className="hover:text-gray-900 dark:hover:text-gray-100">
         Home
       </Link>
       {breadcrumbItems.map((item, index) => (
@@ -65,33 +65,34 @@ function generateBreadcrumbsFromPath(pathname: string): BreadcrumbItem[] {
     return breadcrumbs;
   }
 
-  // Pattern: /orga/orgaName/projectName/resourceName
-  if (segments[0] !== 'orga' || !segments[1]) {
+  const KNOWN_PREFIXES = new Set(['account', 'admin', 'api', 'orga', '_next', 'assets']);
+
+  // Legacy pattern: /orga/orgaName/...
+  if (segments[0] === 'orga' && segments[1]) {
+    const orgaName = segments[1];
+    breadcrumbs.push({ label: orgaName, href: `/${orgaName}` });
+    if (segments[2]) {
+      const projectName = segments[2];
+      breadcrumbs.push({ label: projectName, href: `/${orgaName}/${projectName}` });
+      if (segments[3]) {
+        breadcrumbs.push({ label: segments[3] });
+      }
+    }
     return breadcrumbs;
   }
 
-  const orgaName = segments[1];
-
-  breadcrumbs.push({
-    label: orgaName,
-    href: `/orga/${orgaName}`
-  });
-
-  // Pattern: /orga/orgaName/projectName/...
-  if (segments[2]) {
-    const projectName = segments[2];
-    breadcrumbs.push({
-      label: projectName,
-      href: `/orga/${orgaName}/${projectName}`
-    });
-
-    // Pattern: /orga/orgaName/projectName/resourceName
-    if (segments[3]) {
-      const resourceName = segments[3];
-      breadcrumbs.push({
-        label: resourceName
-      });
+  // Flat namespace pattern: /orgSlug/projectName/...
+  if (segments[0] && !KNOWN_PREFIXES.has(segments[0])) {
+    const orgaName = segments[0];
+    breadcrumbs.push({ label: orgaName, href: `/${orgaName}` });
+    if (segments[1]) {
+      const projectName = segments[1];
+      breadcrumbs.push({ label: projectName, href: `/${orgaName}/${projectName}` });
+      if (segments[2]) {
+        breadcrumbs.push({ label: segments[2] });
+      }
     }
+    return breadcrumbs;
   }
 
   return breadcrumbs;

--- a/src/components/dashboard/OrganisationDashboard.tsx
+++ b/src/components/dashboard/OrganisationDashboard.tsx
@@ -241,7 +241,7 @@ export default function OrganisationDashboard({ user }: { user: any }) {
 
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                 {organisationData.projects.slice(0, 3).map((project) => (
-                  <Link key={project.id} href={`/orga/${organisation.name}`} className="group">
+                  <Link key={project.id} href={`/${organisation.name}`} className="group">
                     <div className="p-5 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-brand-300 dark:hover:border-brand-600 hover:shadow-md transition-all duration-200">
                       <div className="flex items-center gap-3 mb-3">
                         <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">

--- a/src/components/form/AddTeamMemberForm.tsx
+++ b/src/components/form/AddTeamMemberForm.tsx
@@ -38,7 +38,7 @@ export default function AddTeamMemberForm({
   useEffect(() => {
     if (state?.success) {
       const timer = setTimeout(() => {
-        router.push(`/orga/${organisationName}/teams/${teamName}`);
+        router.push(`/${organisationName}/teams/${teamName}`);
       }, 800);
       return () => clearTimeout(timer);
     }
@@ -91,7 +91,7 @@ export default function AddTeamMemberForm({
             <Button
               type="button"
               variant="light"
-              onClick={() => router.push(`/orga/${organisationName}/teams/${teamName}`)}
+              onClick={() => router.push(`/${organisationName}/teams/${teamName}`)}
               disabled={pending}
             >
               Cancel

--- a/src/components/form/CreateResourceForm.tsx
+++ b/src/components/form/CreateResourceForm.tsx
@@ -86,13 +86,11 @@ export default function CreateResourceForm({ currentUserId, projectId, projectNa
       setTimeout(() => {
         if (projectId && projectName && resourceName) {
           // Redirect to resource page if created from project context
-          router.push(`/orga/${organisationName}/${projectName}/${resourceName}`);
+          router.push(`/${organisationName}/${projectName}/${resourceName}`);
         } else if (projectId && projectName) {
-          // Redirect to project page if no resource name
-          router.push(`/orga/${organisationName}/${projectName}`);
+          router.push(`/${organisationName}/${projectName}`);
         } else {
-          // Redirect to organisation page if no project context
-          router.push(`/orga/${organisationName}`);
+          router.push(`/${organisationName}`);
         }
         router.refresh();
       }, 1500);

--- a/src/components/form/CreateTeamForm.tsx
+++ b/src/components/form/CreateTeamForm.tsx
@@ -33,7 +33,7 @@ export default function CreateTeamForm({ organisationId, organisationName }: Cre
   useEffect(() => {
     if (state?.success && state?.teamName) {
       const timer = setTimeout(() => {
-        router.push(`/orga/${organisationName}/teams/${state.teamName}`);
+        router.push(`/${organisationName}/teams/${state.teamName}`);
       }, 800);
       return () => clearTimeout(timer);
     }
@@ -108,7 +108,7 @@ export default function CreateTeamForm({ organisationId, organisationName }: Cre
           <Button
             type="button"
             variant="light"
-            onClick={() => router.push(`/orga/${organisationName}/teams`)}
+            onClick={() => router.push(`/${organisationName}/teams`)}
             disabled={pending}
           >
             Cancel

--- a/src/components/form/GrantProjectAccessForm.tsx
+++ b/src/components/form/GrantProjectAccessForm.tsx
@@ -38,7 +38,7 @@ export default function GrantProjectAccessForm({
   useEffect(() => {
     if (state?.success) {
       const timer = setTimeout(() => {
-        router.push(`/orga/${organisationName}/${projectName}/access`);
+        router.push(`/${organisationName}/${projectName}/access`);
       }, 800);
       return () => clearTimeout(timer);
     }
@@ -109,7 +109,7 @@ export default function GrantProjectAccessForm({
             <Button
               type="button"
               variant="light"
-              onClick={() => router.push(`/orga/${organisationName}/${projectName}/access`)}
+              onClick={() => router.push(`/${organisationName}/${projectName}/access`)}
               disabled={pending}
             >
               Cancel

--- a/src/components/form/InviteMemberForm.tsx
+++ b/src/components/form/InviteMemberForm.tsx
@@ -33,7 +33,7 @@ export default function InviteMemberForm({ organisationId, organisationName }: I
   useEffect(() => {
     if (state?.success) {
       const timer = setTimeout(() => {
-        router.push(`/orga/${organisationName}/members`);
+        router.push(`/${organisationName}/members`);
       }, 1200);
       return () => clearTimeout(timer);
     }
@@ -100,7 +100,7 @@ export default function InviteMemberForm({ organisationId, organisationName }: I
           <Button
             type="button"
             variant="light"
-            onClick={() => router.push(`/orga/${organisationName}/members`)}
+            onClick={() => router.push(`/${organisationName}/members`)}
             disabled={pending}
           >
             Cancel

--- a/src/components/invitation/AcceptInvitationButton.tsx
+++ b/src/components/invitation/AcceptInvitationButton.tsx
@@ -23,7 +23,7 @@ export default function AcceptInvitationButton({ token, organisationName }: Acce
         setError(result.error || 'Failed to accept invitation.');
         return;
       }
-      router.push(`/orga/${result.organisationName || organisationName}`);
+      router.push(`/${result.organisationName || organisationName}`);
       router.refresh();
     });
   };

--- a/src/components/navigation/CommandPalette.tsx
+++ b/src/components/navigation/CommandPalette.tsx
@@ -243,7 +243,7 @@ export default function CommandPalette() {
           setQuery('');
         } else if (selected.type === 'resource') {
           // Navigate to resource
-          router.push(`/orga/${selected.organisationName}/${selected.projectName}/${selected.name}`);
+          router.push(`/${selected.organisationName}/${selected.projectName}/${selected.name}`);
           close();
         }
       }
@@ -398,7 +398,7 @@ export default function CommandPalette() {
                           setCurrentLevel('resources');
                           setQuery('');
                         } else if (item.type === 'resource') {
-                          router.push(`/orga/${item.organisationName}/${item.projectName}/${item.name}`);
+                          router.push(`/${item.organisationName}/${item.projectName}/${item.name}`);
                           close();
                         }
                       }}

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -57,11 +57,15 @@ export default function MobileNavigation({ user, organisations: initialOrganisat
   const pathname = usePathname();
   const { open } = useCommandPalette();
 
-  // Get organisation name from pathname
   const getOrganisationName = () => {
     const pathSegments = pathname.split('/');
     if (pathSegments[1] === 'orga' && pathSegments[2]) {
       return pathSegments[2];
+    }
+    if (pathSegments[1] && pathSegments[1] !== 'account' && pathSegments[1] !== 'admin' && pathSegments[1] !== 'api') {
+      const candidate = pathSegments[1];
+      const match = initialOrganisations.find(org => org.name === candidate);
+      if (match) return candidate;
     }
     return null;
   };
@@ -78,9 +82,6 @@ export default function MobileNavigation({ user, organisations: initialOrganisat
   const projects = organisation?.projects || [];
 
   const isActivePath = (href: string) => {
-    if (href === '/orga') {
-      return pathname === '/orga' && organisationId;
-    }
     return pathname.startsWith(href);
   };
 
@@ -162,7 +163,7 @@ export default function MobileNavigation({ user, organisations: initialOrganisat
                         return (
                           <Link
                             key={org.id}
-                            href={`/orga/${org.name}`}
+                            href={`/${org.name}`}
                             onClick={handleLinkClick}
                             className={`
                               block p-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors border-l-4
@@ -254,26 +255,26 @@ export default function MobileNavigation({ user, organisations: initialOrganisat
                       {
                         name: 'Projects',
                         icon: RiProjectorLine,
-                        href: `/orga/${organisationName}`,
-                        active: pathname === `/orga/${organisationName}`
+                        href: `/${organisationName}`,
+                        active: pathname === `/${organisationName}`
                       },
                       {
                         name: 'Members',
                         icon: RiUserLine,
-                        href: `/orga/${organisationName}/members`,
-                        active: pathname.startsWith(`/orga/${organisationName}/members`)
+                        href: `/${organisationName}/members`,
+                        active: pathname.startsWith(`/${organisationName}/members`)
                       },
                       {
                         name: 'Roles',
                         icon: RiShieldLine,
-                        href: `/orga/${organisationName}/roles`,
-                        active: pathname.startsWith(`/orga/${organisationName}/roles`)
+                        href: `/${organisationName}/roles`,
+                        active: pathname.startsWith(`/${organisationName}/roles`)
                       },
                       {
                         name: 'Settings',
                         icon: RiSettings3Line,
-                        href: `/orga/${organisationName}/settings`,
-                        active: pathname.startsWith(`/orga/${organisationName}/settings`)
+                        href: `/${organisationName}/settings`,
+                        active: pathname.startsWith(`/${organisationName}/settings`)
                       },
                     ].map((item) => (
                       <Link

--- a/src/components/navigation/OrganisationSecondaryNav.tsx
+++ b/src/components/navigation/OrganisationSecondaryNav.tsx
@@ -10,17 +10,17 @@ export default function OrganisationSecondaryNav({ orgName }: { orgName: string 
   const tabs = [
     {
       name: 'Projects',
-      href: `/orga/${orgName}/projects`,
+      href: `/${orgName}/projects`,
       icon: RiProjectorLine,
     },
     {
       name: 'Members',
-      href: `/orga/${orgName}/members`,
+      href: `/${orgName}/members`,
       icon: RiUserLine,
     },
     {
       name: 'Roles',
-      href: `/orga/${orgName}/roles`,
+      href: `/${orgName}/roles`,
       icon: RiShieldLine,
     },
   ];

--- a/src/components/navigation/SidebarNavigation.tsx
+++ b/src/components/navigation/SidebarNavigation.tsx
@@ -54,14 +54,16 @@ export default function SidebarNavigation({
 
   const [showOrgDropdown, setShowOrgDropdown] = useState(false);
 
-  // Get organisation name from pathname
   const getOrganisationName = () => {
-    // Check if we're on an organisation tree page (/orga/[name]/...)
     const pathSegments = pathname.split('/');
     if (pathSegments[1] === 'orga' && pathSegments[2]) {
       return pathSegments[2];
     }
-
+    if (pathSegments[1] && pathSegments[1] !== 'account' && pathSegments[1] !== 'admin' && pathSegments[1] !== 'api') {
+      const candidate = pathSegments[1];
+      const match = initialOrganisations.find(org => org.name === candidate);
+      if (match) return candidate;
+    }
     return null;
   };
 
@@ -140,7 +142,7 @@ export default function SidebarNavigation({
                     return (
                       <Link
                         key={org.id}
-                        href={`/orga/${org.name}`}
+                        href={`/${org.name}`}
                         onClick={() => setShowOrgDropdown(false)}
                         className={`
                           block p-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors border-l-4
@@ -232,26 +234,26 @@ export default function SidebarNavigation({
                   {
                     name: 'Projects',
                     icon: RiProjectorLine,
-                    href: `/orga/${organisationName}`,
-                    active: pathname === `/orga/${organisationName}`
+                    href: `/${organisationName}`,
+                    active: pathname === `/${organisationName}`
                   },
                   {
                     name: 'Members',
                     icon: RiUserLine,
-                    href: `/orga/${organisationName}/members`,
-                    active: pathname.startsWith(`/orga/${organisationName}/members`)
+                    href: `/${organisationName}/members`,
+                    active: pathname.startsWith(`/${organisationName}/members`)
                   },
                   {
                     name: 'Roles',
                     icon: RiShieldLine,
-                    href: `/orga/${organisationName}/roles`,
-                    active: pathname.startsWith(`/orga/${organisationName}/roles`)
+                    href: `/${organisationName}/roles`,
+                    active: pathname.startsWith(`/${organisationName}/roles`)
                   },
                   {
                     name: 'Settings',
                     icon: RiSettings3Line,
-                    href: `/orga/${organisationName}/settings`,
-                    active: pathname.startsWith(`/orga/${organisationName}/settings`)
+                    href: `/${organisationName}/settings`,
+                    active: pathname.startsWith(`/${organisationName}/settings`)
                   },
                 ].map((item) => (
                   <Link

--- a/src/components/project/EnhancedProjectGrid.tsx
+++ b/src/components/project/EnhancedProjectGrid.tsx
@@ -255,12 +255,12 @@ export default function EnhancedProjectGrid({ projects, selectedTeamName }: Enha
 
                     {/* Action buttons */}
                     <div className="flex gap-2">
-                      <Link href={`/orga/${organisation.name}`} className="flex-1">
+                      <Link href={`/${organisation.name}`} className="flex-1">
                         <Button variant="outline" size="sm" className="text-xs px-3 py-1 w-full">
                           View Details
                         </Button>
                       </Link>
-                      <Link href={`/orga/${organisation.name}/add-resource`}>
+                      <Link href={`/${organisation.name}/add-resource`}>
                         <Button size="sm" className="text-xs px-3 py-1">
                           <RiAddLine className="mr-1 h-3 w-3" />
                           Add Resource
@@ -296,12 +296,12 @@ export default function EnhancedProjectGrid({ projects, selectedTeamName }: Enha
 
                   {/* Actions */}
                   <div className="flex gap-2 flex-shrink-0">
-                    <Link href={`/orga/${organisation.name}`}>
+                    <Link href={`/${organisation.name}`}>
                       <Button variant="outline" size="sm" className="text-xs px-3 py-1">
                         View
                       </Button>
                     </Link>
-                    <Link href={`/orga/${organisation.name}/add-resource`}>
+                    <Link href={`/${organisation.name}/add-resource`}>
                       <Button size="sm" className="text-xs px-3 py-1">
                         <RiAddLine className="h-3 w-3" />
                       </Button>

--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -75,7 +75,7 @@ export default function ProjectCard({ project, organisationName }: ProjectCardPr
 
   return (
     <Link
-      href={`/orga/${organisationName}/${project.name}`}
+      href={`/${organisationName}/${project.name}`}
       className="block"
     >
       <Card className="p-6 hover:shadow-lg transition-shadow h-full">

--- a/src/components/project/ProjectResources.tsx
+++ b/src/components/project/ProjectResources.tsx
@@ -134,7 +134,7 @@ export default function ProjectResources({ resources, projectId, orgName, projec
         return (
           <Link
             key={allocation.id}
-            href={`/orga/${orgName}/${projectName}/${resource.name}`}
+            href={`/${orgName}/${projectName}/${resource.name}`}
             className="block group"
           >
             <Card className="p-6 hover:shadow-md transition-shadow">

--- a/src/components/resource/ResourceWizard.tsx
+++ b/src/components/resource/ResourceWizard.tsx
@@ -87,9 +87,9 @@ export default function ResourceWizard({
     if (state.success) {
       setTimeout(() => {
         if (projectId && organisationName) {
-          router.push(`/orga/${organisationName}/${projectId}`);
+          router.push(`/${organisationName}/${projectId}`);
         } else if (organisationName) {
-          router.push(`/orga/${organisationName}/projects`);
+          router.push(`/${organisationName}/projects`);
         } else {
           router.push('/main/resources');
         }

--- a/src/components/table/OrganisationResources.tsx
+++ b/src/components/table/OrganisationResources.tsx
@@ -85,7 +85,7 @@ export default function OrganisationResources({ resources, orgName, canManage }:
           Create your first resource to get started.
         </p>
         {canManage && (
-          <Link href={`/orga/${orgName}/resources/new`}>
+          <Link href={`/${orgName}/resources/new`}>
             <Button>Create Resource</Button>
           </Link>
         )}
@@ -115,7 +115,7 @@ export default function OrganisationResources({ resources, orgName, canManage }:
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-3 mb-2">
                     <Link
-                      href={`/orga/${orgName}/resources/${resource.id}`}
+                      href={`/${orgName}/resources/${resource.id}`}
                       className="text-lg font-semibold text-gray-900 dark:text-white hover:text-brand-600 dark:hover:text-brand-400 transition-colours"
                     >
                       {resource.name}
@@ -204,7 +204,7 @@ export default function OrganisationResources({ resources, orgName, canManage }:
               {/* Actions */}
               {canManage && (
                 <div className="flex items-center gap-2 ml-4">
-                  <Link href={`/orga/${orgName}/resources/${resource.id}`}>
+                  <Link href={`/${orgName}/resources/${resource.id}`}>
                     <Button variant="outline" size="sm">
                       <RiEyeLine className="h-4 w-4" />
                     </Button>

--- a/src/components/table/Resource.tsx
+++ b/src/components/table/Resource.tsx
@@ -203,10 +203,10 @@ const columns: ColumnDef<ResourceWithDetails>[] = [
 
       const orgId = row.original.organisationId;
       const resourceViewUrl = orgId
-        ? `/orga/${organisation.name}`
+        ? `/${organisation.name}`
         : `/main/resources/${row.original.id}`;
       const resourceEditUrl = orgId
-        ? `/orga/${organisation.name}/edit`
+        ? `/${organisation.name}/edit`
         : `/main/resources/${row.original.id}/edit`;
 
       return (

--- a/src/components/team/DeleteTeamButton.tsx
+++ b/src/components/team/DeleteTeamButton.tsx
@@ -15,7 +15,7 @@ interface DeleteTeamButtonProps {
 
 export default function DeleteTeamButton({ teamId, teamName, organisationName }: DeleteTeamButtonProps) {
   const { isLoading, error, executeAction } = useConfirmAction({
-    redirectTo: `/orga/${organisationName}/teams`,
+    redirectTo: `/${organisationName}/teams`,
   });
 
   const handleDelete = async () => {

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -16,7 +16,7 @@ export default {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
 
-      const publicPaths = ['/', '/signin', '/register', '/api/auth', '/api/email'];
+      const publicPaths = ['/', '/signin', '/register', '/accept-invite', '/api/auth', '/api/email'];
       const isPublic = publicPaths.some(p =>
         nextUrl.pathname === p || nextUrl.pathname.startsWith(p + '/')
       );

--- a/src/lib/seed-namespaces.ts
+++ b/src/lib/seed-namespaces.ts
@@ -1,0 +1,50 @@
+import { getStoreAsync } from '@/lib/store';
+
+export async function seedNamespaces(): Promise<{ registered: number; skipped: number; errors: string[] }> {
+  const store = await getStoreAsync();
+  let registered = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  const allOrgs = await store.organisations.search('', 10000);
+  for (const org of allOrgs) {
+    const slug = org.slug || org.name.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    try {
+      const existing = await store.namespaces.findBySlug(slug);
+      if (existing) {
+        skipped++;
+        continue;
+      }
+      await store.namespaces.register({
+        slug,
+        entityType: 'ORGANISATION',
+        entityId: org.id,
+      });
+      registered++;
+    } catch (e: unknown) {
+      errors.push(`Org "${org.name}": ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  const allUsers = await store.users.findMany({ take: 10000 });
+  for (const user of allUsers) {
+    const slug = user.slug || user.email.split('@')[0].toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    try {
+      const existing = await store.namespaces.findBySlug(slug);
+      if (existing) {
+        skipped++;
+        continue;
+      }
+      await store.namespaces.register({
+        slug,
+        entityType: 'USER',
+        entityId: user.id,
+      });
+      registered++;
+    } catch (e: unknown) {
+      errors.push(`User "${user.email}": ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return { registered, skipped, errors };
+}

--- a/src/lib/services/organisation.ts
+++ b/src/lib/services/organisation.ts
@@ -25,6 +25,11 @@ export class OrganisationService {
         defaultProjectRole: 'DEVELOPER',
       });
 
+      try {
+        const orgSlug = organisation.slug || organisation.name.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+        await store.namespaces.register({ slug: orgSlug, entityType: 'ORGANISATION', entityId: organisation.id });
+      } catch {}
+
       return { ...organisation, memberCount: 1 };
     } catch (error) {
       console.error('Failed to create organisation:', error);


### PR DESCRIPTION
## Summary

Flat namespace routing. `enopax.com/Enopax/platform` replaces `enopax.com/orga/Enopax/platform`. Builds on Phase 1A (#65) + 1B (#66).

### What changed

**Namespace resolver** — new \`/{slug}/layout.tsx\`:
- Resolves slug via Namespace table → renders Org or User page
- Backward compat: also tries \`store.organisations.findByName(slug)\` for orgs not yet in namespace table
- USER slugs render a placeholder profile page

**Route migration** — 21 org sub-route files copied from \`/orga/[orgaName]/\` to \`/[slug]/\`:
- members, teams, settings, roles, projects, resources — all work at flat URLs
- Param name \`orgaName\` → \`slug\` throughout

**Namespace seeding:**
- \`src/lib/seed-namespaces.ts\` — one-time migration function
- \`/api/admin/seed-namespaces\` — POST endpoint (ADMIN-only)
- Auto-register on user registration + org creation

**Navigation** — 22 component files updated:
- All \`/orga/\${name}/...\` links → \`/\${name}/...\`
- Sidebar detects current org from flat URL path
- Breadcrumbs handle both old and new URL patterns

**Old routes preserved** — \`/orga/[orgaName]/\` still works (not deleted, not redirected). Bookmarks don't break.

### Stats
- 4 commits, 53 files, ~2400 lines
- 261 tests green
- Old routes untouched (backward compat)

## Test plan
- [ ] After deploy + namespace seed: \`/Enopax\` shows org overview
- [ ] \`/Enopax/teams\` shows team list
- [ ] \`/Enopax/platform/access\` shows project access
- [ ] Old URL \`/orga/Enopax\` still works
- [ ] Navigation links use flat URLs
- [ ] Sidebar correctly detects current org from flat path