### PR TITLE
feat: Phase 2 — Custom Project Roles with permission grid

### DIFF
--- a/src/actions/project-role.ts
+++ b/src/actions/project-role.ts
@@ -1,0 +1,198 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import type { ProjectPermission } from '@/lib/store';
+
+export interface RoleState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { name?: string; description?: string };
+}
+
+const ALL_PERMISSIONS: ProjectPermission[] = [
+  'project:view',
+  'project:settings',
+  'resource:view',
+  'resource:create',
+  'resource:edit',
+  'resource:delete',
+  'resource:deploy',
+  'access:view',
+  'access:manage',
+];
+
+async function requireOrgAdminAccess(organisationId: string) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { error: 'Authentication required' as const };
+  }
+
+  const store = await getStoreAsync();
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+
+  const isOrgAdmin = session.user.role === 'ADMIN';
+  const isOwnerOrAdmin = membership?.role === 'OWNER' || membership?.role === 'ADMIN';
+
+  if (!isOrgAdmin && !isOwnerOrAdmin) {
+    return { error: 'You do not have permission to manage roles in this organisation' as const };
+  }
+
+  return { store, session };
+}
+
+function parsePermissions(formData: FormData): ProjectPermission[] {
+  const raw = formData.get('permissions') as string | null;
+  if (raw) {
+    return raw
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p): p is ProjectPermission => ALL_PERMISSIONS.includes(p as ProjectPermission));
+  }
+  return ALL_PERMISSIONS.filter((p) => formData.get(`perm_${p}`) === 'on');
+}
+
+export async function createProjectRole(
+  organisationId: string,
+  prevState: RoleState,
+  formData: FormData
+): Promise<RoleState> {
+  try {
+    const access = await requireOrgAdminAccess(organisationId);
+    if ('error' in access) return { error: access.error };
+
+    const { store } = access;
+    const name = (formData.get('name') as string | null)?.trim() ?? '';
+    const description = (formData.get('description') as string | null)?.trim() ?? '';
+    const rankRaw = formData.get('rank') as string | null;
+    const rank = rankRaw ? parseInt(rankRaw, 10) : 10;
+
+    if (!name || name.length < 2) {
+      return {
+        error: 'Name must be at least 2 characters',
+        fieldErrors: { name: 'Name must be at least 2 characters' },
+      };
+    }
+
+    const existing = await store.projectRoles.findByNameAndOrg(name, organisationId);
+    if (existing) {
+      return {
+        error: 'A role with this name already exists in the organisation',
+        fieldErrors: { name: 'A role with this name already exists' },
+      };
+    }
+
+    const permissions = parsePermissions(formData);
+
+    await store.projectRoles.create({
+      organisationId,
+      name,
+      description,
+      permissions,
+      isBuiltIn: false,
+      rank: isNaN(rank) ? 10 : rank,
+    });
+
+    revalidatePath('/[slug]/roles', 'page');
+
+    return { success: true };
+  } catch {
+    return { error: 'Failed to create role. Please try again.' };
+  }
+}
+
+export async function updateProjectRole(
+  roleId: string,
+  prevState: RoleState,
+  formData: FormData
+): Promise<RoleState> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) return { error: 'Authentication required' };
+
+    const store = await getStoreAsync();
+    const role = await store.projectRoles.findById(roleId);
+    if (!role) return { error: 'Role not found' };
+
+    const access = await requireOrgAdminAccess(role.organisationId);
+    if ('error' in access) return { error: access.error };
+
+    const description = (formData.get('description') as string | null)?.trim() ?? '';
+    const rankRaw = formData.get('rank') as string | null;
+    const rank = rankRaw ? parseInt(rankRaw, 10) : role.rank;
+    const permissions = parsePermissions(formData);
+
+    const updates: { name?: string; description?: string; permissions?: ProjectPermission[]; rank?: number } = {
+      description,
+      permissions,
+      rank: isNaN(rank) ? role.rank : rank,
+    };
+
+    if (!role.isBuiltIn) {
+      const name = (formData.get('name') as string | null)?.trim() ?? '';
+      if (!name || name.length < 2) {
+        return {
+          error: 'Name must be at least 2 characters',
+          fieldErrors: { name: 'Name must be at least 2 characters' },
+        };
+      }
+      const conflicting = await store.projectRoles.findByNameAndOrg(name, role.organisationId);
+      if (conflicting && conflicting.id !== roleId) {
+        return {
+          error: 'A role with this name already exists in the organisation',
+          fieldErrors: { name: 'A role with this name already exists' },
+        };
+      }
+      updates.name = name;
+    }
+
+    await store.projectRoles.update(roleId, updates);
+
+    revalidatePath('/[slug]/roles', 'page');
+
+    return { success: true };
+  } catch {
+    return { error: 'Failed to update role. Please try again.' };
+  }
+}
+
+export async function deleteProjectRole(
+  roleId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) return { success: false, error: 'Authentication required' };
+
+    const store = await getStoreAsync();
+    const role = await store.projectRoles.findById(roleId);
+    if (!role) return { success: false, error: 'Role not found' };
+
+    const access = await requireOrgAdminAccess(role.organisationId);
+    if ('error' in access) return { success: false, error: access.error };
+
+    const projects = await store.projects.findByOrgId(role.organisationId);
+    let usageCount = 0;
+
+    for (const project of projects) {
+      const accesses = await store.projectAccess.findByProjectId(project.id);
+      usageCount += accesses.filter((a) => a.role === role.name).length;
+    }
+
+    if (usageCount > 0) {
+      return {
+        success: false,
+        error: `Role is in use by ${usageCount} project${usageCount === 1 ? '' : 's'}`,
+      };
+    }
+
+    await store.projectRoles.delete(roleId);
+
+    revalidatePath('/[slug]/roles', 'page');
+
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete role. Please try again.';
+    return { success: false, error: message };
+  }
+}

--- a/src/app/(main)/[slug]/roles/[roleId]/page.tsx
+++ b/src/app/(main)/[slug]/roles/[roleId]/page.tsx
@@ -1,0 +1,82 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { updateProjectRole } from '@/actions/project-role';
+import { RoleForm } from '@/components/role/RoleForm';
+import { DeleteRoleButton } from '@/components/role/DeleteRoleButton';
+import { Badge } from '@/components/common/Badge';
+import { RiArrowLeftLine, RiShieldLine } from '@remixicon/react';
+
+interface EditRolePageProps {
+  params: Promise<{ slug: string; roleId: string }>;
+}
+
+export default async function EditRolePage({ params }: EditRolePageProps) {
+  const { slug, roleId } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) notFound();
+  if (!slug || !roleId) notFound();
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const role = await store.projectRoles.findById(roleId);
+  if (!role || role.organisationId !== organisation.id) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  if (!canManage) notFound();
+
+  const boundAction = updateProjectRole.bind(null, roleId);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/${slug}/roles`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to roles
+        </Link>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{role.name}</h1>
+          {role.isBuiltIn && (
+            <Badge variant="default">
+              <RiShieldLine className="w-3 h-3 mr-1" />
+              Built-in
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      <div className="max-w-xl space-y-6">
+        <RoleForm
+          organisationName={slug}
+          organisationId={organisation.id}
+          role={role}
+          action={boundAction}
+        />
+
+        {!role.isBuiltIn && (
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Danger zone</h3>
+            <DeleteRoleButton
+              roleId={role.id}
+              roleName={role.name}
+              organisationName={slug}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/roles/new/page.tsx
+++ b/src/app/(main)/[slug]/roles/new/page.tsx
@@ -1,0 +1,57 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { createProjectRole } from '@/actions/project-role';
+import { RoleForm } from '@/components/role/RoleForm';
+import { RiArrowLeftLine } from '@remixicon/react';
+
+interface NewRolePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function NewRolePage({ params }: NewRolePageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) notFound();
+  if (!slug) notFound();
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
+
+  if (!canManage) notFound();
+
+  const boundAction = createProjectRole.bind(null, organisation.id);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={`/${slug}/roles`}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
+        >
+          <RiArrowLeftLine className="w-4 h-4" />
+          Back to roles
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">New Role</h1>
+      </div>
+
+      <div className="max-w-xl">
+        <RoleForm
+          organisationName={slug}
+          organisationId={organisation.id}
+          action={boundAction}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/roles/page.tsx
+++ b/src/app/(main)/[slug]/roles/page.tsx
@@ -1,7 +1,14 @@
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
-import { RolesManagementClient } from '@/components/RolesManagementClient';
+import { seedBuiltInRoles } from '@/lib/seed-roles';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { Card } from '@/components/common/Card';
+import { PermissionGrid } from '@/components/role/PermissionGrid';
+import { DeleteRoleButton } from '@/components/role/DeleteRoleButton';
+import { RiAddLine, RiEditLine, RiShieldLine } from '@remixicon/react';
 
 interface RolesPageProps {
   params: Promise<{ slug: string }>;
@@ -11,67 +18,95 @@ export default async function RolesPage({ params }: RolesPageProps) {
   const { slug } = await params;
   const session = await auth();
 
-  if (!session?.user?.id) {
-    notFound();
-  }
-
-  if (!slug) {
-    notFound();
-  }
+  if (!session?.user?.id) notFound();
+  if (!slug) notFound();
 
   const store = await getStoreAsync();
-  const orgLookup = await store.organisations.findByName(slug);
-  if (!orgLookup) notFound();
-  const organisationId = orgLookup.id;
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
 
-  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  if (!membership && session.user.role !== 'ADMIN') notFound();
 
-  const isAdmin = session.user.role === 'ADMIN';
-  const isOwner = membership?.role === 'OWNER';
-  const isManager = membership?.role === 'MANAGER';
+  const canManage =
+    session.user.role === 'ADMIN' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'ADMIN';
 
-  if (!membership && !isAdmin) {
-    notFound();
+  let roles = await store.projectRoles.findByOrgId(organisation.id);
+
+  if (roles.length === 0) {
+    await seedBuiltInRoles(organisation.id);
+    roles = await store.projectRoles.findByOrgId(organisation.id);
   }
 
-  const storeMembers = await store.organisationMembers.findByOrgId(organisationId);
-
-  const members = await Promise.all(
-    storeMembers.map(async (m) => {
-      const user = await store.users.findById(m.userId);
-      return {
-        id: m.id,
-        userId: m.userId,
-        organisationId: m.organisationId,
-        role: m.role,
-        joinedAt: m.joinedAt,
-        updatedAt: m.updatedAt,
-        user: {
-          id: m.userId,
-          name: user?.name ?? null,
-          firstname: user?.firstname ?? null,
-          lastname: user?.lastname ?? null,
-          email: user?.email ?? '',
-          image: user?.image ?? null,
-        },
-      };
-    })
-  );
-
-  const roleOrder = { OWNER: 0, MANAGER: 1, MEMBER: 2 };
-  members.sort((a, b) => {
-    const roleCompare = (roleOrder[a.role as keyof typeof roleOrder] ?? 3) - (roleOrder[b.role as keyof typeof roleOrder] ?? 3);
-    if (roleCompare !== 0) return roleCompare;
-    return a.joinedAt.getTime() - b.joinedAt.getTime();
-  });
-
-  if (!members) {
-    notFound();
-  }
+  roles.sort((a, b) => a.rank - b.rank);
 
   return (
-    <RolesManagementClient
-      members={members as { id: string; role: 'OWNER' | 'MANAGER' | 'MEMBER'; joinedAt: Date; updatedAt: Date; user: { id: string; name: string | null; firstname: string | null; lastname: string | null; email: string; image: string | null } }[]}
-    />
+    <div>
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Roles</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Project role definitions for {organisation.name}
+          </p>
+        </div>
+        {canManage && (
+          <Link href={`/${slug}/roles/new`}>
+            <Button variant="primary">
+              <RiAddLine className="w-4 h-4 mr-1" />
+              New role
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        {roles.map((role) => (
+          <Card key={role.id} className="p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                    {role.name}
+                  </h3>
+                  {role.isBuiltIn && (
+                    <Badge variant="default">
+                      <RiShieldLine className="w-3 h-3 mr-1" />
+                      Built-in
+                    </Badge>
+                  )}
+                  <Badge variant="default">Rank {role.rank}</Badge>
+                </div>
+                {role.description && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                    {role.description}
+                  </p>
+                )}
+                <PermissionGrid permissions={role.permissions} readOnly />
+              </div>
+
+              {canManage && (
+                <div className="flex items-center gap-2 shrink-0">
+                  <Link href={`/${slug}/roles/${role.id}`}>
+                    <Button variant="light" className="gap-1">
+                      <RiEditLine className="w-4 h-4" />
+                      Edit
+                    </Button>
+                  </Link>
+                  {!role.isBuiltIn && (
+                    <DeleteRoleButton
+                      roleId={role.id}
+                      roleName={role.name}
+                      organisationName={slug}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/components/role/DeleteRoleButton.tsx
+++ b/src/components/role/DeleteRoleButton.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Button } from '@/components/common/Button';
+import ConfirmDialog from '@/components/common/ConfirmDialog';
+import { Callout } from '@/components/common/Callout';
+import { deleteProjectRole } from '@/actions/project-role';
+import { useConfirmAction } from '@/hooks/useConfirmAction';
+import { RiDeleteBin7Line, RiErrorWarningLine } from '@remixicon/react';
+
+interface DeleteRoleButtonProps {
+  roleId: string;
+  roleName: string;
+  organisationName: string;
+}
+
+export function DeleteRoleButton({ roleId, roleName, organisationName }: DeleteRoleButtonProps) {
+  const { isLoading, error, executeAction } = useConfirmAction({
+    redirectTo: `/${organisationName}/roles`,
+  });
+
+  const handleDelete = async () => {
+    return executeAction(async () => {
+      const result = await deleteProjectRole(roleId);
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      return result;
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningLine}>
+          {error}
+        </Callout>
+      )}
+      <ConfirmDialog
+        trigger={
+          <Button
+            variant="secondary"
+            className="text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 border-red-300 dark:border-red-700"
+          >
+            <RiDeleteBin7Line className="w-4 h-4 mr-1" />
+            Delete role
+          </Button>
+        }
+        title="Delete role"
+        description={`Are you sure you want to delete "${roleName}"?\n\nAny teams currently using this role will lose their access.\n\nThis action cannot be undone.`}
+        confirmText="Delete role"
+        requiredInput="DELETE"
+        onConfirm={handleDelete}
+        isLoading={isLoading}
+        variant="danger"
+      />
+    </div>
+  );
+}

--- a/src/components/role/PermissionGrid.tsx
+++ b/src/components/role/PermissionGrid.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import type { ProjectPermission } from '@/lib/store';
+import { Badge } from '@/components/common/Badge';
+
+export const PERMISSION_LABELS: Record<ProjectPermission, string> = {
+  'project:view': 'View project',
+  'project:settings': 'Manage settings',
+  'resource:view': 'View resources',
+  'resource:create': 'Create resources',
+  'resource:edit': 'Edit resources',
+  'resource:delete': 'Delete resources',
+  'resource:deploy': 'Deploy resources',
+  'access:view': 'View access',
+  'access:manage': 'Manage access',
+};
+
+export const PERMISSION_GROUPS: Record<string, ProjectPermission[]> = {
+  Project: ['project:view', 'project:settings'],
+  Resources: ['resource:view', 'resource:create', 'resource:edit', 'resource:delete', 'resource:deploy'],
+  Access: ['access:view', 'access:manage'],
+};
+
+interface PermissionGridReadOnlyProps {
+  permissions: ProjectPermission[];
+  readOnly: true;
+  onChange?: never;
+}
+
+interface PermissionGridEditableProps {
+  permissions: ProjectPermission[];
+  readOnly?: false;
+  onChange: (permissions: ProjectPermission[]) => void;
+}
+
+type PermissionGridProps = PermissionGridReadOnlyProps | PermissionGridEditableProps;
+
+export function PermissionGrid({ permissions, readOnly, onChange }: PermissionGridProps) {
+  if (readOnly) {
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {permissions.length === 0 ? (
+          <span className="text-sm text-gray-400 dark:text-gray-500">No permissions</span>
+        ) : (
+          permissions.map((p) => (
+            <Badge key={p} variant="default">
+              {PERMISSION_LABELS[p]}
+            </Badge>
+          ))
+        )}
+      </div>
+    );
+  }
+
+  const handleToggle = (perm: ProjectPermission) => {
+    if (!onChange) return;
+    if (permissions.includes(perm)) {
+      onChange(permissions.filter((p) => p !== perm));
+    } else {
+      onChange([...permissions, perm]);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(PERMISSION_GROUPS).map(([group, perms]) => (
+        <div key={group}>
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+            {group}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {perms.map((perm) => {
+              const checked = permissions.includes(perm);
+              return (
+                <label
+                  key={perm}
+                  className="flex items-center gap-2 cursor-pointer select-none"
+                >
+                  <input
+                    type="checkbox"
+                    name={`perm_${perm}`}
+                    value="on"
+                    checked={checked}
+                    onChange={() => handleToggle(perm)}
+                    className="h-4 w-4 rounded border-gray-300 text-brand-600 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-700"
+                  />
+                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                    {PERMISSION_LABELS[perm]}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/role/RoleForm.tsx
+++ b/src/components/role/RoleForm.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useActionState, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Label } from '@/components/common/Label';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { RiErrorWarningFill, RiCheckboxCircleFill } from '@remixicon/react';
+import { PermissionGrid } from './PermissionGrid';
+import type { RoleState } from '@/actions/project-role';
+import type { ProjectPermission, ProjectRoleDefinition } from '@/lib/store';
+
+interface RoleFormProps {
+  organisationName: string;
+  organisationId: string;
+  role?: ProjectRoleDefinition;
+  action: (prevState: RoleState, formData: FormData) => Promise<RoleState>;
+}
+
+const initialState: RoleState = {};
+
+export function RoleForm({ organisationName, role, action }: RoleFormProps) {
+  const [state, formAction, pending] = useActionState(action, initialState);
+  const router = useRouter();
+
+  const defaultPerms: ProjectPermission[] = role?.permissions ?? ['project:view'];
+  const [selectedPermissions, setSelectedPermissions] = useState<ProjectPermission[]>(defaultPerms);
+
+  useEffect(() => {
+    if (state?.success) {
+      const timer = setTimeout(() => {
+        router.push(`/${organisationName}/roles`);
+      }, 800);
+      return () => clearTimeout(timer);
+    }
+  }, [state?.success, organisationName, router]);
+
+  return (
+    <Card className="p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+        {role ? 'Edit role' : 'Create a new role'}
+      </h2>
+
+      {state?.error && !state?.fieldErrors && (
+        <Callout variant="error" title="Error" icon={RiErrorWarningFill} className="mb-4">
+          {state.error}
+        </Callout>
+      )}
+
+      {state?.success && (
+        <Callout variant="success" title={role ? 'Role updated' : 'Role created'} icon={RiCheckboxCircleFill} className="mb-4">
+          Redirecting to roles page…
+        </Callout>
+      )}
+
+      <form action={formAction} className="space-y-5">
+        {role && <input type="hidden" name="roleId" value={role.id} />}
+
+        <div>
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            name="name"
+            type="text"
+            required={!role?.isBuiltIn}
+            defaultValue={role?.name ?? ''}
+            placeholder="e.g. Reviewer"
+            hasError={!!state?.fieldErrors?.name}
+            disabled={pending || !!state?.success || role?.isBuiltIn}
+          />
+          {role?.isBuiltIn && (
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Built-in role names cannot be changed.</p>
+          )}
+          {state?.fieldErrors?.name && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.name}</p>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="description">Description</Label>
+          <Input
+            id="description"
+            name="description"
+            type="text"
+            defaultValue={role?.description ?? ''}
+            placeholder="Optional description"
+            disabled={pending || !!state?.success}
+          />
+          {state?.fieldErrors?.description && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{state.fieldErrors.description}</p>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="rank">Rank</Label>
+          <Input
+            id="rank"
+            name="rank"
+            type="number"
+            min={0}
+            defaultValue={role?.rank ?? 10}
+            placeholder="e.g. 10"
+            disabled={pending || !!state?.success}
+          />
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Lower rank = higher privilege. Built-in roles use 0–3.
+          </p>
+        </div>
+
+        <div>
+          <Label>Permissions</Label>
+          <div className="mt-2 p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+            <PermissionGrid
+              permissions={selectedPermissions}
+              onChange={setSelectedPermissions}
+            />
+          </div>
+          {selectedPermissions.map((perm) => (
+            <input key={perm} type="hidden" name={`perm_${perm}`} value="on" />
+          ))}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="light"
+            onClick={() => router.push(`/${organisationName}/roles`)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={pending || !!state?.success}>
+            {pending ? (role ? 'Saving…' : 'Creating…') : (role ? 'Save changes' : 'Create role')}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/lib/seed-roles.ts
+++ b/src/lib/seed-roles.ts
@@ -1,0 +1,44 @@
+import type { ProjectPermission } from '@/lib/store';
+import { getStoreAsync } from '@/lib/store';
+
+const BUILT_IN_ROLES = [
+  {
+    name: 'Viewer',
+    description: 'Read project metadata and view resources',
+    permissions: ['project:view', 'resource:view', 'access:view'] as ProjectPermission[],
+    rank: 0,
+  },
+  {
+    name: 'Developer',
+    description: 'Create, edit, and delete resources',
+    permissions: ['project:view', 'resource:view', 'resource:create', 'resource:edit', 'resource:delete', 'access:view'] as ProjectPermission[],
+    rank: 1,
+  },
+  {
+    name: 'Deployer',
+    description: 'Deploy and provision resources',
+    permissions: ['project:view', 'resource:view', 'resource:create', 'resource:edit', 'resource:delete', 'resource:deploy', 'access:view'] as ProjectPermission[],
+    rank: 2,
+  },
+  {
+    name: 'Admin',
+    description: 'Full project control including access management',
+    permissions: ['project:view', 'project:settings', 'resource:view', 'resource:create', 'resource:edit', 'resource:delete', 'resource:deploy', 'access:view', 'access:manage'] as ProjectPermission[],
+    rank: 3,
+  },
+];
+
+export async function seedBuiltInRoles(organisationId: string): Promise<void> {
+  const store = await getStoreAsync();
+
+  for (const role of BUILT_IN_ROLES) {
+    const existing = await store.projectRoles.findByNameAndOrg(role.name, organisationId);
+    if (!existing) {
+      await store.projectRoles.create({
+        ...role,
+        organisationId,
+        isBuiltIn: true,
+      });
+    }
+  }
+}

--- a/src/lib/services/organisation.ts
+++ b/src/lib/services/organisation.ts
@@ -2,6 +2,7 @@ import { getStoreAsync } from '@/lib/store';
 import type { Organisation, OrganisationRole } from '@/lib/store';
 import type { CreateOrganisationData, OrganisationWithMemberCount } from '@/lib/store/repositories/organisation.repository';
 import { validateNameFormat } from '../name-validation';
+import { seedBuiltInRoles } from '../seed-roles';
 
 export type { CreateOrganisationData };
 export type OrganisationInfo = OrganisationWithMemberCount;
@@ -24,6 +25,8 @@ export class OrganisationService {
         description: 'Default team — all organisation members',
         defaultProjectRole: 'DEVELOPER',
       });
+
+      await seedBuiltInRoles(organisation.id);
 
       try {
         const orgSlug = organisation.slug || organisation.name.toLowerCase().replace(/[^a-z0-9-]/g, '-');

--- a/src/lib/store/data-store.ts
+++ b/src/lib/store/data-store.ts
@@ -12,6 +12,7 @@ import type { ITeamRepository, ITeamMemberRepository } from './repositories/team
 import type { IProjectAccessRepository } from './repositories/project-access.repository';
 import type { IProjectShareRepository } from './repositories/project-share.repository';
 import type { INamespaceRepository } from './repositories/namespace.repository';
+import type { IProjectRoleRepository } from './repositories/project-role.repository';
 import { createStore } from 'tinybase';
 import { FileRecordPersister } from './tinybase/file-record-persister';
 import { TinyBaseUserRepository } from './tinybase/user.tinybase';
@@ -28,6 +29,7 @@ import { TinyBaseTeamRepository, TinyBaseTeamMemberRepository } from './tinybase
 import { TinyBaseProjectAccessRepository } from './tinybase/project-access.tinybase';
 import { TinyBaseProjectShareRepository } from './tinybase/project-share.tinybase';
 import { TinyBaseNamespaceRepository } from './tinybase/namespace.tinybase';
+import { TinyBaseProjectRoleRepository } from './tinybase/project-role.tinybase';
 import path from 'path';
 
 export interface DataStore {
@@ -50,6 +52,7 @@ export interface DataStore {
   teamMembers: ITeamMemberRepository;
   projectAccess: IProjectAccessRepository;
   projectShares: IProjectShareRepository;
+  projectRoles: IProjectRoleRepository;
   destroy(): Promise<void>;
 }
 
@@ -75,6 +78,7 @@ const TABLE_CONFIG = [
   { tableName: 'team-members', indexes: [{ name: 'teamId', cellId: 'teamId' }, { name: 'userId', cellId: 'userId' }] },
   { tableName: 'project-access', indexes: [{ name: 'projectId', cellId: 'projectId' }, { name: 'teamId', cellId: 'teamId' }] },
   { tableName: 'project-shares', indexes: [{ name: 'projectId', cellId: 'projectId' }, { name: 'sharedWithId', cellId: 'sharedWithId' }] },
+  { tableName: 'project-roles', indexes: [{ name: 'organisationId', cellId: 'organisationId' }] },
 ];
 
 let _store: DataStore | null = null;
@@ -107,6 +111,7 @@ async function createDataStore(): Promise<DataStore> {
     teamMembers: new TinyBaseTeamMemberRepository(tinyStore, persister),
     projectAccess: new TinyBaseProjectAccessRepository(tinyStore, persister),
     projectShares: new TinyBaseProjectShareRepository(tinyStore, persister),
+    projectRoles: new TinyBaseProjectRoleRepository(tinyStore, persister),
     async destroy() {
       await persister.destroy();
     },

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -34,6 +34,8 @@ export type {
   Resource,
   ProjectResource,
   ApiKey,
+  ProjectPermission,
+  ProjectRoleDefinition,
 } from './types';
 
 export { getStore, getStoreAsync, setStore, resetStore } from './data-store';
@@ -85,4 +87,7 @@ export type {
   CreateProjectShareData,
   INamespaceRepository,
   RegisterNamespaceData,
+  IProjectRoleRepository,
+  CreateProjectRoleData,
+  UpdateProjectRoleData,
 } from './repositories';

--- a/src/lib/store/repositories/index.ts
+++ b/src/lib/store/repositories/index.ts
@@ -12,3 +12,4 @@ export type { ITeamRepository, ITeamMemberRepository, CreateTeamData, UpdateTeam
 export type { IProjectAccessRepository, GrantProjectAccessData } from './project-access.repository';
 export type { IProjectShareRepository, CreateProjectShareData } from './project-share.repository';
 export type { INamespaceRepository, RegisterNamespaceData } from './namespace.repository';
+export type { IProjectRoleRepository, CreateProjectRoleData, UpdateProjectRoleData } from './project-role.repository';

--- a/src/lib/store/repositories/project-role.repository.ts
+++ b/src/lib/store/repositories/project-role.repository.ts
@@ -1,0 +1,27 @@
+import type { ProjectRoleDefinition, ProjectPermission } from '../types';
+
+export interface CreateProjectRoleData {
+  organisationId: string;
+  name: string;
+  description: string;
+  permissions: ProjectPermission[];
+  isBuiltIn?: boolean;
+  rank: number;
+}
+
+export interface UpdateProjectRoleData {
+  name?: string;
+  description?: string;
+  permissions?: ProjectPermission[];
+  rank?: number;
+}
+
+export interface IProjectRoleRepository {
+  create(data: CreateProjectRoleData): Promise<ProjectRoleDefinition>;
+  findById(id: string): Promise<ProjectRoleDefinition | null>;
+  findByOrgId(organisationId: string): Promise<ProjectRoleDefinition[]>;
+  findByNameAndOrg(name: string, organisationId: string): Promise<ProjectRoleDefinition | null>;
+  findBuiltInByOrg(organisationId: string): Promise<ProjectRoleDefinition[]>;
+  update(id: string, data: UpdateProjectRoleData): Promise<ProjectRoleDefinition>;
+  delete(id: string): Promise<void>;
+}

--- a/src/lib/store/tinybase/project-role.tinybase.ts
+++ b/src/lib/store/tinybase/project-role.tinybase.ts
@@ -1,0 +1,100 @@
+import type { Store } from 'tinybase';
+import type { ProjectRoleDefinition, ProjectPermission } from '../types';
+import type { IProjectRoleRepository, CreateProjectRoleData, UpdateProjectRoleData } from '../repositories/project-role.repository';
+import type { FileRecordPersister } from './file-record-persister';
+import crypto from 'crypto';
+
+const TABLE = 'project-roles';
+
+function generateId(): string {
+  return crypto.randomBytes(12).toString('hex');
+}
+
+function rowToRole(id: string, row: Record<string, any>): ProjectRoleDefinition {
+  return {
+    id,
+    organisationId: row.organisationId as string,
+    name: row.name as string,
+    description: (row.description as string) || '',
+    permissions: JSON.parse((row.permissions as string) || '[]') as ProjectPermission[],
+    isBuiltIn: row.isBuiltIn === 1,
+    rank: row.rank as number,
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+  };
+}
+
+export class TinyBaseProjectRoleRepository implements IProjectRoleRepository {
+  constructor(private store: Store, private persister?: FileRecordPersister) {}
+
+  async create(data: CreateProjectRoleData): Promise<ProjectRoleDefinition> {
+    const id = generateId();
+    const now = new Date().toISOString();
+
+    this.store.setRow(TABLE, id, {
+      organisationId: data.organisationId,
+      name: data.name,
+      description: data.description ?? '',
+      permissions: JSON.stringify(data.permissions),
+      isBuiltIn: data.isBuiltIn ? 1 : 0,
+      rank: data.rank,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return rowToRole(id, this.store.getRow(TABLE, id));
+  }
+
+  async findById(id: string): Promise<ProjectRoleDefinition | null> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.name) return null;
+    return rowToRole(id, row);
+  }
+
+  async findByOrgId(organisationId: string): Promise<ProjectRoleDefinition[]> {
+    const results: ProjectRoleDefinition[] = [];
+
+    const ids = this.persister
+      ? this.persister.lookupIndex(TABLE, 'organisationId', organisationId)
+      : this.store.getRowIds(TABLE);
+
+    for (const id of ids) {
+      const row = this.store.getRow(TABLE, id);
+      if (!this.persister && row.organisationId !== organisationId) continue;
+      if (!row.name) continue;
+      results.push(rowToRole(id, row));
+    }
+
+    return results;
+  }
+
+  async findByNameAndOrg(name: string, organisationId: string): Promise<ProjectRoleDefinition | null> {
+    const roles = await this.findByOrgId(organisationId);
+    return roles.find(r => r.name === name) ?? null;
+  }
+
+  async findBuiltInByOrg(organisationId: string): Promise<ProjectRoleDefinition[]> {
+    const roles = await this.findByOrgId(organisationId);
+    return roles.filter(r => r.isBuiltIn);
+  }
+
+  async update(id: string, data: UpdateProjectRoleData): Promise<ProjectRoleDefinition> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.name) throw new Error(`ProjectRoleDefinition ${id} not found`);
+
+    if (data.name !== undefined) this.store.setCell(TABLE, id, 'name', data.name);
+    if (data.description !== undefined) this.store.setCell(TABLE, id, 'description', data.description);
+    if (data.permissions !== undefined) this.store.setCell(TABLE, id, 'permissions', JSON.stringify(data.permissions));
+    if (data.rank !== undefined) this.store.setCell(TABLE, id, 'rank', data.rank);
+    this.store.setCell(TABLE, id, 'updatedAt', new Date().toISOString());
+
+    return rowToRole(id, this.store.getRow(TABLE, id));
+  }
+
+  async delete(id: string): Promise<void> {
+    const role = await this.findById(id);
+    if (!role) return;
+    if (role.isBuiltIn) throw new Error('Cannot delete built-in role');
+    this.store.delRow(TABLE, id);
+  }
+}

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -303,3 +303,26 @@ export interface ApiKey {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export type ProjectPermission =
+  | 'project:view'
+  | 'project:settings'
+  | 'resource:view'
+  | 'resource:create'
+  | 'resource:edit'
+  | 'resource:delete'
+  | 'resource:deploy'
+  | 'access:view'
+  | 'access:manage';
+
+export interface ProjectRoleDefinition {
+  id: string;
+  organisationId: string;
+  name: string;
+  description: string;
+  permissions: ProjectPermission[];
+  isBuiltIn: boolean;
+  rank: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/tests/services/helpers.ts
+++ b/tests/services/helpers.ts
@@ -13,6 +13,7 @@ import { TinyBaseTeamRepository, TinyBaseTeamMemberRepository } from '@/lib/stor
 import { TinyBaseProjectAccessRepository } from '@/lib/store/tinybase/project-access.tinybase';
 import { TinyBaseProjectShareRepository } from '@/lib/store/tinybase/project-share.tinybase';
 import { TinyBaseNamespaceRepository } from '@/lib/store/tinybase/namespace.tinybase';
+import { TinyBaseProjectRoleRepository } from '@/lib/store/tinybase/project-role.tinybase';
 import type { DataStore } from '@/lib/store/data-store';
 
 export function createTestStore(): DataStore {
@@ -37,6 +38,7 @@ export function createTestStore(): DataStore {
     teamMembers: new TinyBaseTeamMemberRepository(store),
     projectAccess: new TinyBaseProjectAccessRepository(store),
     projectShares: new TinyBaseProjectShareRepository(store),
+    projectRoles: new TinyBaseProjectRoleRepository(store),
     async destroy() {},
   };
 }

--- a/tests/store/tinybase/project-role.tinybase.test.ts
+++ b/tests/store/tinybase/project-role.tinybase.test.ts
@@ -1,0 +1,121 @@
+import { createStore } from 'tinybase';
+import { TinyBaseProjectRoleRepository } from '@/lib/store/tinybase/project-role.tinybase';
+
+describe('TinyBaseProjectRoleRepository', () => {
+  let repo: TinyBaseProjectRoleRepository;
+
+  beforeEach(() => {
+    const store = createStore();
+    repo = new TinyBaseProjectRoleRepository(store);
+  });
+
+  it('creates a role definition with permissions', async () => {
+    const role = await repo.create({
+      organisationId: 'org-1',
+      name: 'Developer',
+      description: 'Can create and edit resources',
+      permissions: ['project:view', 'resource:view', 'resource:create'],
+      rank: 1,
+    });
+
+    expect(role.id).toBeDefined();
+    expect(role.organisationId).toBe('org-1');
+    expect(role.name).toBe('Developer');
+    expect(role.description).toBe('Can create and edit resources');
+    expect(role.permissions).toEqual(['project:view', 'resource:view', 'resource:create']);
+    expect(role.isBuiltIn).toBe(false);
+    expect(role.rank).toBe(1);
+    expect(role.createdAt).toBeInstanceOf(Date);
+    expect(role.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('finds roles by organisation', async () => {
+    await repo.create({ organisationId: 'org-1', name: 'Viewer', description: '', permissions: ['project:view'], rank: 0 });
+    await repo.create({ organisationId: 'org-1', name: 'Admin', description: '', permissions: ['project:view', 'access:manage'], rank: 3 });
+    await repo.create({ organisationId: 'org-2', name: 'Viewer', description: '', permissions: ['project:view'], rank: 0 });
+
+    const org1Roles = await repo.findByOrgId('org-1');
+    expect(org1Roles).toHaveLength(2);
+
+    const org2Roles = await repo.findByOrgId('org-2');
+    expect(org2Roles).toHaveLength(1);
+  });
+
+  it('finds by name and org', async () => {
+    await repo.create({ organisationId: 'org-1', name: 'Viewer', description: '', permissions: ['project:view'], rank: 0 });
+    await repo.create({ organisationId: 'org-2', name: 'Viewer', description: '', permissions: ['project:view'], rank: 0 });
+
+    const found = await repo.findByNameAndOrg('Viewer', 'org-1');
+    expect(found).not.toBeNull();
+    expect(found!.organisationId).toBe('org-1');
+
+    const notFound = await repo.findByNameAndOrg('Admin', 'org-1');
+    expect(notFound).toBeNull();
+  });
+
+  it('updates role permissions', async () => {
+    const role = await repo.create({
+      organisationId: 'org-1',
+      name: 'Developer',
+      description: 'Old description',
+      permissions: ['project:view', 'resource:view'],
+      rank: 1,
+    });
+
+    const updated = await repo.update(role.id, {
+      permissions: ['project:view', 'resource:view', 'resource:create', 'resource:edit'],
+      description: 'New description',
+    });
+
+    expect(updated.permissions).toEqual(['project:view', 'resource:view', 'resource:create', 'resource:edit']);
+    expect(updated.description).toBe('New description');
+    expect(updated.id).toBe(role.id);
+  });
+
+  it('prevents deletion of built-in roles', async () => {
+    const role = await repo.create({
+      organisationId: 'org-1',
+      name: 'Admin',
+      description: 'Built-in admin',
+      permissions: ['project:view', 'access:manage'],
+      isBuiltIn: true,
+      rank: 3,
+    });
+
+    await expect(repo.delete(role.id)).rejects.toThrow('Cannot delete built-in role');
+  });
+
+  it('deletes custom roles', async () => {
+    const role = await repo.create({
+      organisationId: 'org-1',
+      name: 'Custom Role',
+      description: 'A custom role',
+      permissions: ['project:view'],
+      isBuiltIn: false,
+      rank: 5,
+    });
+
+    await repo.delete(role.id);
+
+    const found = await repo.findById(role.id);
+    expect(found).toBeNull();
+  });
+
+  it('permissions are stored and retrieved as arrays (not corrupted by JSON serialisation)', async () => {
+    const permissions = ['project:view', 'resource:view', 'resource:create', 'resource:edit', 'resource:delete', 'resource:deploy', 'access:view', 'access:manage'] as const;
+
+    const role = await repo.create({
+      organisationId: 'org-1',
+      name: 'Power User',
+      description: '',
+      permissions: [...permissions],
+      rank: 2,
+    });
+
+    const retrieved = await repo.findById(role.id);
+    expect(retrieved).not.toBeNull();
+    expect(Array.isArray(retrieved!.permissions)).toBe(true);
+    expect(retrieved!.permissions).toHaveLength(permissions.length);
+    expect(retrieved!.permissions).toEqual([...permissions]);
+  });
+});


### PR DESCRIPTION
## Summary

Custom project role definitions per org, with a visual permission editor.

### New entity
- \`ProjectRoleDefinition\`: org-scoped, with name, description, permissions array (\`ProjectPermission[]\`), rank, isBuiltIn flag
- 7 repository tests, 274 total passing
- Built-in roles (Viewer/Developer/Deployer/Admin) seeded on org creation

### Permission primitives (9)
\`project:view\`, \`project:settings\`, \`resource:view/create/edit/delete/deploy\`, \`access:view/manage\`

### Server actions
- \`createProjectRole\` — validates, checks uniqueness, creates with isBuiltIn=false
- \`updateProjectRole\` — built-in: description+permissions editable, name locked
- \`deleteProjectRole\` — refuses built-in + in-use roles

### Pages
- \`/{slug}/roles\` — **replaced** old member-grouped view with role definitions list. Auto-seeds built-ins for pre-existing orgs. Shows permission badges per role.
- \`/{slug}/roles/new\` — create custom role with permission checkbox grid
- \`/{slug}/roles/{roleId}\` — edit role, danger zone for deletion

### Components
- \`PermissionGrid\` — dual-mode (read-only badges / editable checkboxes), grouped by Project/Resources/Access
- \`RoleForm\` — create+edit mode, disables name for built-ins
- \`DeleteRoleButton\` — with confirm dialog

### Stats
- 3 commits, 17 files, ~1050 lines
- 274 tests green
- \`ProjectAccess.role\` stays as string matching role name (no schema migration)