### PR TITLE
fix: add missing dark mode colour variants across all pages

### DIFF
--- a/src/app/(auth)/register/RegisterForm.tsx
+++ b/src/app/(auth)/register/RegisterForm.tsx
@@ -67,7 +67,7 @@ export default function RegisterForm({ prefilledEmail, inviteToken, organisation
 
             <div>
               <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Display Name <span className="text-gray-400">(optional)</span>
+                Display Name <span className="text-gray-400 dark:text-gray-500">(optional)</span>
               </label>
               <input
                 id="name"

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -10,7 +10,7 @@ export default function SignInPage() {
 
   return (
     <main className="min-h-[80vh] flex items-center justify-center">
-      <p className="text-gray-500">Redirecting to login...</p>
+      <p className="text-gray-500 dark:text-gray-400">Redirecting to login...</p>
     </main>
   );
 }

--- a/src/app/(main)/[slug]/[projectName]/(resource)/new/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/(resource)/new/page.tsx
@@ -150,14 +150,14 @@ export default function AddResourcePage() {
 
             <div className="space-y-3 text-sm">
               <div>
-                <span className="text-gray-500">Project Name:</span>
+                <span className="text-gray-500 dark:text-gray-400">Project Name:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {project.name}
                 </span>
               </div>
 
               <div>
-                <span className="text-gray-500">Organisation:</span>
+                <span className="text-gray-500 dark:text-gray-400">Organisation:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {organisation.name}
                 </span>
@@ -165,7 +165,7 @@ export default function AddResourcePage() {
 
               {project.description && (
                 <div>
-                  <span className="text-gray-500">Description:</span>
+                  <span className="text-gray-500 dark:text-gray-400">Description:</span>
                   <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm">
                     {project.description}
                   </p>

--- a/src/app/(main)/[slug]/[projectName]/access/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/page.tsx
@@ -116,7 +116,7 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
 
       {accessWithTeams.length === 0 ? (
         <Card className="p-12 text-center">
-          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 dark:text-gray-600 mb-3" />
           <p className="text-gray-600 dark:text-gray-400 font-medium">No teams have been granted access yet</p>
           {availableTeams.length > 0 && (
             <div className="mt-4">

--- a/src/app/(main)/[slug]/[projectName]/settings/ProjectSettingsClient.tsx
+++ b/src/app/(main)/[slug]/[projectName]/settings/ProjectSettingsClient.tsx
@@ -118,17 +118,17 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
 
             <div className="space-y-3 text-sm">
               <div>
-                <span className="text-gray-500">Organisation:</span>
+                <span className="text-gray-500 dark:text-gray-400">Organisation:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">{organisation.name}</span>
               </div>
 
               <div>
-                <span className="text-gray-500">Progress:</span>
+                <span className="text-gray-500 dark:text-gray-400">Progress:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">{project.progress}%</span>
               </div>
 
               <div>
-                <span className="text-gray-500">Created:</span>
+                <span className="text-gray-500 dark:text-gray-400">Created:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {new Date(project.createdAt).toLocaleDateString('en-GB', {
                     year: 'numeric',
@@ -139,7 +139,7 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
               </div>
 
               <div>
-                <span className="text-gray-500">Last Updated:</span>
+                <span className="text-gray-500 dark:text-gray-400">Last Updated:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {new Date(project.updatedAt).toLocaleDateString('en-GB', {
                     year: 'numeric',
@@ -151,7 +151,7 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
 
               {project.description && (
                 <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
-                  <span className="text-gray-500">Description:</span>
+                  <span className="text-gray-500 dark:text-gray-400">Description:</span>
                   <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm">{project.description}</p>
                 </div>
               )}

--- a/src/app/(main)/[slug]/[projectName]/share/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/share/page.tsx
@@ -141,7 +141,7 @@ export default async function ProjectSharePage({ params }: ProjectSharePageProps
 
         {sharesWithNames.length === 0 && (
           <Card className="p-12 text-center">
-            <RiShareLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+            <RiShareLine className="mx-auto w-10 h-10 text-gray-400 dark:text-gray-600 mb-3" />
             <p className="text-gray-600 dark:text-gray-400 font-medium">
               This project has not been shared with anyone yet
             </p>

--- a/src/app/(main)/[slug]/[projectName]/transfer/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/transfer/page.tsx
@@ -52,7 +52,7 @@ export default async function TransferProjectPage({ params }: TransferProjectPag
       <Card className="max-w-lg">
         <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center gap-2">
           <span className="font-semibold text-gray-900 dark:text-white">{organisation.name}</span>
-          <RiArrowRightLine className="w-4 h-4 text-gray-400" />
+          <RiArrowRightLine className="w-4 h-4 text-gray-400 dark:text-gray-600" />
           <span className="text-sm text-gray-500 dark:text-gray-400">target organisation</span>
         </div>
         <div className="p-6">

--- a/src/app/(main)/[slug]/invitations/page.tsx
+++ b/src/app/(main)/[slug]/invitations/page.tsx
@@ -65,7 +65,7 @@ export default async function InvitationsPage({ params }: InvitationsPageProps) 
 
       {invitationsWithDetails.length === 0 ? (
         <Card className="p-12 text-center">
-          <RiMailLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <RiMailLine className="mx-auto w-10 h-10 text-gray-400 dark:text-gray-600 mb-3" />
           <p className="text-gray-600 dark:text-gray-400 font-medium">
             No pending invitations
           </p>

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function NamespacePage({ params }: NamespacePageProps) {
     return (
       <main className="p-8">
         <h1 className="text-2xl font-bold">{user.name || user.slug}</h1>
-        <p className="text-gray-500 mt-2">Personal projects coming soon</p>
+        <p className="text-gray-500 dark:text-gray-400 mt-2">Personal projects coming soon</p>
       </main>
     );
   }

--- a/src/app/(main)/[slug]/settings/test-resource-api/page.tsx
+++ b/src/app/(main)/[slug]/settings/test-resource-api/page.tsx
@@ -34,8 +34,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
     return (
       <div className="p-8">
         <Card className="p-8 text-center">
-          <p className="text-gray-600">You do not have permission to access this page.</p>
-          <p className="text-sm text-gray-500 mt-2">Only organisation owners can test Resource API integration.</p>
+          <p className="text-gray-600 dark:text-gray-300">You do not have permission to access this page.</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">Only organisation owners can test Resource API integration.</p>
         </Card>
       </div>
     );
@@ -51,15 +51,15 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
           <div className="flex items-center gap-3 mb-2">
             <Link
               href={`/${slug}/settings`}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
             >
               <RiArrowLeftLine className="w-5 h-5" />
             </Link>
-            <h1 className="text-3xl font-semibold text-gray-900">
+            <h1 className="text-3xl font-semibold text-gray-900 dark:text-white">
               Resource API Test
             </h1>
           </div>
-          <p className="text-gray-600">
+          <p className="text-gray-600 dark:text-gray-300">
             Test connectivity and integration with the Resource API
           </p>
         </div>
@@ -67,8 +67,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
 
       <Card className="p-6">
         <div className="mb-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Resource API Testing</h2>
-          <p className="text-sm text-gray-600">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">About Resource API Testing</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
             This page allows you to test the connection between the Platform and the Resource API.
             You can discover available providers, provision test resources, check their status, and clean up test resources.
           </p>

--- a/src/app/(main)/[slug]/teams/[teamName]/page.tsx
+++ b/src/app/(main)/[slug]/teams/[teamName]/page.tsx
@@ -102,7 +102,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 
         {members.length === 0 ? (
           <div className="p-12 text-center">
-            <RiUserLine className="mx-auto w-8 h-8 text-gray-400 mb-3" />
+            <RiUserLine className="mx-auto w-8 h-8 text-gray-400 dark:text-gray-600 mb-3" />
             <p className="text-gray-600 dark:text-gray-400">No members in this team yet.</p>
             {canManage && (
               <div className="mt-4">

--- a/src/app/(main)/[slug]/teams/page.tsx
+++ b/src/app/(main)/[slug]/teams/page.tsx
@@ -68,7 +68,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
 
       {teamsWithCounts.length === 0 ? (
         <Card className="p-12 text-center">
-          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 dark:text-gray-600 mb-3" />
           <p className="text-gray-600 dark:text-gray-400 font-medium">No teams yet</p>
           {canManage && (
             <p className="text-sm text-gray-500 dark:text-gray-500 mt-1">
@@ -108,7 +108,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
                     <span className="text-sm text-gray-500 dark:text-gray-400">
                       {team.memberCount} {team.memberCount === 1 ? 'member' : 'members'}
                     </span>
-                    <RiArrowRightLine className="w-4 h-4 text-gray-400" />
+                    <RiArrowRightLine className="w-4 h-4 text-gray-400 dark:text-gray-600" />
                   </div>
                 </div>
               </Card>

--- a/src/app/(main)/admin/projects/page.tsx
+++ b/src/app/(main)/admin/projects/page.tsx
@@ -42,7 +42,7 @@ export default async function ProjectAdminPage() {
                         <Badge variant={project.status === 'ACTIVE' ? 'success' : 'warning'}>
                           {project.status}
                         </Badge>
-                        <span className="text-xs text-gray-400">{project.createdAt.toLocaleDateString('en-GB')}</span>
+                        <span className="text-xs text-gray-400 dark:text-gray-500">{project.createdAt.toLocaleDateString('en-GB')}</span>
                       </div>
                     </div>
                   </Link>
@@ -52,7 +52,7 @@ export default async function ProjectAdminPage() {
           ))}
 
           {totalProjects === 0 && (
-            <p className="text-gray-500 text-center py-12">No projects yet</p>
+            <p className="text-gray-500 dark:text-gray-400 text-center py-12">No projects yet</p>
           )}
         </div>
       </Container>

--- a/src/app/(main)/admin/requests/page.tsx
+++ b/src/app/(main)/admin/requests/page.tsx
@@ -35,7 +35,7 @@ export default async function RequestsAdminPage() {
         <Headline>Guest Requests ({requests.length})</Headline>
 
         {requests.length === 0 ? (
-          <p className="text-gray-500 text-center py-12">No requests yet</p>
+          <p className="text-gray-500 dark:text-gray-400 text-center py-12">No requests yet</p>
         ) : (
           <div className="space-y-4 mt-6">
             {requests.map((req, i) => (
@@ -43,9 +43,9 @@ export default async function RequestsAdminPage() {
                 <div className="flex items-start justify-between mb-2">
                   <div>
                     <span className="font-medium text-gray-900 dark:text-white">{req.name || 'Anonymous'}</span>
-                    <span className="ml-2 text-sm text-gray-500">{req.email}</span>
+                    <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">{req.email}</span>
                   </div>
-                  <span className="text-xs text-gray-400">{new Date(req.createdAt).toLocaleString('en-GB')}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">{new Date(req.createdAt).toLocaleString('en-GB')}</span>
                 </div>
                 <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{req.message}</p>
               </Card>

--- a/src/app/(main)/orga/[orgaName]/[projectName]/(resource)/new/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/(resource)/new/page.tsx
@@ -150,14 +150,14 @@ export default function AddResourcePage() {
 
             <div className="space-y-3 text-sm">
               <div>
-                <span className="text-gray-500">Project Name:</span>
+                <span className="text-gray-500 dark:text-gray-400">Project Name:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {project.name}
                 </span>
               </div>
 
               <div>
-                <span className="text-gray-500">Organisation:</span>
+                <span className="text-gray-500 dark:text-gray-400">Organisation:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {organisation.name}
                 </span>
@@ -165,7 +165,7 @@ export default function AddResourcePage() {
 
               {project.description && (
                 <div>
-                  <span className="text-gray-500">Description:</span>
+                  <span className="text-gray-500 dark:text-gray-400">Description:</span>
                   <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm">
                     {project.description}
                   </p>

--- a/src/app/(main)/orga/[orgaName]/[projectName]/access/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/access/page.tsx
@@ -86,7 +86,7 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
 
       {accessWithTeams.length === 0 ? (
         <Card className="p-12 text-center">
-          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 dark:text-gray-600 mb-3" />
           <p className="text-gray-600 dark:text-gray-400 font-medium">No teams have been granted access yet</p>
           {availableTeams.length > 0 && (
             <div className="mt-4">

--- a/src/app/(main)/orga/[orgaName]/[projectName]/settings/ProjectSettingsClient.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/settings/ProjectSettingsClient.tsx
@@ -118,17 +118,17 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
 
             <div className="space-y-3 text-sm">
               <div>
-                <span className="text-gray-500">Organisation:</span>
+                <span className="text-gray-500 dark:text-gray-400">Organisation:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">{organisation.name}</span>
               </div>
 
               <div>
-                <span className="text-gray-500">Progress:</span>
+                <span className="text-gray-500 dark:text-gray-400">Progress:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">{project.progress}%</span>
               </div>
 
               <div>
-                <span className="text-gray-500">Created:</span>
+                <span className="text-gray-500 dark:text-gray-400">Created:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {new Date(project.createdAt).toLocaleDateString('en-GB', {
                     year: 'numeric',
@@ -139,7 +139,7 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
               </div>
 
               <div>
-                <span className="text-gray-500">Last Updated:</span>
+                <span className="text-gray-500 dark:text-gray-400">Last Updated:</span>
                 <span className="ml-2 font-medium text-gray-900 dark:text-white">
                   {new Date(project.updatedAt).toLocaleDateString('en-GB', {
                     year: 'numeric',
@@ -151,7 +151,7 @@ export default function ProjectSettingsClient({ currentUserId }: ProjectSettings
 
               {project.description && (
                 <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
-                  <span className="text-gray-500">Description:</span>
+                  <span className="text-gray-500 dark:text-gray-400">Description:</span>
                   <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm">{project.description}</p>
                 </div>
               )}

--- a/src/app/(main)/orga/[orgaName]/settings/test-resource-api/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/settings/test-resource-api/page.tsx
@@ -34,8 +34,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
     return (
       <div className="p-8">
         <Card className="p-8 text-center">
-          <p className="text-gray-600">You do not have permission to access this page.</p>
-          <p className="text-sm text-gray-500 mt-2">Only organisation owners can test Resource API integration.</p>
+          <p className="text-gray-600 dark:text-gray-300">You do not have permission to access this page.</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">Only organisation owners can test Resource API integration.</p>
         </Card>
       </div>
     );
@@ -51,15 +51,15 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
           <div className="flex items-center gap-3 mb-2">
             <Link
               href={`/orga/${orgName}/settings`}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
             >
               <RiArrowLeftLine className="w-5 h-5" />
             </Link>
-            <h1 className="text-3xl font-semibold text-gray-900">
+            <h1 className="text-3xl font-semibold text-gray-900 dark:text-white">
               Resource API Test
             </h1>
           </div>
-          <p className="text-gray-600">
+          <p className="text-gray-600 dark:text-gray-300">
             Test connectivity and integration with the Resource API
           </p>
         </div>
@@ -67,8 +67,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
 
       <Card className="p-6">
         <div className="mb-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Resource API Testing</h2>
-          <p className="text-sm text-gray-600">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">About Resource API Testing</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
             This page allows you to test the connection between the Platform and the Resource API.
             You can discover available providers, provision test resources, check their status, and clean up test resources.
           </p>

--- a/src/app/(main)/orga/[orgaName]/teams/[teamName]/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/[teamName]/page.tsx
@@ -102,7 +102,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 
         {members.length === 0 ? (
           <div className="p-12 text-center">
-            <RiUserLine className="mx-auto w-8 h-8 text-gray-400 mb-3" />
+            <RiUserLine className="mx-auto w-8 h-8 text-gray-400 dark:text-gray-600 mb-3" />
             <p className="text-gray-600 dark:text-gray-400">No members in this team yet.</p>
             {canManage && (
               <div className="mt-4">

--- a/src/app/(main)/orga/[orgaName]/teams/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/page.tsx
@@ -68,7 +68,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
 
       {teamsWithCounts.length === 0 ? (
         <Card className="p-12 text-center">
-          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 mb-3" />
+          <RiTeamLine className="mx-auto w-10 h-10 text-gray-400 dark:text-gray-600 mb-3" />
           <p className="text-gray-600 dark:text-gray-400 font-medium">No teams yet</p>
           {canManage && (
             <p className="text-sm text-gray-500 dark:text-gray-500 mt-1">
@@ -108,7 +108,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
                     <span className="text-sm text-gray-500 dark:text-gray-400">
                       {team.memberCount} {team.memberCount === 1 ? 'member' : 'members'}
                     </span>
-                    <RiArrowRightLine className="w-4 h-4 text-gray-400" />
+                    <RiArrowRightLine className="w-4 h-4 text-gray-400 dark:text-gray-600" />
                   </div>
                 </div>
               </Card>


### PR DESCRIPTION
## Summary
- Added `dark:` text colour variants to 20 files across admin, auth, settings, teams, access, share, transfer, invitations, and resource pages
- Fixed empty state icons (`text-gray-400` → `dark:text-gray-600`)
- Fixed label text (`text-gray-500` → `dark:text-gray-400`)
- Fixed back arrow icons and timestamp text
- No mobile responsiveness issues found — all layouts properly responsive

## Test plan
- [ ] Navigate all pages in dark mode — no invisible or hard-to-read text
- [ ] Admin pages: projects list, guest requests
- [ ] Settings: test-resource-api, project settings overview panel
- [ ] Teams: list, detail, empty states
- [ ] Auth: register form, signin redirect
- [ ] Resource new, access, share, transfer pages