### PR TITLE
feat: Phase 1.5 — Cross-org project sharing

### DIFF
--- a/src/actions/project-share.ts
+++ b/src/actions/project-share.ts
@@ -1,0 +1,228 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import type { SharePermission } from '@/lib/store';
+
+const VALID_PERMISSIONS: SharePermission[] = ['VIEW', 'CONTRIBUTE', 'MANAGE'];
+
+export interface ShareProjectState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { slug?: string; permission?: string };
+}
+
+export interface UpdateSharePermissionState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { permission?: string };
+}
+
+export async function shareProject(
+  projectId: string,
+  prevState: ShareProjectState,
+  formData: FormData
+): Promise<ShareProjectState> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { error: 'Authentication required' };
+    }
+
+    const slug = (formData.get('slug') as string)?.trim();
+    const permission = formData.get('permission') as string;
+
+    if (!slug) {
+      return {
+        error: 'Organisation or user name is required',
+        fieldErrors: { slug: 'Organisation or user name is required' },
+      };
+    }
+
+    if (!permission || !VALID_PERMISSIONS.includes(permission as SharePermission)) {
+      return {
+        error: 'Permission must be one of VIEW, CONTRIBUTE, MANAGE',
+        fieldErrors: { permission: 'Must be VIEW, CONTRIBUTE, or MANAGE' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const project = await store.projects.findById(projectId);
+    if (!project) {
+      return { error: 'Project not found' };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(
+      session.user.id,
+      project.organisationId
+    );
+    const isOrgAdmin =
+      session.user.role === 'ADMIN' ||
+      (orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role));
+
+    if (!isOrgAdmin) {
+      return { error: 'You do not have permission to share this project' };
+    }
+
+    let namespace = await store.namespaces.findBySlug(slug);
+
+    if (!namespace) {
+      const orgByName = await store.organisations.findByName(slug);
+      if (orgByName) {
+        namespace = await store.namespaces.findByEntity('ORGANISATION', orgByName.id);
+      }
+    }
+
+    if (!namespace) {
+      return {
+        error: 'No user or organisation found with this name',
+        fieldErrors: { slug: 'No user or organisation found with this name' },
+      };
+    }
+
+    const hostOrg = await store.organisations.findById(project.organisationId);
+    if (
+      namespace.entityType === 'ORGANISATION' &&
+      namespace.entityId === project.organisationId
+    ) {
+      return {
+        error: `You cannot share a project with its own organisation`,
+        fieldErrors: { slug: 'Cannot share with the host organisation' },
+      };
+    }
+
+    const existing = await store.projectShares.findByProjectAndEntity(
+      projectId,
+      namespace.entityType as 'USER' | 'ORGANISATION',
+      namespace.entityId
+    );
+    if (existing) {
+      return {
+        error: 'This project is already shared with that organisation or user',
+        fieldErrors: { slug: 'Already shared with this entity' },
+      };
+    }
+
+    await store.projectShares.create({
+      projectId,
+      sharedWithType: namespace.entityType as 'USER' | 'ORGANISATION',
+      sharedWithId: namespace.entityId,
+      permission: permission as SharePermission,
+      sharedBy: session.user.id,
+    });
+
+    const org = await store.organisations.findById(project.organisationId);
+    if (org) {
+      revalidatePath(`/${org.name}/${project.name}/share`);
+    }
+
+    return { success: true };
+  } catch {
+    return { error: 'Failed to share project. Please try again.' };
+  }
+}
+
+export async function updateSharePermission(
+  shareId: string,
+  prevState: UpdateSharePermissionState,
+  formData: FormData
+): Promise<UpdateSharePermissionState> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { error: 'Authentication required' };
+    }
+
+    const permission = formData.get('permission') as string;
+
+    if (!permission || !VALID_PERMISSIONS.includes(permission as SharePermission)) {
+      return {
+        error: 'Permission must be one of VIEW, CONTRIBUTE, MANAGE',
+        fieldErrors: { permission: 'Must be VIEW, CONTRIBUTE, or MANAGE' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const share = await store.projectShares.findById(shareId);
+    if (!share) {
+      return { error: 'Share record not found' };
+    }
+
+    const project = await store.projects.findById(share.projectId);
+    if (!project) {
+      return { error: 'Project not found' };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(
+      session.user.id,
+      project.organisationId
+    );
+    const isOrgAdmin =
+      session.user.role === 'ADMIN' ||
+      (orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role));
+
+    if (!isOrgAdmin) {
+      return { error: 'You do not have permission to update this share' };
+    }
+
+    await store.projectShares.updatePermission(shareId, permission as SharePermission);
+
+    const org = await store.organisations.findById(project.organisationId);
+    if (org) {
+      revalidatePath(`/${org.name}/${project.name}/share`);
+    }
+
+    return { success: true };
+  } catch {
+    return { error: 'Failed to update share permission. Please try again.' };
+  }
+}
+
+export async function revokeShare(
+  shareId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const store = await getStoreAsync();
+
+    const share = await store.projectShares.findById(shareId);
+    if (!share) {
+      return { success: false, error: 'Share record not found' };
+    }
+
+    const project = await store.projects.findById(share.projectId);
+    if (!project) {
+      return { success: false, error: 'Project not found' };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(
+      session.user.id,
+      project.organisationId
+    );
+    const isOrgAdmin =
+      session.user.role === 'ADMIN' ||
+      (orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role));
+
+    if (!isOrgAdmin) {
+      return { success: false, error: 'You do not have permission to revoke this share' };
+    }
+
+    await store.projectShares.revoke(shareId);
+
+    const org = await store.organisations.findById(project.organisationId);
+    if (org) {
+      revalidatePath(`/${org.name}/${project.name}/share`);
+    }
+
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Failed to revoke share. Please try again.' };
+  }
+}

--- a/src/app/(main)/[slug]/[projectName]/access/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/page.tsx
@@ -7,7 +7,7 @@ import { Card } from '@/components/common/Card';
 import { Badge } from '@/components/common/Badge';
 import { Button } from '@/components/common/Button';
 import { Callout } from '@/components/common/Callout';
-import { RiAddLine, RiTeamLine, RiInformationLine } from '@remixicon/react';
+import { RiAddLine, RiTeamLine, RiInformationLine, RiShareLine } from '@remixicon/react';
 import RevokeAccessButton from '@/components/team/RevokeAccessButton';
 import ChangeAccessRoleForm from '@/components/team/ChangeAccessRoleForm';
 
@@ -70,14 +70,22 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
             Manage which teams can access {projectName}
           </p>
         </div>
-        {availableTeams.length > 0 && (
-          <Link href={`/${slug}/${projectName}/access/add`}>
-            <Button>
-              <RiAddLine className="w-4 h-4 mr-1" />
-              Add Team
+        <div className="flex items-center gap-3">
+          <Link href={`/${slug}/${projectName}/share`}>
+            <Button variant="light">
+              <RiShareLine className="w-4 h-4 mr-1" />
+              Share with external
             </Button>
           </Link>
-        )}
+          {availableTeams.length > 0 && (
+            <Link href={`/${slug}/${projectName}/access/add`}>
+              <Button>
+                <RiAddLine className="w-4 h-4 mr-1" />
+                Add Team
+              </Button>
+            </Link>
+          )}
+        </div>
       </div>
 
       <Callout variant="default" title="Inherited access" icon={RiInformationLine} className="mb-6">

--- a/src/app/(main)/[slug]/[projectName]/share/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/share/page.tsx
@@ -1,0 +1,136 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Callout } from '@/components/common/Callout';
+import { RiShareLine, RiInformationLine, RiBuildingLine, RiUserLine } from '@remixicon/react';
+import ShareProjectForm from '@/components/form/ShareProjectForm';
+import ChangeSharePermissionForm from '@/components/project/ChangeSharePermissionForm';
+import RevokeShareButton from '@/components/project/RevokeShareButton';
+
+interface ProjectSharePageProps {
+  params: Promise<{ slug: string; projectName: string }>;
+}
+
+export default async function ProjectSharePage({ params }: ProjectSharePageProps) {
+  const { slug, projectName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const project = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  if (!project) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOrgAdmin =
+    session.user.role === 'ADMIN' ||
+    (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+
+  if (!isOrgAdmin) {
+    notFound();
+  }
+
+  const shares = await store.projectShares.findByProjectId(project.id);
+
+  const sharesWithNames = await Promise.all(
+    shares.map(async (share) => {
+      let entityName = share.sharedWithId;
+      if (share.sharedWithType === 'ORGANISATION') {
+        const org = await store.organisations.findById(share.sharedWithId);
+        entityName = org?.name ?? share.sharedWithId;
+      } else {
+        const user = await store.users.findById(share.sharedWithId);
+        entityName = user?.name ?? user?.email ?? share.sharedWithId;
+      }
+      return { ...share, entityName };
+    })
+  );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Share Project</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Share {projectName} with external organisations or users
+          </p>
+        </div>
+      </div>
+
+      <Callout variant="default" title="Cross-organisation sharing" icon={RiInformationLine} className="mb-6">
+        Shared organisations or users can access this project based on the permission level you assign.
+        This does not grant membership to your organisation.
+      </Callout>
+
+      <div className="space-y-6">
+        <ShareProjectForm
+          projectId={project.id}
+          organisationName={slug}
+          projectName={projectName}
+        />
+
+        {sharesWithNames.length > 0 && (
+          <Card>
+            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+              <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+                Current shares
+              </h2>
+            </div>
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+              {sharesWithNames.map((share) => (
+                <li
+                  key={share.id}
+                  className="flex items-center justify-between px-6 py-4 flex-wrap gap-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                      {share.sharedWithType === 'ORGANISATION' ? (
+                        <RiBuildingLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                      ) : (
+                        <RiUserLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-semibold text-gray-900 dark:text-white">
+                        {share.entityName}
+                      </p>
+                      <Badge variant="default" className="text-xs">
+                        {share.sharedWithType}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <ChangeSharePermissionForm
+                      shareId={share.id}
+                      currentPermission={share.permission}
+                    />
+                    <RevokeShareButton
+                      shareId={share.id}
+                      entityName={share.entityName}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        {sharesWithNames.length === 0 && (
+          <Card className="p-12 text-center">
+            <RiShareLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+            <p className="text-gray-600 dark:text-gray-400 font-medium">
+              This project has not been shared with anyone yet
+            </p>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/form/ShareProjectForm.tsx
+++ b/src/components/form/ShareProjectForm.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { shareProject, type ShareProjectState } from '@/actions/project-share';
+import { Button } from '@/components/common/Button';
+import { Label } from '@/components/common/Label';
+import { Input } from '@/components/common/Input';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+import { RiErrorWarningFill, RiCheckboxCircleFill } from '@remixicon/react';
+
+const initialState: ShareProjectState = {};
+
+interface ShareProjectFormProps {
+  projectId: string;
+  organisationName: string;
+  projectName: string;
+}
+
+export default function ShareProjectForm({
+  projectId,
+  organisationName,
+  projectName,
+}: ShareProjectFormProps) {
+  const boundAction = shareProject.bind(null, projectId);
+  const [state, formAction, pending] = useActionState(boundAction, initialState);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state?.success) {
+      router.refresh();
+    }
+  }, [state?.success, router]);
+
+  return (
+    <Card className="p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+        Share with another organisation or user
+      </h2>
+
+      {state?.error && !state?.fieldErrors && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningFill} className="mb-4">
+          {state.error}
+        </Callout>
+      )}
+
+      {state?.success && (
+        <Callout variant="success" title="Project shared" icon={RiCheckboxCircleFill} className="mb-4">
+          The project has been shared successfully.
+        </Callout>
+      )}
+
+      <form action={formAction} className="space-y-5">
+        <div>
+          <Label htmlFor="slug">Organisation or user name</Label>
+          <Input
+            id="slug"
+            name="slug"
+            type="text"
+            placeholder="Enter organisation or user name"
+            disabled={pending}
+            className={state?.fieldErrors?.slug ? 'border-red-500' : ''}
+          />
+          {state?.fieldErrors?.slug && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.slug}</p>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="permission">Permission</Label>
+          <Select name="permission" defaultValue="VIEW" disabled={pending}>
+            <SelectTrigger id="permission" className={state?.fieldErrors?.permission ? 'border-red-500' : ''}>
+              <SelectValue placeholder="Select permission" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="VIEW">VIEW</SelectItem>
+              <SelectItem value="CONTRIBUTE">CONTRIBUTE</SelectItem>
+              <SelectItem value="MANAGE">MANAGE</SelectItem>
+            </SelectContent>
+          </Select>
+          {state?.fieldErrors?.permission && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.permission}</p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="light"
+            onClick={() => router.push(`/${organisationName}/${projectName}/access`)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={pending}>
+            {pending ? 'Sharing…' : 'Share project'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/project/ChangeSharePermissionForm.tsx
+++ b/src/components/project/ChangeSharePermissionForm.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useActionState } from 'react';
+import { updateSharePermission, type UpdateSharePermissionState } from '@/actions/project-share';
+import { Button } from '@/components/common/Button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/common/Select';
+
+const initialState: UpdateSharePermissionState = {};
+
+interface ChangeSharePermissionFormProps {
+  shareId: string;
+  currentPermission: string;
+}
+
+export default function ChangeSharePermissionForm({
+  shareId,
+  currentPermission,
+}: ChangeSharePermissionFormProps) {
+  const boundAction = updateSharePermission.bind(null, shareId);
+  const [state, formAction, pending] = useActionState(boundAction, initialState);
+
+  return (
+    <form action={formAction} className="flex items-center gap-2">
+      <Select name="permission" defaultValue={currentPermission} disabled={pending}>
+        <SelectTrigger className="w-36 h-8 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="VIEW">VIEW</SelectItem>
+          <SelectItem value="CONTRIBUTE">CONTRIBUTE</SelectItem>
+          <SelectItem value="MANAGE">MANAGE</SelectItem>
+        </SelectContent>
+      </Select>
+      <Button type="submit" variant="light" className="h-8 text-sm px-3" disabled={pending}>
+        {pending ? 'Saving…' : 'Save'}
+      </Button>
+      {state?.error && (
+        <span className="text-xs text-red-600 dark:text-red-400">{state.error}</span>
+      )}
+      {state?.success && (
+        <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
+      )}
+    </form>
+  );
+}

--- a/src/components/project/RevokeShareButton.tsx
+++ b/src/components/project/RevokeShareButton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { revokeShare } from '@/actions/project-share';
+import { Button } from '@/components/common/Button';
+import { RiDeleteBin7Line } from '@remixicon/react';
+
+interface RevokeShareButtonProps {
+  shareId: string;
+  entityName: string;
+}
+
+export default function RevokeShareButton({ shareId, entityName }: RevokeShareButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleRevoke = async () => {
+    if (!confirm(`Remove sharing with "${entityName}"? This cannot be undone.`)) return;
+    setLoading(true);
+    const result = await revokeShare(shareId);
+    setLoading(false);
+    if (result.success) {
+      router.refresh();
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      className="text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 border-red-300 dark:border-red-700"
+      onClick={handleRevoke}
+      disabled={loading}
+    >
+      <RiDeleteBin7Line className="w-4 h-4 mr-1" />
+      {loading ? 'Removing…' : 'Remove'}
+    </Button>
+  );
+}

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -10,6 +10,7 @@ import type { IInvitationRepository } from './repositories/invitation.repository
 import type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository } from './repositories/user-storage.repository';
 import type { ITeamRepository, ITeamMemberRepository } from './repositories/team.repository';
 import type { IProjectAccessRepository } from './repositories/project-access.repository';
+import type { IProjectShareRepository } from './repositories/project-share.repository';
 import type { INamespaceRepository } from './repositories/namespace.repository';
 import { createStore } from 'tinybase';
 import { FileRecordPersister } from './tinybase/file-record-persister';
@@ -25,6 +26,7 @@ import { TinyBaseInvitationRepository } from './tinybase/invitation.tinybase';
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from './tinybase/user-storage.tinybase';
 import { TinyBaseTeamRepository, TinyBaseTeamMemberRepository } from './tinybase/team.tinybase';
 import { TinyBaseProjectAccessRepository } from './tinybase/project-access.tinybase';
+import { TinyBaseProjectShareRepository } from './tinybase/project-share.tinybase';
 import { TinyBaseNamespaceRepository } from './tinybase/namespace.tinybase';
 import path from 'path';
 
@@ -47,6 +49,7 @@ export interface DataStore {
   teams: ITeamRepository;
   teamMembers: ITeamMemberRepository;
   projectAccess: IProjectAccessRepository;
+  projectShares: IProjectShareRepository;
   destroy(): Promise<void>;
 }
 
@@ -71,6 +74,7 @@ const TABLE_CONFIG = [
   { tableName: 'teams', indexes: [{ name: 'organisationId', cellId: 'organisationId' }] },
   { tableName: 'team-members', indexes: [{ name: 'teamId', cellId: 'teamId' }, { name: 'userId', cellId: 'userId' }] },
   { tableName: 'project-access', indexes: [{ name: 'projectId', cellId: 'projectId' }, { name: 'teamId', cellId: 'teamId' }] },
+  { tableName: 'project-shares', indexes: [{ name: 'projectId', cellId: 'projectId' }, { name: 'sharedWithId', cellId: 'sharedWithId' }] },
 ];
 
 let _store: DataStore | null = null;
@@ -102,6 +106,7 @@ async function createDataStore(): Promise<DataStore> {
     teams: new TinyBaseTeamRepository(tinyStore, persister),
     teamMembers: new TinyBaseTeamMemberRepository(tinyStore, persister),
     projectAccess: new TinyBaseProjectAccessRepository(tinyStore, persister),
+    projectShares: new TinyBaseProjectShareRepository(tinyStore, persister),
     async destroy() {
       await persister.destroy();
     },

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -20,6 +20,8 @@ export type {
   TeamMember,
   Project,
   ProjectAccess,
+  SharePermission,
+  ProjectShare,
   Namespace,
   OrganisationJoinRequest,
   OrganisationInvitation,
@@ -79,6 +81,8 @@ export type {
   AddTeamMemberData,
   IProjectAccessRepository,
   GrantProjectAccessData,
+  IProjectShareRepository,
+  CreateProjectShareData,
   INamespaceRepository,
   RegisterNamespaceData,
 } from './repositories';

--- a/src/lib/store/repositories/index.ts
+++ b/src/lib/store/repositories/index.ts
@@ -10,4 +10,5 @@ export type { IUserFileRepository, CreateUserFileData } from './user-file.reposi
 export type { IUserStorageQuotaRepository, IUserStorageMetricsRepository, IUserStorageActivityRepository, CreateStorageQuotaData, CreateStorageMetricsData, CreateStorageActivityData } from './user-storage.repository';
 export type { ITeamRepository, ITeamMemberRepository, CreateTeamData, UpdateTeamData, AddTeamMemberData } from './team.repository';
 export type { IProjectAccessRepository, GrantProjectAccessData } from './project-access.repository';
+export type { IProjectShareRepository, CreateProjectShareData } from './project-share.repository';
 export type { INamespaceRepository, RegisterNamespaceData } from './namespace.repository';

--- a/src/lib/store/repositories/project-share.repository.ts
+++ b/src/lib/store/repositories/project-share.repository.ts
@@ -1,0 +1,20 @@
+import type { ProjectShare, SharePermission, ProjectOwnerType } from '../types';
+
+export interface CreateProjectShareData {
+  projectId: string;
+  sharedWithType: ProjectOwnerType;
+  sharedWithId: string;
+  permission: SharePermission;
+  sharedBy: string;
+}
+
+export interface IProjectShareRepository {
+  create(data: CreateProjectShareData): Promise<ProjectShare>;
+  findById(id: string): Promise<ProjectShare | null>;
+  findByProjectId(projectId: string): Promise<ProjectShare[]>;
+  findSharedWithEntity(entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare[]>;
+  findByProjectAndEntity(projectId: string, entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare | null>;
+  updatePermission(id: string, permission: SharePermission): Promise<ProjectShare>;
+  revoke(id: string): Promise<void>;
+  revokeAllForProject(projectId: string): Promise<void>;
+}

--- a/src/lib/store/tinybase/project-share.tinybase.ts
+++ b/src/lib/store/tinybase/project-share.tinybase.ts
@@ -1,0 +1,126 @@
+import type { Store } from 'tinybase';
+import type { ProjectShare, SharePermission, ProjectOwnerType } from '../types';
+import type { IProjectShareRepository, CreateProjectShareData } from '../repositories/project-share.repository';
+import type { FileRecordPersister } from './file-record-persister';
+import crypto from 'crypto';
+
+const TABLE = 'project-shares';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToProjectShare(id: string, row: Record<string, any>): ProjectShare {
+  return {
+    id,
+    projectId: row.projectId as string,
+    sharedWithType: row.sharedWithType as ProjectOwnerType,
+    sharedWithId: row.sharedWithId as string,
+    permission: row.permission as SharePermission,
+    sharedBy: row.sharedBy as string,
+    sharedAt: new Date(row.sharedAt as string),
+  };
+}
+
+export class TinyBaseProjectShareRepository implements IProjectShareRepository {
+  constructor(private store: Store, private persister?: FileRecordPersister) {}
+
+  async create(data: CreateProjectShareData): Promise<ProjectShare> {
+    const existing = await this.findByProjectAndEntity(data.projectId, data.sharedWithType, data.sharedWithId);
+    if (existing) throw new Error(`Project ${data.projectId} is already shared with ${data.sharedWithType} ${data.sharedWithId}`);
+
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(TABLE, id, {
+      projectId: data.projectId,
+      sharedWithType: data.sharedWithType,
+      sharedWithId: data.sharedWithId,
+      permission: data.permission,
+      sharedBy: data.sharedBy,
+      sharedAt: now,
+    });
+
+    return rowToProjectShare(id, this.store.getRow(TABLE, id));
+  }
+
+  async findById(id: string): Promise<ProjectShare | null> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.projectId) return null;
+    return rowToProjectShare(id, row);
+  }
+
+  async findByProjectId(projectId: string): Promise<ProjectShare[]> {
+    const results: ProjectShare[] = [];
+
+    const ids = this.persister
+      ? this.persister.lookupIndex(TABLE, 'projectId', projectId)
+      : this.store.getRowIds(TABLE);
+
+    for (const id of ids) {
+      const row = this.store.getRow(TABLE, id);
+      if (!this.persister && row.projectId !== projectId) continue;
+      if (!row.sharedWithId) continue;
+      results.push(rowToProjectShare(id, row));
+    }
+
+    return results;
+  }
+
+  async findSharedWithEntity(entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare[]> {
+    const results: ProjectShare[] = [];
+
+    const ids = this.persister
+      ? this.persister.lookupIndex(TABLE, 'sharedWithId', entityId)
+      : this.store.getRowIds(TABLE);
+
+    for (const id of ids) {
+      const row = this.store.getRow(TABLE, id);
+      if (!this.persister && row.sharedWithId !== entityId) continue;
+      if (row.sharedWithType !== entityType) continue;
+      if (!row.projectId) continue;
+      results.push(rowToProjectShare(id, row));
+    }
+
+    return results;
+  }
+
+  async findByProjectAndEntity(projectId: string, entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare | null> {
+    if (this.persister) {
+      const ids = this.persister.lookupIndex(TABLE, 'projectId', projectId);
+      for (const id of ids) {
+        const row = this.store.getRow(TABLE, id);
+        if (row.sharedWithType === entityType && row.sharedWithId === entityId) return rowToProjectShare(id, row);
+      }
+      return null;
+    }
+
+    for (const id of this.store.getRowIds(TABLE)) {
+      const row = this.store.getRow(TABLE, id);
+      if (row.projectId === projectId && row.sharedWithType === entityType && row.sharedWithId === entityId) {
+        return rowToProjectShare(id, row);
+      }
+    }
+    return null;
+  }
+
+  async updatePermission(id: string, permission: SharePermission): Promise<ProjectShare> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.projectId) throw new Error(`ProjectShare ${id} not found`);
+
+    this.store.setCell(TABLE, id, 'permission', permission);
+
+    return rowToProjectShare(id, this.store.getRow(TABLE, id));
+  }
+
+  async revoke(id: string): Promise<void> {
+    this.store.delRow(TABLE, id);
+  }
+
+  async revokeAllForProject(projectId: string): Promise<void> {
+    const shares = await this.findByProjectId(projectId);
+    for (const share of shares) {
+      this.store.delRow(TABLE, share.id);
+    }
+  }
+}

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -134,6 +134,18 @@ export interface ProjectAccess {
   grantedBy: string;
 }
 
+export type SharePermission = 'VIEW' | 'CONTRIBUTE' | 'MANAGE';
+
+export interface ProjectShare {
+  id: string;
+  projectId: string;
+  sharedWithType: ProjectOwnerType;
+  sharedWithId: string;
+  permission: SharePermission;
+  sharedBy: string;
+  sharedAt: Date;
+}
+
 export interface Namespace {
   id: string;
   slug: string;

--- a/tests/services/helpers.ts
+++ b/tests/services/helpers.ts
@@ -11,6 +11,7 @@ import { TinyBaseUserFileRepository } from '@/lib/store/tinybase/user-file.tinyb
 import { TinyBaseUserStorageQuotaRepository, TinyBaseUserStorageMetricsRepository, TinyBaseUserStorageActivityRepository } from '@/lib/store/tinybase/user-storage.tinybase';
 import { TinyBaseTeamRepository, TinyBaseTeamMemberRepository } from '@/lib/store/tinybase/team.tinybase';
 import { TinyBaseProjectAccessRepository } from '@/lib/store/tinybase/project-access.tinybase';
+import { TinyBaseProjectShareRepository } from '@/lib/store/tinybase/project-share.tinybase';
 import { TinyBaseNamespaceRepository } from '@/lib/store/tinybase/namespace.tinybase';
 import type { DataStore } from '@/lib/store/data-store';
 
@@ -35,6 +36,7 @@ export function createTestStore(): DataStore {
     teams: new TinyBaseTeamRepository(store),
     teamMembers: new TinyBaseTeamMemberRepository(store),
     projectAccess: new TinyBaseProjectAccessRepository(store),
+    projectShares: new TinyBaseProjectShareRepository(store),
     async destroy() {},
   };
 }

--- a/tests/store/tinybase/project-share.tinybase.test.ts
+++ b/tests/store/tinybase/project-share.tinybase.test.ts
@@ -1,0 +1,95 @@
+import { createStore } from 'tinybase';
+import { TinyBaseProjectShareRepository } from '@/lib/store/tinybase/project-share.tinybase';
+
+describe('TinyBaseProjectShareRepository', () => {
+  let repo: TinyBaseProjectShareRepository;
+
+  beforeEach(() => {
+    const store = createStore();
+    repo = new TinyBaseProjectShareRepository(store);
+  });
+
+  it('creates a share and retrieves it by id', async () => {
+    const share = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'VIEW',
+      sharedBy: 'user-admin',
+    });
+
+    expect(share.id).toBeDefined();
+    expect(share.projectId).toBe('proj-1');
+    expect(share.sharedWithType).toBe('ORGANISATION');
+    expect(share.sharedWithId).toBe('org-2');
+    expect(share.permission).toBe('VIEW');
+    expect(share.sharedBy).toBe('user-admin');
+    expect(share.sharedAt).toBeInstanceOf(Date);
+
+    const found = await repo.findById(share.id);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(share.id);
+  });
+
+  it('finds shares by project', async () => {
+    await repo.create({ projectId: 'proj-1', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'VIEW', sharedBy: 'admin' });
+    await repo.create({ projectId: 'proj-1', sharedWithType: 'USER', sharedWithId: 'user-5', permission: 'CONTRIBUTE', sharedBy: 'admin' });
+    await repo.create({ projectId: 'proj-2', sharedWithType: 'ORGANISATION', sharedWithId: 'org-3', permission: 'MANAGE', sharedBy: 'admin' });
+
+    const result = await repo.findByProjectId('proj-1');
+    expect(result).toHaveLength(2);
+  });
+
+  it('finds shares by entity (what is shared with org X)', async () => {
+    await repo.create({ projectId: 'proj-1', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'VIEW', sharedBy: 'admin' });
+    await repo.create({ projectId: 'proj-2', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'CONTRIBUTE', sharedBy: 'admin' });
+    await repo.create({ projectId: 'proj-3', sharedWithType: 'USER', sharedWithId: 'org-2', permission: 'VIEW', sharedBy: 'admin' });
+
+    const result = await repo.findSharedWithEntity('ORGANISATION', 'org-2');
+    expect(result).toHaveLength(2);
+    expect(result.every(s => s.sharedWithType === 'ORGANISATION')).toBe(true);
+  });
+
+  it('prevents duplicate share (same project + same entity)', async () => {
+    await repo.create({ projectId: 'proj-1', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'VIEW', sharedBy: 'admin' });
+
+    await expect(
+      repo.create({ projectId: 'proj-1', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'MANAGE', sharedBy: 'admin' })
+    ).rejects.toThrow('already shared');
+  });
+
+  it('updates permission level', async () => {
+    const share = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'VIEW',
+      sharedBy: 'admin',
+    });
+
+    const updated = await repo.updatePermission(share.id, 'MANAGE');
+
+    expect(updated.id).toBe(share.id);
+    expect(updated.permission).toBe('MANAGE');
+    expect(updated.projectId).toBe('proj-1');
+    expect(updated.sharedWithId).toBe('org-2');
+  });
+
+  it('revokes a share', async () => {
+    const share = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'VIEW',
+      sharedBy: 'admin',
+    });
+
+    await repo.revoke(share.id);
+
+    const found = await repo.findById(share.id);
+    expect(found).toBeNull();
+
+    const shares = await repo.findByProjectId('proj-1');
+    expect(shares).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Cross-org project sharing per spec §6. Share a project with another org or user — they see it with a configurable permission level (VIEW / CONTRIBUTE / MANAGE).

### New entity
- `ProjectShare` (projectId, sharedWithType USER|ORG, sharedWithId, permission, sharedBy, sharedAt)
- 6 repository tests, 267 total passing

### Server actions
- `shareProject(projectId, formData)` — resolve target slug, guard self-share + duplicates, OWNER/ADMIN only
- `updateSharePermission(shareId, formData)` — change VIEW/CONTRIBUTE/MANAGE
- `revokeShare(shareId)` — remove share

### Pages
- `/{slug}/{project}/share` — manage shares (list existing, add new, change permission, revoke)
- "Share with external" button added to project access page

### Not in this PR
- Shared projects appearing in recipient's sidebar/namespace (needs context refactor)
- Invite+accept flow for sharing (later phase)