### PR TITLE
fix: dark mode CTA and missing mobile navbar on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,14 @@ export default async function Page() {
 
   return (
     <main>
+      {/* Mobile header — visible only below lg where UserBar is hidden */}
+      <div className="lg:hidden flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-800">
+        <span className="text-sm font-semibold text-gray-900 dark:text-white">Enopax</span>
+        <Link href="/signin">
+          <Button variant="secondary" className="text-sm">Sign In</Button>
+        </Link>
+      </div>
+
       <section className="mx-auto max-w-6xl">
         <Container>
           <div className="relative w-full py-16 md:py-20">

--- a/src/components/layout/UserBar.tsx
+++ b/src/components/layout/UserBar.tsx
@@ -6,11 +6,10 @@ export default function UserBar({
   user?: Object,
 }) {
   return (
-    <header className="hidden lg:flex border-b">
+    <header className="hidden lg:flex border-b border-gray-200 dark:border-gray-800">
       <div className="px-4 text-sm w-full">
-        <div className="mx-auto max-w-6xl w-full relative flex items-center">          
+        <div className="mx-auto max-w-6xl w-full relative flex items-center">
           <span className="text-xs text-gray-400 dark:text-gray-600">v{process.env.APP_VERSION}</span>
-          {/* UserBarMenu positioned on the right */}
           <div className="ml-auto px-4">
             <UserBarMenu user={user} />
           </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
           700: '#2f3bb8',  // Deep blue-purple
           800: '#252f94',  // Dark blue-purple
           900: '#1e2470',  // Very dark blue-purple
+          950: '#141a4d',  // Deepest blue-purple
         }
       },
       keyframes: {


### PR DESCRIPTION
## Summary
- **Dark mode CTA**: Added missing `brand-950` colour to Tailwind config — the homepage CTA section used `dark:bg-brand-950` but the shade wasn't defined, causing white text on a near-white background on iOS dark mode
- **Mobile navbar**: Added a lightweight mobile header (brand + Sign In button) to the homepage — `UserBar` is `hidden lg:flex` and `MobileNavigation` only renders on authenticated pages, leaving mobile visitors with no way to sign in

## Test plan
- [ ] Open homepage on iOS in dark mode — CTA section should have dark blue-purple background with readable white text
- [ ] Open homepage on mobile (any device) — should see "Enopax" + "Sign In" header bar
- [ ] Desktop homepage unchanged — UserBar still shows at top
- [ ] Authenticated pages — MobileNavigation still works as before, no duplicate headers