### PR TITLE
feat(access): early-bird registration with admin activation

### DIFF
--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -5,6 +5,7 @@ import { createDexUser, generateUserIdFromEmail } from '@/lib/dex/client';
 import { getStoreAsync } from '@/lib/store';
 import { createVerificationToken, sendVerificationEmail } from '@/lib/email-verification';
 import { isBlockedName } from '@/lib/name-validation';
+import { sendAdminRegistrationNotification } from '@/lib/admin-notifications';
 
 export interface RegisterState {
   success?: boolean;
@@ -72,15 +73,18 @@ export async function register(
         name,
         email,
         slug: username,
-        role: 'CUSTOMER',
+        role: 'GUEST',
       });
     }
 
     await store.namespaces.register({ slug: username, entityType: 'USER', entityId: user.id });
 
-    // Send verification email
+    // Send verification email to user
     const token = await createVerificationToken(user.id, email);
     await sendVerificationEmail(email, token);
+
+    // Notify admins about new registration
+    await sendAdminRegistrationNotification(user.id, email, name || username);
 
     const inviteToken = (formData.get('inviteToken') as string)?.trim();
     const redirectTo = inviteToken ? `/accept-invite?token=${inviteToken}` : '/';

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,6 +1,9 @@
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import EmailVerificationBanner from '@/components/EmailVerificationBanner';
+import Container from '@/components/common/Container';
+import { Card } from '@/components/common/Card';
+import { RiTimeLine } from '@remixicon/react';
 
 export default async function MainLayout({
   children,
@@ -11,6 +14,27 @@ export default async function MainLayout({
 
   if (!session) {
     redirect('/signin');
+  }
+
+  if (session.user?.role === 'GUEST') {
+    return (
+      <main className="min-h-[80vh] flex items-center justify-center px-4">
+        <Card className="w-full max-w-lg p-8 text-center">
+          <div className="inline-flex p-3 bg-brand-100 dark:bg-brand-900/30 rounded-full mb-4">
+            <RiTimeLine className="h-8 w-8 text-brand-600 dark:text-brand-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">
+            Thanks for registering!
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-2">
+            Your account is on the early access list. We&apos;ll notify you when your access is activated.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            Signed in as {session.user.email}
+          </p>
+        </Card>
+      </main>
+    );
   }
 
   return (

--- a/src/app/api/admin/activate-user/route.ts
+++ b/src/app/api/admin/activate-user/route.ts
@@ -1,0 +1,46 @@
+import { getStoreAsync } from '@/lib/store';
+import { redirect } from 'next/navigation';
+import crypto from 'crypto';
+
+function verifyToken(userId: string, token: string): boolean {
+  const secret = process.env.AUTH_SECRET || '';
+  const expected = crypto.createHmac('sha256', secret).update(userId).digest('hex');
+  return token === expected;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+  const token = searchParams.get('token');
+
+  if (!userId || !token || !verifyToken(userId, token)) {
+    return new Response(
+      '<html><body style="font-family:sans-serif;text-align:center;padding:60px"><h2>Invalid activation link</h2></body></html>',
+      { status: 403, headers: { 'Content-Type': 'text/html' } }
+    );
+  }
+
+  const store = await getStoreAsync();
+  const user = await store.users.findById(userId);
+
+  if (!user) {
+    return new Response(
+      '<html><body style="font-family:sans-serif;text-align:center;padding:60px"><h2>User not found</h2></body></html>',
+      { status: 404, headers: { 'Content-Type': 'text/html' } }
+    );
+  }
+
+  if (user.role === 'CUSTOMER' || user.role === 'ADMIN') {
+    return new Response(
+      '<html><body style="font-family:sans-serif;text-align:center;padding:60px"><h2>Already activated</h2><p>' + user.email + ' is already a ' + user.role + '.</p></body></html>',
+      { status: 200, headers: { 'Content-Type': 'text/html' } }
+    );
+  }
+
+  await store.users.update(userId, { role: 'CUSTOMER' });
+
+  return new Response(
+    '<html><body style="font-family:sans-serif;text-align:center;padding:60px"><h2>Account activated</h2><p>' + user.email + ' now has full access.</p><p><a href="/admin/users">Go to admin</a></p></body></html>',
+    { status: 200, headers: { 'Content-Type': 'text/html' } }
+  );
+}

--- a/src/lib/admin-notifications.ts
+++ b/src/lib/admin-notifications.ts
@@ -1,0 +1,54 @@
+import nodemailer from 'nodemailer';
+import crypto from 'crypto';
+
+const BASE_URL = process.env.AUTH_URL || 'http://localhost:3000';
+const ADMIN_EMAIL = 'register@enopax.com';
+
+function generateActivationToken(userId: string): string {
+  const secret = process.env.AUTH_SECRET || '';
+  return crypto.createHmac('sha256', secret).update(userId).digest('hex');
+}
+
+export async function sendAdminRegistrationNotification(
+  userId: string,
+  userEmail: string,
+  userName: string,
+): Promise<void> {
+  const emailServer = process.env.EMAIL_SERVER;
+  const activationToken = generateActivationToken(userId);
+  const activateUrl = `${BASE_URL}/api/admin/activate-user?userId=${userId}&token=${activationToken}`;
+
+  if (!emailServer) {
+    console.warn('EMAIL_SERVER not configured — skipping admin notification');
+    console.log(`New registration: ${userEmail} (${userName})`);
+    console.log(`Activation link: ${activateUrl}`);
+    return;
+  }
+
+  const transporter = nodemailer.createTransport(emailServer);
+
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || 'noreply@enopax.com',
+    to: ADMIN_EMAIL,
+    subject: `New registration: ${userName} (${userEmail})`,
+    html: `
+      <div style="max-width:500px; margin:0 auto; font-family:Arial,sans-serif; padding:40px 20px;">
+        <h2 style="color:#1f2937; margin-bottom:16px;">New Enopax Registration</h2>
+        <table style="width:100%; border-collapse:collapse; margin-bottom:24px;">
+          <tr><td style="padding:8px 0; color:#6b7280;">Name</td><td style="padding:8px 0; font-weight:600;">${userName}</td></tr>
+          <tr><td style="padding:8px 0; color:#6b7280;">Email</td><td style="padding:8px 0; font-weight:600;">${userEmail}</td></tr>
+          <tr><td style="padding:8px 0; color:#6b7280;">Status</td><td style="padding:8px 0;"><span style="background:#fef3c7; color:#92400e; padding:2px 8px; border-radius:4px; font-size:13px;">Early Access</span></td></tr>
+        </table>
+        <div style="text-align:center; margin:32px 0;">
+          <a href="${activateUrl}"
+             style="background:#3b82f6; color:white; padding:12px 32px; border-radius:8px; text-decoration:none; font-weight:600;">
+            Activate Account
+          </a>
+        </div>
+        <p style="color:#9ca3af; font-size:13px; text-align:center;">
+          Clicking this link will give the user full platform access.
+        </p>
+      </div>
+    `,
+  });
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -42,7 +42,7 @@ export const {
           name: user.name || null,
           email: user.email,
           image: user.image || undefined,
-          role: 'CUSTOMER',
+          role: 'GUEST',
         });
       }
 


### PR DESCRIPTION
## Summary

New users register as \`GUEST\` (waiting list). Admins get an email at \`register@enopax.com\` with a one-click activation link.

### Flow
1. User registers → account created as \`GUEST\`
2. Email sent to \`register@enopax.com\` with user info + "Activate Account" button
3. Admin clicks → user promoted to \`CUSTOMER\` → full platform access
4. Until activated, user sees "Thanks for registering" waiting page

### Security
- Activation link is HMAC-signed with AUTH_SECRET — can't be forged
- Link is idempotent — clicking twice is safe
- No session required to activate (admin can click from any device/email client)

## Test plan
- [ ] Register new user → role is GUEST, sees waiting page
- [ ] Email arrives at register@enopax.com with activation link
- [ ] Click activation link → user becomes CUSTOMER
- [ ] Existing CUSTOMER/ADMIN users unaffected