### PR TITLE
feat(homepage): Enopax K8s positioning — replace legacy IPFS content

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,16 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import Container from '@/components/common/Container';
 import { Button } from '@/components/common/Button';
+import {
+  RiShieldLine,
+  RiServerLine,
+  RiTimeLine,
+  RiOpenSourceLine,
+  RiTeamLine,
+  RiGlobalLine,
+} from '@remixicon/react';
 
 export default async function Page() {
   const session = await auth();
@@ -13,42 +20,171 @@ export default async function Page() {
 
   return (
     <main>
-      {/* Hero Section */}
       <section className="mx-auto max-w-6xl">
         <Container>
-          <div className="relative w-full h-[600px] overflow-hidden">
-            <Image
-              src="/assets/bg.png"
-              alt="Background"
-              className="object-cover object-top opacity-10 dark:invert"
-              fill
-              priority
-            />
-            <div className="absolute inset-0 flex flex-col justify-center items-center text-center">
-              <div className="relative z-10 max-w-2xl px-4">
-                <h1 className="text-5xl md:text-7xl font-bold text-brand-500 mb-6">
-                  Resource Provisioning
-                </h1>
-                <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 mb-8">
-                  Deploy and manage infrastructure resources with one click.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                  <Link href="/orga/organisations">
-                    <Button className="px-8 py-3 text-lg font-semibold bg-brand-600 hover:bg-brand-700 text-white">
-                      Start Now
-                    </Button>
-                  </Link>
-                  <Link href="/docs/api">
-                    <Button variant="outline" className="px-8 py-3 text-lg font-semibold">
-                      View API Docs
-                    </Button>
-                  </Link>
-                </div>
+          <div className="relative w-full py-24 md:py-36">
+            <div className="max-w-3xl mx-auto text-center px-4">
+              <h1 className="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white mb-6 leading-tight">
+                Managed Kubernetes.
+                <br />
+                <span className="text-brand-500">European Infrastructure.</span>
+              </h1>
+              <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 mb-10 max-w-2xl mx-auto">
+                Production-grade Kubernetes clusters on EU cloud providers — deployed in minutes, not days.
+                No vendor lock-in. GDPR-compliant by design.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Link href="/register">
+                  <Button className="px-8 py-3 text-lg font-semibold">
+                    Get Started Free
+                  </Button>
+                </Link>
+                <Link href="/signin">
+                  <Button variant="secondary" className="px-8 py-3 text-lg font-semibold">
+                    Sign In
+                  </Button>
+                </Link>
               </div>
             </div>
           </div>
         </Container>
       </section>
+
+      <section className="bg-gray-50 dark:bg-gray-900 py-20">
+        <Container>
+          <div className="max-w-6xl mx-auto px-4">
+            <h2 className="text-3xl font-bold text-center text-gray-900 dark:text-white mb-4">
+              Why Enopax?
+            </h2>
+            <p className="text-center text-gray-600 dark:text-gray-400 mb-14 max-w-2xl mx-auto">
+              We give small and medium businesses, startups, and agencies access to Kubernetes
+              without the complexity of running it — all on EU infrastructure.
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              <FeatureCard
+                icon={RiTimeLine}
+                title="Clusters in Minutes"
+                description="Fully configured Kubernetes clusters with CNI, storage, and load balancing — ready to deploy your workloads."
+              />
+              <FeatureCard
+                icon={RiShieldLine}
+                title="EU Data Sovereignty"
+                description="All infrastructure runs on European cloud providers. Your data never leaves the EU. GDPR-compliant by design."
+              />
+              <FeatureCard
+                icon={RiOpenSourceLine}
+                title="No Vendor Lock-in"
+                description="Standard Kubernetes. Export your workloads any time. No proprietary APIs, no hidden dependencies."
+              />
+              <FeatureCard
+                icon={RiServerLine}
+                title="Managed Operations"
+                description="We handle upgrades, monitoring, and maintenance. You focus on your application, not your infrastructure."
+              />
+              <FeatureCard
+                icon={RiTeamLine}
+                title="Team Collaboration"
+                description="Organisations, teams, and role-based access control. Share projects across organisations with fine-grained permissions."
+              />
+              <FeatureCard
+                icon={RiGlobalLine}
+                title="AI-First Platform"
+                description="Built with AI at the core — automating provisioning, optimising resources, and simplifying operations."
+              />
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-20">
+        <Container>
+          <div className="max-w-4xl mx-auto px-4">
+            <h2 className="text-3xl font-bold text-center text-gray-900 dark:text-white mb-14">
+              Built for
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <AudienceCard
+                title="SMEs & Startups"
+                description="Outgrown shared hosting? Need containers but can't justify a full DevOps hire? We handle the infrastructure so you can ship product."
+              />
+              <AudienceCard
+                title="Agencies & IT Service Providers"
+                description="Provision isolated environments per client. Multi-cluster management, hosted control planes, API-driven provisioning."
+              />
+              <AudienceCard
+                title="Developers"
+                description="Kubernetes without the ops overhead. Transparent pricing, standard APIs, developer-friendly tooling."
+              />
+              <AudienceCard
+                title="Regulated Industries"
+                description="Healthcare, finance, public sector — strict data residency requirements met by EU-only infrastructure with audit trails."
+              />
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="bg-brand-50 dark:bg-brand-950 py-20">
+        <Container>
+          <div className="max-w-2xl mx-auto text-center px-4">
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+              Ready to deploy?
+            </h2>
+            <p className="text-lg text-gray-600 dark:text-gray-300 mb-8">
+              Create your free account and provision your first cluster in minutes.
+            </p>
+            <Link href="/register">
+              <Button className="px-10 py-3 text-lg font-semibold">
+                Get Started
+              </Button>
+            </Link>
+          </div>
+        </Container>
+      </section>
+
+      <footer className="border-t border-gray-200 dark:border-gray-800 py-10">
+        <Container>
+          <div className="max-w-6xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Enopax — European Kubernetes Infrastructure
+            </p>
+            <div className="flex gap-6 text-sm text-gray-500 dark:text-gray-400">
+              <Link href="/signin" className="hover:text-gray-900 dark:hover:text-white">Sign In</Link>
+              <Link href="/register" className="hover:text-gray-900 dark:hover:text-white">Register</Link>
+            </div>
+          </div>
+        </Container>
+      </footer>
     </main>
+  );
+}
+
+function FeatureCard({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="p-6 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
+      <div className="p-3 bg-brand-100 dark:bg-brand-900/30 rounded-lg w-fit mb-4">
+        <Icon className="h-6 w-6 text-brand-600 dark:text-brand-400" />
+      </div>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">{title}</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
+function AudienceCard({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="p-6 border border-gray-200 dark:border-gray-700 rounded-xl">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">{title}</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{description}</p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the old "Resource Provisioning" / IPFS-era homepage with content that matches Enopax's actual mission post-pivot: managed Kubernetes on EU infrastructure.

Content sourced from \`enopax/orga\` PR #9 (vision.md, target-audience.md, decision records).

## Sections

1. **Hero** — "Managed Kubernetes. European Infrastructure." + tagline about GDPR and no lock-in
2. **Why Enopax** — 6 feature cards (Clusters in Minutes, EU Sovereignty, No Vendor Lock-in, Managed Ops, Team Collaboration, AI-First)
3. **Built for** — 4 audience cards (SMEs, Agencies, Developers, Regulated Industries)
4. **CTA** — "Ready to deploy?" → Register
5. **Footer** — Minimal brand line

Design kept intentionally simple — styling polish comes later.

## Test plan

- [ ] \`/\` shows new homepage for unauthenticated users
- [ ] Logged-in users still redirect to \`/orga\`