### PR TITLE
feat(user): username on registration + profile link + display name

### DIFF
--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -4,11 +4,13 @@ import { signIn } from '@/lib/auth';
 import { createDexUser, generateUserIdFromEmail } from '@/lib/dex/client';
 import { getStoreAsync } from '@/lib/store';
 import { createVerificationToken, sendVerificationEmail } from '@/lib/email-verification';
+import { isBlockedName } from '@/lib/name-validation';
 
 export interface RegisterState {
   success?: boolean;
   error?: string;
   fieldErrors?: {
+    username?: string;
     name?: string;
     email?: string;
     password?: string;
@@ -21,15 +23,20 @@ export async function register(
   formData: FormData
 ): Promise<RegisterState> {
   try {
-    const name = (formData.get('name') as string)?.trim();
+    const username = (formData.get('username') as string)?.trim().toLowerCase();
+    const name = (formData.get('name') as string)?.trim() || null;
     const email = (formData.get('email') as string)?.trim().toLowerCase();
     const password = formData.get('password') as string;
     const password2 = formData.get('password2') as string;
 
     const fieldErrors: RegisterState['fieldErrors'] = {};
 
-    if (!name || name.length < 2) {
-      fieldErrors.name = 'Name must be at least 2 characters';
+    if (!username || username.length < 2 || username.length > 39) {
+      fieldErrors.username = 'Username must be between 2 and 39 characters';
+    } else if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(username) && !/^[a-z0-9]$/.test(username)) {
+      fieldErrors.username = 'Username can only contain lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen';
+    } else if (isBlockedName(username)) {
+      fieldErrors.username = 'This username is reserved and cannot be used';
     }
 
     if (!email || !email.includes('@')) {
@@ -48,24 +55,28 @@ export async function register(
       return { error: 'Please fix the errors below', fieldErrors };
     }
 
+    const store = await getStoreAsync();
+
+    const namespaceAvailable = await store.namespaces.isAvailable(username);
+    if (!namespaceAvailable) {
+      return { error: 'Please fix the errors below', fieldErrors: { username: 'Username is taken' } };
+    }
+
     // Create user in Dex
-    await createDexUser(email, password, name);
+    await createDexUser(email, password, name || username);
 
     // Pre-create TinyBase user so we have an ID for the verification token
-    const store = await getStoreAsync();
     let user = await store.users.findByEmail(email);
     if (!user) {
       user = await store.users.create({
         name,
         email,
+        slug: username,
         role: 'CUSTOMER',
       });
     }
 
-    try {
-      const userSlug = user.slug || email.split('@')[0].toLowerCase().replace(/[^a-z0-9-]/g, '-');
-      await store.namespaces.register({ slug: userSlug, entityType: 'USER', entityId: user.id });
-    } catch {}
+    await store.namespaces.register({ slug: username, entityType: 'USER', entityId: user.id });
 
     // Send verification email
     const token = await createVerificationToken(user.id, email);

--- a/src/app/(auth)/register/RegisterForm.tsx
+++ b/src/app/(auth)/register/RegisterForm.tsx
@@ -47,16 +47,34 @@ export default function RegisterForm({ prefilledEmail, inviteToken, organisation
           <form action={formAction} className="space-y-4">
             {inviteToken && <input type="hidden" name="inviteToken" value={inviteToken} />}
             <div>
+              <label htmlFor="username" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Username
+              </label>
+              <input
+                id="username"
+                name="username"
+                type="text"
+                required
+                pattern="[a-z0-9-]+"
+                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="your-username"
+              />
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Lowercase letters, numbers, and hyphens. This is your URL: enopax.com/<strong>username</strong></p>
+              {state.fieldErrors?.username && (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.username}</p>
+              )}
+            </div>
+
+            <div>
               <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Name
+                Display Name <span className="text-gray-400">(optional)</span>
               </label>
               <input
                 id="name"
                 name="name"
                 type="text"
-                required
                 className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="Your name"
+                placeholder="How you want to be known"
               />
               {state.fieldErrors?.name && (
                 <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.name}</p>

--- a/src/components/form/SettingsForm.tsx
+++ b/src/components/form/SettingsForm.tsx
@@ -33,6 +33,21 @@ export default function SettingsForm({
         </Callout>
       )}
 
+      {user.slug && (
+        <div className="space-y-2">
+          <Label htmlFor="slug">Username</Label>
+          <Input
+            id="slug"
+            name="slug"
+            type="text"
+            defaultValue={user.slug}
+            disabled
+            className="bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400 cursor-not-allowed"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400">enopax.com/<strong>{user.slug}</strong></p>
+        </div>
+      )}
+
       <div className="space-y-2">
         <Label htmlFor="firstname">First Name</Label>
         <Input

--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -30,7 +30,7 @@ export default function UserBarMenu({
 
   return (
     <div className="flex items-center gap-2">
-      <Link href="/account/settings" aria-label="Profile settings" className="inline-flex">
+      <Link href={user.slug ? `/${user.slug}` : '/account/settings'} aria-label="My profile" className="inline-flex">
         <Avatar
           name={user.name || user.email}
           image={user.image}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -56,6 +56,7 @@ export const {
           token.sub = dbUser.id;
           token.role = dbUser.role;
           token.name = dbUser.name || `${dbUser.firstname || ''} ${dbUser.lastname || ''}`.trim() || dbUser.email;
+          token.slug = dbUser.slug || '';
           token.image = dbUser.image;
           token.emailVerified = dbUser.emailVerified ? true : false;
         }
@@ -67,6 +68,7 @@ export const {
         session.user.id = token.sub;
         session.user.role = token.role as string;
         session.user.name = token.name as string;
+        session.user.slug = token.slug as string;
         session.user.image = token.image || undefined;
         session.user.emailVerified = token.emailVerified as boolean;
       }

--- a/src/lib/next-auth.d.ts
+++ b/src/lib/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module "next-auth" {
     user: {
       id: string;
       role?: string;
+      slug?: string;
       emailVerified?: boolean;
     } & DefaultSession["user"];
   }
@@ -13,6 +14,7 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     role?: string;
+    slug?: string;
     image?: string | null;
     emailVerified?: boolean;
   }

--- a/src/lib/store/repositories/user.repository.ts
+++ b/src/lib/store/repositories/user.repository.ts
@@ -1,13 +1,14 @@
 import type { User, UserRole } from '../types';
 
 export interface CreateUserData {
-  name?: string;
+  name?: string | null;
   firstname?: string;
   lastname?: string;
   email: string;
   image?: string;
   role?: UserRole;
   password?: string;
+  slug?: string;
 }
 
 export interface UpdateUserData {

--- a/src/lib/store/tinybase/user.tinybase.ts
+++ b/src/lib/store/tinybase/user.tinybase.ts
@@ -45,7 +45,7 @@ export class TinyBaseUserRepository implements IUserRepository {
       password: data.password ?? '',
       role: data.role ?? 'CUSTOMER',
       storageTier: 'FREE_500MB',
-      slug: data.email ? data.email.split('@')[0].toLowerCase().replace(/[^a-z0-9-]/g, '-') : '',
+      slug: data.slug || (data.email ? data.email.split('@')[0].toLowerCase().replace(/[^a-z0-9-]/g, '-') : ''),
       createdAt: now,
       updatedAt: now,
     });

--- a/tests/components/UserBarMenu.test.tsx
+++ b/tests/components/UserBarMenu.test.tsx
@@ -32,6 +32,22 @@ jest.mock('@/lib/auth', () => ({
   signOut: jest.fn(),
 }));
 
+const baseUser = {
+  id: 'user-123',
+  name: 'John Doe' as string | null,
+  email: 'john@example.com',
+  image: null as string | null,
+  role: 'CUSTOMER' as const,
+  firstname: null as string | null,
+  lastname: null as string | null,
+  password: 'hashed',
+  slug: 'john-doe',
+  storageTier: 'FREE_500MB' as const,
+  emailVerified: null as Date | null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
 describe('UserBarMenu Component', () => {
   it('should render Sign In button when user is not provided', () => {
     render(<UserBarMenu />);
@@ -41,158 +57,54 @@ describe('UserBarMenu Component', () => {
   });
 
   it('should render dropdown menu when user is provided', () => {
-    const user = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={user} />);
+    render(<UserBarMenu user={baseUser} />);
 
     expect(screen.getByTestId('dropdown-menu')).toBeInTheDocument();
   });
 
   it('should render user avatar in dropdown trigger', () => {
-    const user = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: 'avatar.png',
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={user} />);
+    render(<UserBarMenu user={{ ...baseUser, image: 'avatar.png' }} />);
 
     expect(screen.getByTestId('avatar')).toBeInTheDocument();
   });
 
   it('should include Organisations link in main menu', () => {
-    const user = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={user} />);
+    render(<UserBarMenu user={baseUser} />);
 
     const orgLink = screen.getByText('Organisations');
     expect(orgLink).toBeInTheDocument();
   });
 
   it('should include Developer link in account menu', () => {
-    const user = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={user} />);
+    render(<UserBarMenu user={baseUser} />);
 
     const developerLink = screen.getByText('Developer');
     expect(developerLink).toBeInTheDocument();
   });
 
   it('should include Settings link in account menu', () => {
-    const user = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={user} />);
+    render(<UserBarMenu user={baseUser} />);
 
     const settingsLink = screen.getByText('Settings');
     expect(settingsLink).toBeInTheDocument();
   });
 
   it('should show admin menu only for admin users', () => {
-    const adminUser = {
-      id: 'user-123',
-      name: 'Admin User',
-      email: 'admin@example.com',
-      image: null,
-      role: 'ADMIN' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={adminUser} />);
+    render(<UserBarMenu user={{ ...baseUser, role: 'ADMIN', name: 'Admin User', email: 'admin@example.com' }} />);
 
     const adminLabel = screen.getByText('Admin');
     expect(adminLabel).toBeInTheDocument();
   });
 
   it('should not show admin menu for non-admin users', () => {
-    const customerUser = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={customerUser} />);
+    render(<UserBarMenu user={baseUser} />);
 
     const adminLabels = screen.queryAllByText('Admin');
     expect(adminLabels.length).toBe(0);
   });
 
   it('should render correct links with href attributes', () => {
-    const user = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={user} />);
+    render(<UserBarMenu user={baseUser} />);
 
     expect(screen.getByText('Organisations').closest('a')).toHaveAttribute('href', '/orga');
     expect(screen.getByText('Developer').closest('a')).toHaveAttribute('href', '/account/developer');
@@ -200,40 +112,28 @@ describe('UserBarMenu Component', () => {
   });
 
   it('should use user name or email for avatar', () => {
-    const userWithName = {
-      id: 'user-123',
-      name: 'John Doe',
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={userWithName} />);
+    render(<UserBarMenu user={baseUser} />);
 
     expect(screen.getByTestId('avatar')).toHaveAttribute('data-name', 'John Doe');
   });
 
   it('should use email when name is not available', () => {
-    const userWithoutName = {
-      id: 'user-123',
-      name: null,
-      email: 'john@example.com',
-      image: null,
-      role: 'CUSTOMER' as const,
-      firstname: null,
-      lastname: null,
-      password: 'hashed',
-      storageTier: 'FREE' as const,
-      createdAt: new Date(),
-    };
-
-    render(<UserBarMenu user={userWithoutName} />);
+    render(<UserBarMenu user={{ ...baseUser, name: null }} />);
 
     expect(screen.getByTestId('avatar')).toHaveAttribute('data-name', 'john@example.com');
+  });
+
+  it('should link avatar to user profile when slug is set', () => {
+    render(<UserBarMenu user={baseUser} />);
+
+    const avatarLink = screen.getByTestId('avatar').closest('a');
+    expect(avatarLink).toHaveAttribute('href', '/john-doe');
+  });
+
+  it('should link avatar to account settings when slug is empty', () => {
+    render(<UserBarMenu user={{ ...baseUser, slug: '' }} />);
+
+    const avatarLink = screen.getByTestId('avatar').closest('a');
+    expect(avatarLink).toHaveAttribute('href', '/account/settings');
   });
 });


### PR DESCRIPTION
## Summary

Users now choose their username (slug) during registration. The avatar in the top bar links to their profile page.

### Changes
- **Register:** new "Username" field (required, validated: 2-39 chars, lowercase+hyphens, blocked names, namespace uniqueness). "Name" → "Display Name (optional)"
- **Session:** slug added to JWT + session, available throughout the app
- **Avatar:** links to \`/{slug}\` (profile) instead of \`/account/settings\`
- **Account Settings:** shows username (read-only) + display name (editable)
- **Namespace:** auto-registered on user creation
- **Types:** NextAuth session extended with \`slug\`

## Test plan
- [ ] Register new user → must choose username → appears as URL slug
- [ ] Avatar → links to \`/username\`
- [ ] Account settings shows read-only username with URL hint
- [ ] Existing users (no slug) → avatar falls back to /account/settings