### PR TITLE
fix(auth): redirect to homepage on sign-out

### DIFF
--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -119,7 +119,7 @@ export default function UserBarMenu({
           action={async () => {
             'use server';
             await signOut({
-              redirectTo: '/signin',
+              redirectTo: '/',
             });
           }}
         >


### PR DESCRIPTION
Was redirecting to /signin → bounced to Dex. Now redirects to / (homepage).