### PR TITLE
feat: Phase 3 — Advanced Cross-Org Collaboration

### DIFF
--- a/src/actions/project-share.ts
+++ b/src/actions/project-share.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
 import type { SharePermission } from '@/lib/store';
+import { sendShareInvitationEmail } from '@/lib/share-invitations';
 
 const VALID_PERMISSIONS: SharePermission[] = ['VIEW', 'CONTRIBUTE', 'MANAGE'];
 
@@ -82,7 +83,6 @@ export async function shareProject(
       };
     }
 
-    const hostOrg = await store.organisations.findById(project.organisationId);
     if (
       namespace.entityType === 'ORGANISATION' &&
       namespace.entityId === project.organisationId
@@ -98,7 +98,7 @@ export async function shareProject(
       namespace.entityType as 'USER' | 'ORGANISATION',
       namespace.entityId
     );
-    if (existing) {
+    if (existing && existing.status !== 'REVOKED' && existing.status !== 'DECLINED') {
       return {
         error: 'This project is already shared with that organisation or user',
         fieldErrors: { slug: 'Already shared with this entity' },
@@ -113,9 +113,40 @@ export async function shareProject(
       sharedBy: session.user.id,
     });
 
-    const org = await store.organisations.findById(project.organisationId);
-    if (org) {
-      revalidatePath(`/${org.name}/${project.name}/share`);
+    const hostOrg2 = await store.organisations.findById(project.organisationId);
+
+    if (namespace.entityType === 'ORGANISATION') {
+      const collabOrg = await store.organisations.findById(namespace.entityId);
+      if (collabOrg) {
+        const members = await store.organisationMembers.findByOrgId(collabOrg.id);
+        const ownerMember = members.find((m) => m.role === 'OWNER');
+        if (ownerMember) {
+          const ownerUser = await store.users.findById(ownerMember.userId);
+          if (ownerUser) {
+            await sendShareInvitationEmail(
+              ownerUser.email,
+              project.name,
+              hostOrg2?.name ?? project.organisationId,
+              permission as SharePermission,
+              collabOrg.name,
+            ).catch(() => {});
+          }
+        }
+      }
+    } else {
+      const targetUser = await store.users.findById(namespace.entityId);
+      if (targetUser) {
+        await sendShareInvitationEmail(
+          targetUser.email,
+          project.name,
+          hostOrg2?.name ?? project.organisationId,
+          permission as SharePermission,
+        ).catch(() => {});
+      }
+    }
+
+    if (hostOrg2) {
+      revalidatePath(`/${hostOrg2.name}/${project.name}/share`);
     }
 
     return { success: true };
@@ -224,5 +255,99 @@ export async function revokeShare(
     return { success: true };
   } catch {
     return { success: false, error: 'Failed to revoke share. Please try again.' };
+  }
+}
+
+export async function acceptShare(
+  shareId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const store = await getStoreAsync();
+
+    const share = await store.projectShares.findById(shareId);
+    if (!share) {
+      return { success: false, error: 'Share invitation not found' };
+    }
+
+    if (share.status !== 'INVITED') {
+      return { success: false, error: 'This invitation is no longer pending' };
+    }
+
+    if (share.sharedWithType === 'ORGANISATION') {
+      const membership = await store.organisationMembers.findByUserAndOrg(
+        session.user.id,
+        share.sharedWithId
+      );
+      const isOrgAdmin =
+        session.user.role === 'ADMIN' ||
+        (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+      if (!isOrgAdmin) {
+        return { success: false, error: 'You do not have permission to accept this invitation' };
+      }
+    } else if (share.sharedWithType === 'USER') {
+      if (session.user.id !== share.sharedWithId && session.user.role !== 'ADMIN') {
+        return { success: false, error: 'You do not have permission to accept this invitation' };
+      }
+    }
+
+    await store.projectShares.updateStatus(shareId, 'ACTIVE');
+
+    revalidatePath(`/${session.user.id}/invitations`);
+
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Failed to accept invitation. Please try again.' };
+  }
+}
+
+export async function declineShare(
+  shareId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { success: false, error: 'Authentication required' };
+    }
+
+    const store = await getStoreAsync();
+
+    const share = await store.projectShares.findById(shareId);
+    if (!share) {
+      return { success: false, error: 'Share invitation not found' };
+    }
+
+    if (share.status !== 'INVITED') {
+      return { success: false, error: 'This invitation is no longer pending' };
+    }
+
+    if (share.sharedWithType === 'ORGANISATION') {
+      const membership = await store.organisationMembers.findByUserAndOrg(
+        session.user.id,
+        share.sharedWithId
+      );
+      const isOrgAdmin =
+        session.user.role === 'ADMIN' ||
+        (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+      if (!isOrgAdmin) {
+        return { success: false, error: 'You do not have permission to decline this invitation' };
+      }
+    } else if (share.sharedWithType === 'USER') {
+      if (session.user.id !== share.sharedWithId && session.user.role !== 'ADMIN') {
+        return { success: false, error: 'You do not have permission to decline this invitation' };
+      }
+    }
+
+    await store.projectShares.updateStatus(shareId, 'DECLINED');
+
+    revalidatePath(`/${session.user.id}/invitations`);
+
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Failed to decline invitation. Please try again.' };
   }
 }

--- a/src/actions/project-share.ts
+++ b/src/actions/project-share.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
 import type { SharePermission } from '@/lib/store';
 import { sendShareInvitationEmail } from '@/lib/share-invitations';
+import { logAudit } from '@/lib/audit';
 
 const VALID_PERMISSIONS: SharePermission[] = ['VIEW', 'CONTRIBUTE', 'MANAGE'];
 
@@ -105,12 +106,24 @@ export async function shareProject(
       };
     }
 
-    await store.projectShares.create({
+    const newShare = await store.projectShares.create({
       projectId,
       sharedWithType: namespace.entityType as 'USER' | 'ORGANISATION',
       sharedWithId: namespace.entityId,
       permission: permission as SharePermission,
       sharedBy: session.user.id,
+    });
+
+    logAudit({
+      userId: session.user.id,
+      action: 'share-created',
+      entityType: 'project-share',
+      entityId: newShare.id,
+      details: {
+        projectId,
+        targetSlug: slug,
+        permission,
+      },
     });
 
     const hostOrg2 = await store.organisations.findById(project.organisationId);
@@ -247,6 +260,14 @@ export async function revokeShare(
 
     await store.projectShares.revoke(shareId);
 
+    logAudit({
+      userId: session.user.id,
+      action: 'share-revoked',
+      entityType: 'project-share',
+      entityId: shareId,
+      details: { projectId: share.projectId },
+    });
+
     const org = await store.organisations.findById(project.organisationId);
     if (org) {
       revalidatePath(`/${org.name}/${project.name}/share`);
@@ -297,6 +318,14 @@ export async function acceptShare(
 
     await store.projectShares.updateStatus(shareId, 'ACTIVE');
 
+    logAudit({
+      userId: session.user.id,
+      action: 'share-accepted',
+      entityType: 'project-share',
+      entityId: shareId,
+      details: { projectId: share.projectId },
+    });
+
     revalidatePath(`/${session.user.id}/invitations`);
 
     return { success: true };
@@ -344,10 +373,118 @@ export async function declineShare(
 
     await store.projectShares.updateStatus(shareId, 'DECLINED');
 
+    logAudit({
+      userId: session.user.id,
+      action: 'share-declined',
+      entityType: 'project-share',
+      entityId: shareId,
+      details: { projectId: share.projectId },
+    });
+
     revalidatePath(`/${session.user.id}/invitations`);
 
     return { success: true };
   } catch {
     return { success: false, error: 'Failed to decline invitation. Please try again.' };
+  }
+}
+
+export interface TransferProjectState {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: { targetSlug?: string };
+  newOrgName?: string;
+}
+
+export async function transferProject(
+  projectId: string,
+  prevState: TransferProjectState,
+  formData: FormData
+): Promise<TransferProjectState> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { error: 'Authentication required' };
+    }
+
+    const targetSlug = (formData.get('targetSlug') as string)?.trim();
+
+    if (!targetSlug) {
+      return {
+        error: 'Target organisation slug is required',
+        fieldErrors: { targetSlug: 'Target organisation slug is required' },
+      };
+    }
+
+    const store = await getStoreAsync();
+
+    const project = await store.projects.findById(projectId);
+    if (!project) {
+      return { error: 'Project not found' };
+    }
+
+    const orgMembership = await store.organisationMembers.findByUserAndOrg(
+      session.user.id,
+      project.organisationId
+    );
+    const isOwner =
+      session.user.role === 'ADMIN' ||
+      (orgMembership && orgMembership.role === 'OWNER');
+
+    if (!isOwner) {
+      return { error: 'Only the organisation owner can transfer a project' };
+    }
+
+    let targetNamespace = await store.namespaces.findBySlug(targetSlug);
+
+    if (!targetNamespace) {
+      const orgByName = await store.organisations.findByName(targetSlug);
+      if (orgByName) {
+        targetNamespace = await store.namespaces.findByEntity('ORGANISATION', orgByName.id);
+      }
+    }
+
+    if (!targetNamespace || targetNamespace.entityType !== 'ORGANISATION') {
+      return {
+        error: 'No organisation found with this slug',
+        fieldErrors: { targetSlug: 'No organisation found with this slug' },
+      };
+    }
+
+    const targetOrgId = targetNamespace.entityId;
+
+    if (targetOrgId === project.organisationId) {
+      return {
+        error: 'Project already belongs to this organisation',
+        fieldErrors: { targetSlug: 'Project already belongs to this organisation' },
+      };
+    }
+
+    const targetOrg = await store.organisations.findById(targetOrgId);
+    if (!targetOrg) {
+      return { error: 'Target organisation not found' };
+    }
+
+    await store.projectAccess.revokeAllForProject(projectId);
+    await store.projectShares.revokeAllForProject(projectId);
+    await store.projects.transferToOrg(projectId, targetOrgId);
+
+    logAudit({
+      userId: session.user.id,
+      action: 'project-transferred',
+      entityType: 'project-transfer',
+      entityId: projectId,
+      details: {
+        fromOrgId: project.organisationId,
+        toOrgId: targetOrgId,
+        toOrgName: targetOrg.name,
+      },
+    });
+
+    revalidatePath('/');
+
+    return { success: true, newOrgName: targetOrg.name };
+  } catch {
+    return { error: 'Failed to transfer project. Please try again.' };
   }
 }

--- a/src/actions/team.ts
+++ b/src/actions/team.ts
@@ -6,6 +6,7 @@ import { getStoreAsync } from '@/lib/store';
 import type { ProjectRole } from '@/lib/store';
 import { validateNameFormat } from '@/lib/name-validation';
 import { resolveProjectPermissions } from '@/lib/permissions';
+import { logAudit } from '@/lib/audit';
 
 const VALID_PROJECT_ROLES: ProjectRole[] = ['VIEWER', 'DEVELOPER', 'DEPLOYER', 'ADMIN'];
 
@@ -360,12 +361,28 @@ export async function grantProjectAccess(
       }
     }
 
-    await store.projectAccess.grant({
+    const access = await store.projectAccess.grant({
       projectId,
       teamId,
       role: role as ProjectRole,
       grantedBy: session.user.id,
     });
+
+    const isCrossOrg = team.organisationId !== project.organisationId;
+    if (isCrossOrg) {
+      logAudit({
+        userId: session.user.id,
+        action: 'cross-org-access-granted',
+        entityType: 'project-access',
+        entityId: access.id,
+        details: {
+          projectId,
+          teamId,
+          role,
+          crossOrgTeamOrgId: team.organisationId,
+        },
+      });
+    }
 
     revalidatePath(`/orga`);
 

--- a/src/actions/team.ts
+++ b/src/actions/team.ts
@@ -342,7 +342,7 @@ export async function grantProjectAccess(
         'ORGANISATION',
         team.organisationId
       );
-      if (!share || (share.permission !== 'CONTRIBUTE' && share.permission !== 'MANAGE')) {
+      if (!share || share.status !== 'ACTIVE' || (share.permission !== 'CONTRIBUTE' && share.permission !== 'MANAGE')) {
         return {
           error: 'Team does not belong to the same organisation as the project',
           fieldErrors: { teamId: 'Team must belong to the same organisation or a collaborating organisation' },

--- a/src/actions/team.ts
+++ b/src/actions/team.ts
@@ -337,10 +337,17 @@ export async function grantProjectAccess(
     }
 
     if (team.organisationId !== project.organisationId) {
-      return {
-        error: 'Team does not belong to the same organisation as the project',
-        fieldErrors: { teamId: 'Team must belong to the same organisation' },
-      };
+      const share = await store.projectShares.findByProjectAndEntity(
+        projectId,
+        'ORGANISATION',
+        team.organisationId
+      );
+      if (!share || (share.permission !== 'CONTRIBUTE' && share.permission !== 'MANAGE')) {
+        return {
+          error: 'Team does not belong to the same organisation as the project',
+          fieldErrors: { teamId: 'Team must belong to the same organisation or a collaborating organisation' },
+        };
+      }
     }
 
     const orgMembership = await store.organisationMembers.findByUserAndOrg(session.user.id, project.organisationId);

--- a/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
@@ -42,7 +42,7 @@ export default async function AddProjectAccessPage({ params }: AddProjectAccessP
   const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
   const allTeams = await store.teams.findByOrgId(organisation.id);
 
-  const shares = await store.projectShares.findByProjectId(project.id);
+  const shares = await store.projectShares.findByProjectId(project.id, 'ACTIVE');
   const collabOrgShares = shares.filter(
     (s) => s.sharedWithType === 'ORGANISATION' && (s.permission === 'CONTRIBUTE' || s.permission === 'MANAGE')
   );

--- a/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
@@ -41,9 +41,29 @@ export default async function AddProjectAccessPage({ params }: AddProjectAccessP
   const accessRows = await store.projectAccess.findByProjectId(project.id);
   const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
   const allTeams = await store.teams.findByOrgId(organisation.id);
-  const availableTeams = allTeams
-    .filter((t) => !grantedTeamIds.has(t.id))
-    .map((t) => ({ id: t.id, name: t.name, defaultProjectRole: t.defaultProjectRole }));
+
+  const shares = await store.projectShares.findByProjectId(project.id);
+  const collabOrgShares = shares.filter(
+    (s) => s.sharedWithType === 'ORGANISATION' && (s.permission === 'CONTRIBUTE' || s.permission === 'MANAGE')
+  );
+  const collabTeamsWithOrg: { id: string; name: string; defaultProjectRole: string; orgName: string }[] = [];
+  for (const share of collabOrgShares) {
+    const teams = await store.teams.findByOrgId(share.sharedWithId);
+    const collabOrg = await store.organisations.findById(share.sharedWithId);
+    const orgName = collabOrg?.name ?? share.sharedWithId;
+    for (const t of teams) {
+      if (!grantedTeamIds.has(t.id)) {
+        collabTeamsWithOrg.push({ id: t.id, name: t.name, defaultProjectRole: t.defaultProjectRole, orgName });
+      }
+    }
+  }
+
+  const availableTeams = [
+    ...allTeams
+      .filter((t) => !grantedTeamIds.has(t.id))
+      .map((t) => ({ id: t.id, name: t.name, defaultProjectRole: t.defaultProjectRole, orgName: undefined as string | undefined })),
+    ...collabTeamsWithOrg,
+  ];
 
   return (
     <div>

--- a/src/app/(main)/[slug]/[projectName]/access/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/page.tsx
@@ -68,7 +68,7 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
   const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
   const allTeams = await store.teams.findByOrgId(organisation.id);
 
-  const shares = await store.projectShares.findByProjectId(project.id);
+  const shares = await store.projectShares.findByProjectId(project.id, 'ACTIVE');
   const collabOrgShares = shares.filter(
     (s) => s.sharedWithType === 'ORGANISATION' && (s.permission === 'CONTRIBUTE' || s.permission === 'MANAGE')
   );

--- a/src/app/(main)/[slug]/[projectName]/access/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/page.tsx
@@ -49,17 +49,39 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
     accessRows.map(async (row) => {
       const team = await store.teams.findById(row.teamId);
       const members = team ? await store.teamMembers.findByTeamId(team.id) : [];
+      const isExternal = team ? team.organisationId !== organisation.id : false;
+      let orgName: string | undefined;
+      if (isExternal && team) {
+        const teamOrg = await store.organisations.findById(team.organisationId);
+        orgName = teamOrg?.name;
+      }
       return {
         ...row,
         teamName: team?.name ?? 'Unknown team',
         memberCount: members.length,
+        isExternal,
+        orgName,
       };
     })
   );
 
   const grantedTeamIds = new Set(accessRows.map((r) => r.teamId));
   const allTeams = await store.teams.findByOrgId(organisation.id);
-  const availableTeams = allTeams.filter((t) => !grantedTeamIds.has(t.id));
+
+  const shares = await store.projectShares.findByProjectId(project.id);
+  const collabOrgShares = shares.filter(
+    (s) => s.sharedWithType === 'ORGANISATION' && (s.permission === 'CONTRIBUTE' || s.permission === 'MANAGE')
+  );
+  const collabTeams: (typeof allTeams[number])[] = [];
+  for (const share of collabOrgShares) {
+    const teams = await store.teams.findByOrgId(share.sharedWithId);
+    collabTeams.push(...teams);
+  }
+
+  const availableTeams = [
+    ...allTeams.filter((t) => !grantedTeamIds.has(t.id)),
+    ...collabTeams.filter((t) => !grantedTeamIds.has(t.id)),
+  ];
 
   return (
     <div>
@@ -117,12 +139,23 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
                     <RiTeamLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
                   </div>
                   <div>
-                    <Link
-                      href={`/${slug}/teams/${row.teamName}`}
-                      className="font-semibold text-gray-900 dark:text-white hover:underline"
-                    >
-                      {row.teamName}
-                    </Link>
+                    <div className="flex items-center gap-2">
+                      {row.isExternal ? (
+                        <span className="font-semibold text-gray-900 dark:text-white">
+                          {row.teamName}
+                        </span>
+                      ) : (
+                        <Link
+                          href={`/${slug}/teams/${row.teamName}`}
+                          className="font-semibold text-gray-900 dark:text-white hover:underline"
+                        >
+                          {row.teamName}
+                        </Link>
+                      )}
+                      {row.isExternal && row.orgName && (
+                        <Badge variant="default">{row.orgName}</Badge>
+                      )}
+                    </div>
                     <p className="text-xs text-gray-500 dark:text-gray-400">
                       {row.memberCount} {row.memberCount === 1 ? 'member' : 'members'}
                     </p>

--- a/src/app/(main)/[slug]/[projectName]/share/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/share/page.tsx
@@ -101,20 +101,37 @@ export default async function ProjectSharePage({ params }: ProjectSharePageProps
                       <p className="font-semibold text-gray-900 dark:text-white">
                         {share.entityName}
                       </p>
-                      <Badge variant="default" className="text-xs">
-                        {share.sharedWithType}
-                      </Badge>
+                      <div className="flex items-center gap-2 mt-1">
+                        <Badge variant="default" className="text-xs">
+                          {share.sharedWithType}
+                        </Badge>
+                        <Badge
+                          variant={
+                            share.status === 'ACTIVE' ? 'success' :
+                            share.status === 'INVITED' ? 'warning' :
+                            share.status === 'DECLINED' ? 'error' :
+                            'default'
+                          }
+                          className="text-xs"
+                        >
+                          {share.status}
+                        </Badge>
+                      </div>
                     </div>
                   </div>
                   <div className="flex items-center gap-3">
-                    <ChangeSharePermissionForm
-                      shareId={share.id}
-                      currentPermission={share.permission}
-                    />
-                    <RevokeShareButton
-                      shareId={share.id}
-                      entityName={share.entityName}
-                    />
+                    {share.status === 'ACTIVE' && (
+                      <ChangeSharePermissionForm
+                        shareId={share.id}
+                        currentPermission={share.permission}
+                      />
+                    )}
+                    {(share.status === 'ACTIVE' || share.status === 'INVITED') && (
+                      <RevokeShareButton
+                        shareId={share.id}
+                        entityName={share.entityName}
+                      />
+                    )}
                   </div>
                 </li>
               ))}

--- a/src/app/(main)/[slug]/[projectName]/transfer/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/transfer/page.tsx
@@ -1,0 +1,67 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Callout } from '@/components/common/Callout';
+import { RiArrowRightLine, RiErrorWarningLine } from '@remixicon/react';
+import TransferProjectForm from '@/components/project/TransferProjectForm';
+
+interface TransferProjectPageProps {
+  params: Promise<{ slug: string; projectName: string }>;
+}
+
+export default async function TransferProjectPage({ params }: TransferProjectPageProps) {
+  const { slug, projectName } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const project = await store.projects.findByNameAndOrg(projectName, organisation.id);
+  if (!project) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOwner =
+    session.user.role === 'ADMIN' ||
+    (membership && membership.role === 'OWNER');
+
+  if (!isOwner) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Transfer Project</h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Move {projectName} to another organisation
+        </p>
+      </div>
+
+      <Callout variant="warning" title="This action cannot be undone" icon={RiErrorWarningLine} className="mb-6">
+        Transferring this project will remove all existing team access and cross-organisation shares.
+        The receiving organisation will take full ownership. You will lose access unless you are also
+        a member of the target organisation.
+      </Callout>
+
+      <Card className="max-w-lg">
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center gap-2">
+          <span className="font-semibold text-gray-900 dark:text-white">{organisation.name}</span>
+          <RiArrowRightLine className="w-4 h-4 text-gray-400" />
+          <span className="text-sm text-gray-500 dark:text-gray-400">target organisation</span>
+        </div>
+        <div className="p-6">
+          <TransferProjectForm
+            projectId={project.id}
+            projectName={project.name}
+          />
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/invitations/page.tsx
+++ b/src/app/(main)/[slug]/invitations/page.tsx
@@ -1,0 +1,117 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getStoreAsync } from '@/lib/store';
+import { Card } from '@/components/common/Card';
+import { Badge } from '@/components/common/Badge';
+import { Callout } from '@/components/common/Callout';
+import { RiMailLine, RiBuildingLine, RiInformationLine } from '@remixicon/react';
+import AcceptShareButton from '@/components/project/AcceptShareButton';
+import DeclineShareButton from '@/components/project/DeclineShareButton';
+
+interface InvitationsPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function InvitationsPage({ params }: InvitationsPageProps) {
+  const { slug } = await params;
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    notFound();
+  }
+
+  const store = await getStoreAsync();
+  const organisation = await store.organisations.findByName(slug);
+  if (!organisation) notFound();
+
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
+  const isOrgAdmin =
+    session.user.role === 'ADMIN' ||
+    (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+
+  if (!isOrgAdmin) {
+    notFound();
+  }
+
+  const pendingShares = await store.projectShares.findSharedWithEntity('ORGANISATION', organisation.id, 'INVITED');
+
+  const invitationsWithDetails = await Promise.all(
+    pendingShares.map(async (share) => {
+      const project = await store.projects.findById(share.projectId);
+      const hostOrg = project ? await store.organisations.findById(project.organisationId) : null;
+      return {
+        ...share,
+        projectName: project?.name ?? share.projectId,
+        hostOrgName: hostOrg?.name ?? share.projectId,
+      };
+    })
+  );
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Invitations</h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Pending project collaboration invitations for {organisation.name}
+          </p>
+        </div>
+      </div>
+
+      <Callout variant="default" title="Project invitations" icon={RiInformationLine} className="mb-6">
+        Accepting an invitation lets your teams be granted access to shared projects.
+        Declining removes the invitation without granting any access.
+      </Callout>
+
+      {invitationsWithDetails.length === 0 ? (
+        <Card className="p-12 text-center">
+          <RiMailLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <p className="text-gray-600 dark:text-gray-400 font-medium">
+            No pending invitations
+          </p>
+        </Card>
+      ) : (
+        <Card>
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {invitationsWithDetails.map((invitation) => (
+              <li
+                key={invitation.id}
+                className="flex items-center justify-between px-6 py-4 flex-wrap gap-3"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-brand-100 dark:bg-brand-900/30 rounded-lg">
+                    <RiBuildingLine className="w-5 h-5 text-brand-600 dark:text-brand-400" />
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-900 dark:text-white">
+                      {invitation.projectName}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      from {invitation.hostOrgName}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <Badge variant="default" className="text-xs">
+                        {invitation.permission}
+                      </Badge>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <AcceptShareButton
+                    shareId={invitation.id}
+                    organisationName={slug}
+                  />
+                  <DeclineShareButton
+                    shareId={invitation.id}
+                    organisationName={slug}
+                    projectName={invitation.projectName}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/[slug]/layout.tsx
+++ b/src/app/(main)/[slug]/layout.tsx
@@ -26,6 +26,16 @@ export default async function NamespaceLayout({
     const projects = await store.projects.findByOrgId(organisation.id, { isActive: true });
     const members = await store.organisationMembers.findByOrgId(organisation.id);
 
+    const activeShares = await store.projectShares.findSharedWithEntity('ORGANISATION', organisation.id, 'ACTIVE');
+    const sharedProjects = [];
+    for (const share of activeShares) {
+      const project = await store.projects.findById(share.projectId);
+      if (project && project.isActive) {
+        const ownerOrg = await store.organisations.findById(project.organisationId);
+        sharedProjects.push({ ...project, ownerName: ownerOrg?.name || 'Unknown', ownerSlug: ownerOrg?.slug || ownerOrg?.name || 'unknown' });
+      }
+    }
+
     return (
       <OrganisationProvider
         organisation={{
@@ -35,6 +45,7 @@ export default async function NamespaceLayout({
           ownerId: organisation.ownerId,
           isActive: organisation.isActive,
           projects,
+          sharedProjects,
           _count: {
             members: members.length,
             projects: projects.length,
@@ -57,6 +68,16 @@ export default async function NamespaceLayout({
     const projects = await store.projects.findByOrgId(orgByName.id, { isActive: true });
     const members = await store.organisationMembers.findByOrgId(orgByName.id);
 
+    const activeShares = await store.projectShares.findSharedWithEntity('ORGANISATION', orgByName.id, 'ACTIVE');
+    const sharedProjects = [];
+    for (const share of activeShares) {
+      const project = await store.projects.findById(share.projectId);
+      if (project && project.isActive) {
+        const ownerOrg = await store.organisations.findById(project.organisationId);
+        sharedProjects.push({ ...project, ownerName: ownerOrg?.name || 'Unknown', ownerSlug: ownerOrg?.slug || ownerOrg?.name || 'unknown' });
+      }
+    }
+
     return (
       <OrganisationProvider
         organisation={{
@@ -66,6 +87,7 @@ export default async function NamespaceLayout({
           ownerId: orgByName.ownerId,
           isActive: orgByName.isActive,
           projects,
+          sharedProjects,
           _count: {
             members: members.length,
             projects: projects.length,

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -4,6 +4,13 @@ import { getStoreAsync } from '@/lib/store';
 import { checkOrganisationPermissions } from '@/lib/permissions';
 import OrganisationOverviewClient from '@/components/OrganisationOverviewClient';
 
+async function resolveIsOrgAdmin(userId: string, userRole: string, orgId: string): Promise<boolean> {
+  if (userRole === 'ADMIN') return true;
+  const store = await getStoreAsync();
+  const membership = await store.organisationMembers.findByUserAndOrg(userId, orgId);
+  return membership?.role === 'OWNER' || membership?.role === 'ADMIN';
+}
+
 interface NamespacePageProps {
   params: Promise<{ slug: string }>;
 }
@@ -27,7 +34,8 @@ export default async function NamespacePage({ params }: NamespacePageProps) {
 
     if (!permissions.isMember && !permissions.isAdmin) notFound();
 
-    return <OrganisationOverviewClient canManage={permissions.canManage} />;
+    const isOrgAdmin = await resolveIsOrgAdmin(session.user.id, session.user.role, organisation.id);
+    return <OrganisationOverviewClient canManage={permissions.canManage} isOrgAdmin={isOrgAdmin} />;
   }
 
   if (namespace?.entityType === 'USER') {
@@ -53,7 +61,8 @@ export default async function NamespacePage({ params }: NamespacePageProps) {
 
     if (!permissions.isMember && !permissions.isAdmin) notFound();
 
-    return <OrganisationOverviewClient canManage={permissions.canManage} />;
+    const isOrgAdmin2 = await resolveIsOrgAdmin(session.user.id, session.user.role, orgByName.id);
+    return <OrganisationOverviewClient canManage={permissions.canManage} isOrgAdmin={isOrgAdmin2} />;
   }
 
   notFound();

--- a/src/app/(main)/orga/[orgaName]/layout.tsx
+++ b/src/app/(main)/orga/[orgaName]/layout.tsx
@@ -25,6 +25,16 @@ export default async function OrganisationLayout({
   const projects = await store.projects.findByOrgId(organisation.id, { isActive: true });
   const members = await store.organisationMembers.findByOrgId(organisation.id);
 
+  const activeShares = await store.projectShares.findSharedWithEntity('ORGANISATION', organisation.id, 'ACTIVE');
+  const sharedProjects = [];
+  for (const share of activeShares) {
+    const project = await store.projects.findById(share.projectId);
+    if (project && project.isActive) {
+      const ownerOrg = await store.organisations.findById(project.organisationId);
+      sharedProjects.push({ ...project, ownerName: ownerOrg?.name || 'Unknown', ownerSlug: ownerOrg?.slug || ownerOrg?.name || 'unknown' });
+    }
+  }
+
   return (
     <OrganisationProvider
       organisation={{
@@ -34,6 +44,7 @@ export default async function OrganisationLayout({
         ownerId: organisation.ownerId,
         isActive: organisation.isActive,
         projects,
+        sharedProjects,
         _count: {
           members: members.length,
           projects: projects.length,

--- a/src/components/OrganisationOverviewClient.tsx
+++ b/src/components/OrganisationOverviewClient.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
 import ProjectCard from '@/components/project/ProjectCard';
 import Link from 'next/link';
+import { Badge } from '@/components/common/Badge';
 import {
   RiSettings3Line,
   RiProjectorLine,
@@ -13,6 +14,7 @@ import {
   RiUserLine,
   RiTeamLine,
   RiMailLine,
+  RiShareLine,
 } from '@remixicon/react';
 
 interface OrganisationOverviewClientProps {
@@ -125,6 +127,36 @@ export default function OrganisationOverviewClient({
             </Card>
           )}
         </div>
+
+        {organisation.sharedProjects && organisation.sharedProjects.length > 0 && (
+          <div className="mb-8">
+            <div className="flex items-center gap-3 mb-6">
+              <RiShareLine className="h-6 w-6 text-gray-500 dark:text-gray-400" />
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                Shared Projects
+              </h2>
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {organisation.sharedProjects.map((project) => (
+                <Link key={project.id} href={`/${project.ownerSlug}/${project.name}`}>
+                  <Card className="p-6 hover:shadow-lg transition-shadow cursor-pointer">
+                    <div className="flex items-start justify-between mb-2">
+                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                        {project.name}
+                      </h3>
+                      <Badge variant="neutral">Owner: {project.ownerName}</Badge>
+                    </div>
+                    {project.description && (
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {project.description}
+                      </p>
+                    )}
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
       </Container>
     </main>
   );

--- a/src/components/OrganisationOverviewClient.tsx
+++ b/src/components/OrganisationOverviewClient.tsx
@@ -11,15 +11,18 @@ import {
   RiProjectorLine,
   RiAddLine,
   RiUserLine,
-  RiTeamLine
+  RiTeamLine,
+  RiMailLine,
 } from '@remixicon/react';
 
 interface OrganisationOverviewClientProps {
   canManage: boolean;
+  isOrgAdmin?: boolean;
 }
 
 export default function OrganisationOverviewClient({
   canManage,
+  isOrgAdmin,
 }: OrganisationOverviewClientProps) {
   const organisation = useOrganisation();
 
@@ -61,6 +64,14 @@ export default function OrganisationOverviewClient({
                 Teams
               </Button>
             </Link>
+            {isOrgAdmin && (
+              <Link href={`/${organisation.name}/invitations`}>
+                <Button variant="light" className="text-sm px-3 py-2">
+                  <RiMailLine className="mr-2 h-4 w-4" />
+                  Invitations
+                </Button>
+              </Link>
+            )}
             {canManage && (
               <Link href={`/${organisation.name}/settings`}>
                 <Button variant="light" className="text-sm px-3 py-2">

--- a/src/components/form/GrantProjectAccessForm.tsx
+++ b/src/components/form/GrantProjectAccessForm.tsx
@@ -16,6 +16,7 @@ interface AvailableTeam {
   id: string;
   name: string;
   defaultProjectRole: string;
+  orgName?: string;
 }
 
 interface GrantProjectAccessFormProps {
@@ -77,7 +78,7 @@ export default function GrantProjectAccessForm({
               <SelectContent>
                 {availableTeams.map((t) => (
                   <SelectItem key={t.id} value={t.id}>
-                    {t.name} (default: {t.defaultProjectRole})
+                    {t.name}{t.orgName ? ` (${t.orgName})` : ''} — default: {t.defaultProjectRole}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/project/AcceptShareButton.tsx
+++ b/src/components/project/AcceptShareButton.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { acceptShare } from '@/actions/project-share';
+import { Button } from '@/components/common/Button';
+import { RiCheckLine } from '@remixicon/react';
+
+interface AcceptShareButtonProps {
+  shareId: string;
+  organisationName: string;
+}
+
+export default function AcceptShareButton({ shareId, organisationName }: AcceptShareButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleAccept = async () => {
+    setLoading(true);
+    const result = await acceptShare(shareId);
+    setLoading(false);
+    if (result.success) {
+      router.refresh();
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="primary"
+      onClick={handleAccept}
+      disabled={loading}
+    >
+      <RiCheckLine className="w-4 h-4 mr-1" />
+      {loading ? 'Accepting…' : 'Accept'}
+    </Button>
+  );
+}

--- a/src/components/project/DeclineShareButton.tsx
+++ b/src/components/project/DeclineShareButton.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { declineShare } from '@/actions/project-share';
+import { Button } from '@/components/common/Button';
+import { RiCloseLine } from '@remixicon/react';
+
+interface DeclineShareButtonProps {
+  shareId: string;
+  organisationName: string;
+  projectName: string;
+}
+
+export default function DeclineShareButton({ shareId, organisationName, projectName }: DeclineShareButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleDecline = async () => {
+    if (!confirm(`Decline invitation to collaborate on "${projectName}"?`)) return;
+    setLoading(true);
+    const result = await declineShare(shareId);
+    setLoading(false);
+    if (result.success) {
+      router.refresh();
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      className="text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 border-red-300 dark:border-red-700"
+      onClick={handleDecline}
+      disabled={loading}
+    >
+      <RiCloseLine className="w-4 h-4 mr-1" />
+      {loading ? 'Declining…' : 'Decline'}
+    </Button>
+  );
+}

--- a/src/components/project/TransferProjectForm.tsx
+++ b/src/components/project/TransferProjectForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useActionState, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { transferProject } from '@/actions/project-share';
+import type { TransferProjectState } from '@/actions/project-share';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { Callout } from '@/components/common/Callout';
+import { RiErrorWarningLine } from '@remixicon/react';
+
+interface TransferProjectFormProps {
+  projectId: string;
+  projectName: string;
+}
+
+const initialState: TransferProjectState = {};
+
+export default function TransferProjectForm({ projectId, projectName }: TransferProjectFormProps) {
+  const router = useRouter();
+  const [confirmName, setConfirmName] = useState('');
+
+  const boundAction = transferProject.bind(null, projectId);
+  const [state, formAction, isPending] = useActionState(boundAction, initialState);
+
+  if (state.success && state.newOrgName) {
+    router.push(`/${state.newOrgName}`);
+    return null;
+  }
+
+  const confirmMatches = confirmName === projectName;
+
+  return (
+    <form action={formAction} className="space-y-6">
+      <div>
+        <label
+          htmlFor="targetSlug"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          Target organisation slug
+        </label>
+        <Input
+          id="targetSlug"
+          name="targetSlug"
+          placeholder="target-org-slug"
+          hasError={!!state.fieldErrors?.targetSlug}
+        />
+        {state.fieldErrors?.targetSlug && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {state.fieldErrors.targetSlug}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="confirmProjectName"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          Type <span className="font-mono font-semibold">{projectName}</span> to confirm
+        </label>
+        <Input
+          id="confirmProjectName"
+          name="confirmProjectName"
+          placeholder={projectName}
+          value={confirmName}
+          onChange={(e) => setConfirmName(e.target.value)}
+        />
+      </div>
+
+      {state.error && (
+        <Callout variant="error" title="Transfer failed" icon={RiErrorWarningLine}>
+          {state.error}
+        </Callout>
+      )}
+
+      <Button
+        type="submit"
+        variant="destructive"
+        disabled={!confirmMatches || isPending}
+        isLoading={isPending}
+      >
+        Transfer project
+      </Button>
+    </form>
+  );
+}

--- a/src/contexts/OrganisationContext.tsx
+++ b/src/contexts/OrganisationContext.tsx
@@ -3,6 +3,11 @@
 import React, { createContext, useContext } from 'react';
 import type { Project } from '@/lib/store';
 
+export interface SharedProject extends Project {
+  ownerName: string;
+  ownerSlug: string;
+}
+
 export interface OrganisationContextType {
   id: string;
   name: string;
@@ -10,6 +15,7 @@ export interface OrganisationContextType {
   ownerId: string;
   isActive: boolean;
   projects: Project[];
+  sharedProjects: SharedProject[];
   _count: {
     members: number;
     projects: number;

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,20 @@
+
+// TODO: Phase 4 — migrate cross-org audit events to a dedicated audit log table
+// with extended entityType support (project-share, project-access, project-transfer).
+// For now, cross-org audit events are written to console with a structured format.
+
+export interface AuditEvent {
+  userId: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  details?: Record<string, string>;
+}
+
+export function logAudit(event: AuditEvent): void {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    ...event,
+  };
+  console.log('[AUDIT]', JSON.stringify(entry));
+}

--- a/src/lib/share-invitations.ts
+++ b/src/lib/share-invitations.ts
@@ -1,0 +1,49 @@
+import nodemailer from 'nodemailer';
+import type { SharePermission } from '@/lib/store';
+
+const BASE_URL = process.env.AUTH_URL || 'http://localhost:3000';
+
+export async function sendShareInvitationEmail(
+  recipientEmail: string,
+  projectName: string,
+  hostOrgName: string,
+  permission: SharePermission,
+  recipientOrgName?: string,
+): Promise<void> {
+  const emailServer = process.env.EMAIL_SERVER;
+  const invitationsUrl = BASE_URL;
+
+  if (!emailServer) {
+    console.warn('EMAIL_SERVER not configured — skipping share invitation email');
+    console.log(`Share invitation: ${recipientEmail} invited to ${projectName} by ${hostOrgName}`);
+    return;
+  }
+
+  const transporter = nodemailer.createTransport(emailServer);
+  const recipientLabel = recipientOrgName ? `your organisation (${recipientOrgName})` : 'you';
+
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || 'noreply@enopax.com',
+    to: recipientEmail,
+    subject: `${hostOrgName} has invited ${recipientOrgName ?? 'you'} to collaborate on ${projectName}`,
+    html: `
+      <div style="max-width:500px; margin:0 auto; font-family:Arial,sans-serif; padding:40px 20px;">
+        <h2 style="color:#1f2937; margin-bottom:16px;">Project collaboration invitation</h2>
+        <p style="color:#4b5563; line-height:1.6;">
+          <strong>${hostOrgName}</strong> has invited ${recipientLabel} to collaborate on the project
+          <strong>${projectName}</strong> with <strong>${permission}</strong> access.
+        </p>
+        <div style="text-align:center; margin:32px 0;">
+          <a href="${invitationsUrl}"
+             style="background:#3b82f6; color:white; padding:12px 32px; border-radius:8px; text-decoration:none; font-weight:600;">
+            Review invitation
+          </a>
+        </div>
+        <p style="color:#9ca3af; font-size:13px;">
+          Log in to Enopax and visit your organisation's Invitations page to accept or decline.
+          If you don't recognise this invitation, you can safely ignore this email.
+        </p>
+      </div>
+    `,
+  });
+}

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -21,6 +21,7 @@ export type {
   Project,
   ProjectAccess,
   SharePermission,
+  ShareStatus,
   ProjectShare,
   Namespace,
   OrganisationJoinRequest,

--- a/src/lib/store/repositories/project-share.repository.ts
+++ b/src/lib/store/repositories/project-share.repository.ts
@@ -1,4 +1,4 @@
-import type { ProjectShare, SharePermission, ProjectOwnerType } from '../types';
+import type { ProjectShare, SharePermission, ShareStatus, ProjectOwnerType } from '../types';
 
 export interface CreateProjectShareData {
   projectId: string;
@@ -11,10 +11,11 @@ export interface CreateProjectShareData {
 export interface IProjectShareRepository {
   create(data: CreateProjectShareData): Promise<ProjectShare>;
   findById(id: string): Promise<ProjectShare | null>;
-  findByProjectId(projectId: string): Promise<ProjectShare[]>;
-  findSharedWithEntity(entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare[]>;
+  findByProjectId(projectId: string, status?: ShareStatus): Promise<ProjectShare[]>;
+  findSharedWithEntity(entityType: ProjectOwnerType, entityId: string, status?: ShareStatus): Promise<ProjectShare[]>;
   findByProjectAndEntity(projectId: string, entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare | null>;
   updatePermission(id: string, permission: SharePermission): Promise<ProjectShare>;
+  updateStatus(id: string, status: ShareStatus): Promise<ProjectShare>;
   revoke(id: string): Promise<void>;
   revokeAllForProject(projectId: string): Promise<void>;
 }

--- a/src/lib/store/repositories/project.repository.ts
+++ b/src/lib/store/repositories/project.repository.ts
@@ -43,5 +43,6 @@ export interface IProjectRepository {
   findByNameAndOrg(name: string, organisationId: string): Promise<Project | null>;
   findByOrgId(organisationId: string, options?: { isActive?: boolean }): Promise<Project[]>;
   update(id: string, data: UpdateProjectData): Promise<Project>;
+  transferToOrg(id: string, targetOrgId: string): Promise<Project>;
   search(query: string, limit?: number): Promise<Project[]>;
 }

--- a/src/lib/store/tinybase/project-share.tinybase.ts
+++ b/src/lib/store/tinybase/project-share.tinybase.ts
@@ -1,5 +1,5 @@
 import type { Store } from 'tinybase';
-import type { ProjectShare, SharePermission, ProjectOwnerType } from '../types';
+import type { ProjectShare, SharePermission, ShareStatus, ProjectOwnerType } from '../types';
 import type { IProjectShareRepository, CreateProjectShareData } from '../repositories/project-share.repository';
 import type { FileRecordPersister } from './file-record-persister';
 import crypto from 'crypto';
@@ -19,6 +19,7 @@ function rowToProjectShare(id: string, row: Record<string, any>): ProjectShare {
     permission: row.permission as SharePermission,
     sharedBy: row.sharedBy as string,
     sharedAt: new Date(row.sharedAt as string),
+    status: (row.status as ShareStatus) || 'ACTIVE',
   };
 }
 
@@ -27,7 +28,9 @@ export class TinyBaseProjectShareRepository implements IProjectShareRepository {
 
   async create(data: CreateProjectShareData): Promise<ProjectShare> {
     const existing = await this.findByProjectAndEntity(data.projectId, data.sharedWithType, data.sharedWithId);
-    if (existing) throw new Error(`Project ${data.projectId} is already shared with ${data.sharedWithType} ${data.sharedWithId}`);
+    if (existing && existing.status !== 'REVOKED' && existing.status !== 'DECLINED') {
+      throw new Error(`Project ${data.projectId} is already shared with ${data.sharedWithType} ${data.sharedWithId}`);
+    }
 
     const id = generateId();
     const now = new Date().toISOString();
@@ -39,6 +42,7 @@ export class TinyBaseProjectShareRepository implements IProjectShareRepository {
       permission: data.permission,
       sharedBy: data.sharedBy,
       sharedAt: now,
+      status: 'INVITED',
     });
 
     return rowToProjectShare(id, this.store.getRow(TABLE, id));
@@ -50,7 +54,7 @@ export class TinyBaseProjectShareRepository implements IProjectShareRepository {
     return rowToProjectShare(id, row);
   }
 
-  async findByProjectId(projectId: string): Promise<ProjectShare[]> {
+  async findByProjectId(projectId: string, status?: ShareStatus): Promise<ProjectShare[]> {
     const results: ProjectShare[] = [];
 
     const ids = this.persister
@@ -61,13 +65,15 @@ export class TinyBaseProjectShareRepository implements IProjectShareRepository {
       const row = this.store.getRow(TABLE, id);
       if (!this.persister && row.projectId !== projectId) continue;
       if (!row.sharedWithId) continue;
-      results.push(rowToProjectShare(id, row));
+      const share = rowToProjectShare(id, row);
+      if (status && share.status !== status) continue;
+      results.push(share);
     }
 
     return results;
   }
 
-  async findSharedWithEntity(entityType: ProjectOwnerType, entityId: string): Promise<ProjectShare[]> {
+  async findSharedWithEntity(entityType: ProjectOwnerType, entityId: string, status?: ShareStatus): Promise<ProjectShare[]> {
     const results: ProjectShare[] = [];
 
     const ids = this.persister
@@ -79,7 +85,9 @@ export class TinyBaseProjectShareRepository implements IProjectShareRepository {
       if (!this.persister && row.sharedWithId !== entityId) continue;
       if (row.sharedWithType !== entityType) continue;
       if (!row.projectId) continue;
-      results.push(rowToProjectShare(id, row));
+      const share = rowToProjectShare(id, row);
+      if (status && share.status !== status) continue;
+      results.push(share);
     }
 
     return results;
@@ -113,14 +121,25 @@ export class TinyBaseProjectShareRepository implements IProjectShareRepository {
     return rowToProjectShare(id, this.store.getRow(TABLE, id));
   }
 
+  async updateStatus(id: string, status: ShareStatus): Promise<ProjectShare> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.projectId) throw new Error(`ProjectShare ${id} not found`);
+
+    this.store.setCell(TABLE, id, 'status', status);
+
+    return rowToProjectShare(id, this.store.getRow(TABLE, id));
+  }
+
   async revoke(id: string): Promise<void> {
-    this.store.delRow(TABLE, id);
+    const row = this.store.getRow(TABLE, id);
+    if (!row.projectId) return;
+    this.store.setCell(TABLE, id, 'status', 'REVOKED');
   }
 
   async revokeAllForProject(projectId: string): Promise<void> {
     const shares = await this.findByProjectId(projectId);
     for (const share of shares) {
-      this.store.delRow(TABLE, share.id);
+      this.store.setCell(TABLE, share.id, 'status', 'REVOKED');
     }
   }
 }

--- a/src/lib/store/tinybase/project.tinybase.ts
+++ b/src/lib/store/tinybase/project.tinybase.ts
@@ -149,6 +149,18 @@ export class TinyBaseProjectRepository implements IProjectRepository {
     return rowToProject(id, this.store.getRow(TABLE, id));
   }
 
+  async transferToOrg(id: string, targetOrgId: string): Promise<Project> {
+    const row = this.store.getRow(TABLE, id);
+    if (!row.name) throw new Error(`Project ${id} not found`);
+
+    this.store.setCell(TABLE, id, 'organisationId', targetOrgId);
+    this.store.setCell(TABLE, id, 'ownerType', 'ORGANISATION');
+    this.store.setCell(TABLE, id, 'ownerId', targetOrgId);
+    this.store.setCell(TABLE, id, 'updatedAt', new Date().toISOString());
+
+    return rowToProject(id, this.store.getRow(TABLE, id));
+  }
+
   async search(query: string, limit: number = 10): Promise<Project[]> {
     const q = query.toLowerCase();
     let results: Project[] = [];

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -136,6 +136,8 @@ export interface ProjectAccess {
 
 export type SharePermission = 'VIEW' | 'CONTRIBUTE' | 'MANAGE';
 
+export type ShareStatus = 'INVITED' | 'ACTIVE' | 'DECLINED' | 'REVOKED';
+
 export interface ProjectShare {
   id: string;
   projectId: string;
@@ -144,6 +146,7 @@ export interface ProjectShare {
   permission: SharePermission;
   sharedBy: string;
   sharedAt: Date;
+  status: ShareStatus;
 }
 
 export interface Namespace {

--- a/tests/services/permissions.test.ts
+++ b/tests/services/permissions.test.ts
@@ -76,4 +76,27 @@ describe('resolveProjectPermissions', () => {
     const result = await resolveProjectPermissions('stranger-999', project.id);
     expect(result).toBeNull();
   });
+
+  it('returns role from cross-org team on shared project', async () => {
+    const orgA = await store.organisations.create({ name: 'org-a', ownerId: 'owner-a' });
+    const orgB = await store.organisations.create({ name: 'org-b', ownerId: 'owner-b' });
+
+    const project = await store.projects.create({ name: 'shared-proj', organisationId: orgA.id });
+
+    await store.projectShares.create({
+      projectId: project.id,
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: orgB.id,
+      permission: 'CONTRIBUTE',
+      sharedBy: 'owner-a',
+    });
+
+    const teamB = await store.teams.create({ organisationId: orgB.id, name: 'Dev', defaultProjectRole: 'DEVELOPER' });
+    await store.teamMembers.add({ teamId: teamB.id, userId: 'user-b', addedBy: 'owner-b' });
+
+    await store.projectAccess.grant({ projectId: project.id, teamId: teamB.id, role: 'DEVELOPER', grantedBy: 'owner-a' });
+
+    const result = await resolveProjectPermissions('user-b', project.id);
+    expect(result).toBe('DEVELOPER');
+  });
 });

--- a/tests/store/tinybase/project-share.tinybase.test.ts
+++ b/tests/store/tinybase/project-share.tinybase.test.ts
@@ -75,7 +75,7 @@ describe('TinyBaseProjectShareRepository', () => {
     expect(updated.sharedWithId).toBe('org-2');
   });
 
-  it('revokes a share', async () => {
+  it('revokes a share (soft delete — sets status to REVOKED)', async () => {
     const share = await repo.create({
       projectId: 'proj-1',
       sharedWithType: 'ORGANISATION',
@@ -87,9 +87,73 @@ describe('TinyBaseProjectShareRepository', () => {
     await repo.revoke(share.id);
 
     const found = await repo.findById(share.id);
-    expect(found).toBeNull();
+    expect(found).not.toBeNull();
+    expect(found!.status).toBe('REVOKED');
 
-    const shares = await repo.findByProjectId('proj-1');
-    expect(shares).toHaveLength(0);
+    const activeShares = await repo.findByProjectId('proj-1', 'ACTIVE');
+    expect(activeShares).toHaveLength(0);
+
+    const allShares = await repo.findByProjectId('proj-1');
+    expect(allShares).toHaveLength(1);
+    expect(allShares[0].status).toBe('REVOKED');
+  });
+
+  it('new shares start as INVITED status', async () => {
+    const share = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'CONTRIBUTE',
+      sharedBy: 'admin',
+    });
+    expect(share.status).toBe('INVITED');
+  });
+
+  it('updateStatus changes status', async () => {
+    const share = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'VIEW',
+      sharedBy: 'admin',
+    });
+
+    const updated = await repo.updateStatus(share.id, 'ACTIVE');
+    expect(updated.status).toBe('ACTIVE');
+  });
+
+  it('findSharedWithEntity can filter by status', async () => {
+    const share = await repo.create({ projectId: 'proj-1', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'VIEW', sharedBy: 'admin' });
+    await repo.updateStatus(share.id, 'ACTIVE');
+    await repo.create({ projectId: 'proj-2', sharedWithType: 'ORGANISATION', sharedWithId: 'org-2', permission: 'VIEW', sharedBy: 'admin' });
+
+    const activeOnly = await repo.findSharedWithEntity('ORGANISATION', 'org-2', 'ACTIVE');
+    expect(activeOnly).toHaveLength(1);
+    expect(activeOnly[0].projectId).toBe('proj-1');
+
+    const invitedOnly = await repo.findSharedWithEntity('ORGANISATION', 'org-2', 'INVITED');
+    expect(invitedOnly).toHaveLength(1);
+    expect(invitedOnly[0].projectId).toBe('proj-2');
+  });
+
+  it('allows re-sharing after revoke', async () => {
+    const share = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'VIEW',
+      sharedBy: 'admin',
+    });
+    await repo.revoke(share.id);
+
+    const reshared = await repo.create({
+      projectId: 'proj-1',
+      sharedWithType: 'ORGANISATION',
+      sharedWithId: 'org-2',
+      permission: 'MANAGE',
+      sharedBy: 'admin',
+    });
+    expect(reshared.status).toBe('INVITED');
+    expect(reshared.permission).toBe('MANAGE');
   });
 });


### PR DESCRIPTION
## Summary

Completes the access-control concept. Cross-org teams on shared projects, invite+accept sharing, shared project visibility, project transfer, and audit trail.

### 3A — Cross-org teams on shared projects
- Collab orgs with CONTRIBUTE/MANAGE shares can assign their own teams to the project
- Permission resolver automatically picks up cross-org team grants (no resolver change needed)
- Access page shows teams from collab orgs with org badge

### 3B — Invite + Accept sharing flow
- ProjectShare gains \`status: INVITED | ACTIVE | DECLINED | REVOKED\`
- Host admin shares → status=INVITED → collab org admin accepts/declines
- New \`/{slug}/invitations\` page for pending share invitations
- Share invitation notification email via existing SMTP config
- Revoke is now soft-delete (status=REVOKED, audit trail preserved)

### 3C — Shared projects in recipient view
- Shared projects appear on org overview with "Owner: {name}" badge
- Links point to host org's namespace (\`/{ownerSlug}/{project}\`)
- Loaded via OrganisationContext for both \`/[slug]/\` and legacy \`/orga/\` layouts

### 3D — Project transfer
- OWNER-only: transfer project from one org to another
- Revokes all team access + shares (clean slate for new owner)
- Confirm-by-name safety gate
- Transfer page at \`/{slug}/{project}/transfer\`

### 3E — Cross-org audit trail
- \`logAudit()\` helper logging structured events for: share-created, share-accepted, share-declined, share-revoked, cross-org-access-granted, project-transferred
- Console-based for now (TODO: migrate to proper audit table)

### Stats
- 6 commits, 26 files, ~1040 lines
- 279 tests green (+5 new: cross-org permission test + share status tests)