### PR TITLE
feat: unified navigation with context-aware sidebar and top nav bar

### DIFF
--- a/docs/specs/2026-04-19-navigation-redesign.md
+++ b/docs/specs/2026-04-19-navigation-redesign.md
@@ -1,0 +1,171 @@
+# Navigation Redesign
+
+**Date**: 2026-04-19
+**Status**: Approved
+
+## Overview
+
+Unify the platform's navigation into a single top nav bar and a single context-aware sidebar. Remove the org selector dropdown — org switching happens via the Organisations overview page or the command palette. Current org is persisted in localStorage.
+
+---
+
+## Top Nav Bar
+
+Replaces the current `UserBar` component. Always visible on all authenticated pages.
+
+**Layout**: `[ Hamburger | Breadcrumb + Visibility badge | ---- gap ---- | Search | User avatar ]`
+
+### Left side (left-aligned)
+
+1. **Hamburger menu** (mobile: toggles sidebar, desktop: always visible for consistency or hidden — matches current `lg:hidden` pattern for mobile)
+2. **Breadcrumb path** — context-aware:
+   - Org-level pages: `Enopax`
+   - Project-level pages: `Enopax / ResourceTest`
+   - Each segment is a clickable link
+3. **Visibility badge** — `Private` or `Public` pill next to the breadcrumb (for projects/resources that have a visibility flag)
+
+### Right side (right-aligned)
+
+4. **Smart Search** — triggers the existing CommandPalette (`cmd+K`). Styled as a search input placeholder: `Search or jump to... ⌘K`
+5. **User avatar** — links to user profile/settings. Existing `UserBarMenu` dropdown behaviour (Sign Out, Account, Admin links)
+
+### What's removed from top nav
+
+- Version number (`v0.4.1`)
+- The `E` logo
+- The hamburger menu icon from `UserBarMenu` (menu items move into sidebar or stay in avatar dropdown)
+
+---
+
+## Sidebar
+
+Replaces both `SidebarNavigation` and `OrgSidebar` with a single unified sidebar. Content is context-aware based on the current page.
+
+### On org-level pages
+
+Pages: Overview, Members, Teams, Roles, Invitations, Settings, teams/new, roles/new, etc.
+
+```
+┌─────────────────────┐
+│ ORGANISATION        │
+│  Overview           │
+│  Members            │
+│  Teams              │
+│  Roles              │
+│  Invitations        │
+│  Settings           │
+│                     │
+│ PROJECTS            │
+│  ResourceTest       │
+│  Resource-Tests     │
+└─────────────────────┘
+```
+
+- Show org navigation items
+- Show project list below (clickable to navigate into project)
+- **Exception**: on the org Overview page (which already shows projects as its main content), hide the PROJECTS section to avoid duplication
+
+### On project-level pages
+
+Pages: Resources, Access, Share, Transfer, Settings (under `/{orgName}/{projectName}/...`)
+
+```
+┌─────────────────────┐
+│ PROJECT             │
+│  Resources    ← active
+│  Access             │
+│  Share              │
+│  Transfer           │
+│  Settings           │
+│─────────────────────│
+│ ORGANISATION        │
+│  Overview           │
+│  Members            │
+│  Teams              │
+│  Roles              │
+│  Invitations        │
+│  Settings           │
+└─────────────────────┘
+```
+
+- Context section (project actions) on top
+- Org navigation below the divider
+- No project list (you're already in a project; use breadcrumb or back to overview)
+
+### On non-org pages
+
+Pages: `/account/settings`, `/account/developer`, `/admin/*`
+
+- Sidebar shows account or admin navigation as it currently does
+- No org/project sections
+
+---
+
+## Org Persistence
+
+- Current org saved to `localStorage` key (e.g. `enopax:current-org`)
+- When navigating to `/orga` or the root authenticated page, redirect to the saved org if one exists
+- Updated whenever the user navigates into an org
+- Org overview page (`/orga`) always accessible from the user menu dropdown or command palette
+
+---
+
+## Components Affected
+
+### New/Modified
+
+| Component | Change |
+|-----------|--------|
+| `UserBar` | Rewrite — becomes the top nav bar with breadcrumb, search, user avatar |
+| `OrgSidebar` | Delete — merged into unified sidebar |
+| `SidebarNavigation` | Rewrite — becomes context-aware unified sidebar |
+| `MobileNavigation` | Update — align with new sidebar content, hamburger in top nav |
+| `UserBarMenu` | Simplify — avatar + dropdown only (no hamburger icon) |
+
+### Removed
+
+| Component | Reason |
+|-----------|--------|
+| `OrgSidebar` | Merged into `SidebarNavigation` |
+| Org selector dropdown (in `SidebarNavigation`) | Replaced by localStorage persistence + org overview page |
+
+### Unchanged
+
+| Component | Reason |
+|-----------|--------|
+| `CommandPalette` | Reused as-is, triggered from top nav search |
+| `CommandPaletteProvider` | No changes |
+
+---
+
+## Breadcrumb Logic
+
+The top nav breadcrumb is derived from the URL pathname and current context:
+
+| URL pattern | Breadcrumb |
+|-------------|------------|
+| `/{orgName}` | `Enopax` |
+| `/{orgName}/members` | `Enopax` |
+| `/{orgName}/teams/new` | `Enopax` |
+| `/{orgName}/{projectName}` | `Enopax / ResourceTest` |
+| `/{orgName}/{projectName}/settings` | `Enopax / ResourceTest` |
+| `/account/settings` | (no breadcrumb) |
+| `/admin/users` | (no breadcrumb) |
+
+---
+
+## Mobile Behaviour
+
+- Hamburger in top nav toggles sidebar as a slide-in drawer (existing pattern)
+- Top nav always visible
+- Sidebar content identical to desktop — just presented as an overlay
+- Search triggers command palette (same as desktop)
+
+---
+
+## Out of Scope
+
+- Changing the command palette functionality
+- Changing page content or layouts
+- Changing the route structure
+- Adding new pages

--- a/src/app/(main)/[slug]/layout.tsx
+++ b/src/app/(main)/[slug]/layout.tsx
@@ -1,7 +1,76 @@
 import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
 import { OrganisationProvider } from '@/contexts/OrganisationContext';
-import OrgSidebar from '@/components/navigation/OrgSidebar';
+import SidebarNavigation from '@/components/navigation/SidebarNavigation';
+import MobileNavigation from '@/components/navigation/MobileNavigation';
+
+async function getOrganisationData(store: any, org: any) {
+  const projects = await store.projects.findByOrgId(org.id, { isActive: true });
+  const members = await store.organisationMembers.findByOrgId(org.id);
+
+  const activeShares = await store.projectShares.findSharedWithEntity('ORGANISATION', org.id, 'ACTIVE');
+  const sharedProjects = [];
+  for (const share of activeShares) {
+    const project = await store.projects.findById(share.projectId);
+    if (project && project.isActive) {
+      const ownerOrg = await store.organisations.findById(project.organisationId);
+      sharedProjects.push({ ...project, ownerName: ownerOrg?.name || 'Unknown', ownerSlug: ownerOrg?.slug || ownerOrg?.name || 'unknown' });
+    }
+  }
+
+  return { projects, members, sharedProjects };
+}
+
+async function getUserOrganisations(store: any, userId: string) {
+  const memberships = await store.organisationMembers.findByUserId(userId);
+  const memberOrgIds = new Set(memberships.map((m: any) => m.organisationId));
+  const allOrgs = await store.organisations.search('', 1000);
+  const userOrgs = allOrgs.filter((org: any) =>
+    org.isActive && (org.ownerId === userId || memberOrgIds.has(org.id))
+  );
+
+  const orgDataPromises = userOrgs
+    .sort((a: any, b: any) => a.name.localeCompare(b.name))
+    .map(async (org: any) => {
+      const projects = await store.projects.findByOrgId(org.id, { isActive: true });
+      return {
+        id: org.id,
+        name: org.name,
+        projects: projects.map((p: any) => ({ id: p.id, name: p.name, status: p.status })),
+      };
+    });
+
+  return Promise.all(orgDataPromises);
+}
+
+function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjects: any[], organisations: any[], children: React.ReactNode) {
+  return (
+    <OrganisationProvider
+      organisation={{
+        id: org.id,
+        name: org.name,
+        description: org.description,
+        ownerId: org.ownerId,
+        isActive: org.isActive,
+        projects,
+        sharedProjects,
+        _count: {
+          members: members.length,
+          projects: projects.length,
+        },
+      }}
+    >
+      <div className="flex min-h-[calc(100vh-2.5rem)]">
+        <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
+          <SidebarNavigation organisations={organisations} />
+        </div>
+        <MobileNavigation organisations={organisations} />
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </OrganisationProvider>
+  );
+}
 
 export default async function NamespaceLayout({
   children,
@@ -17,6 +86,10 @@ export default async function NamespaceLayout({
   }
 
   const store = await getStoreAsync();
+  const session = await auth();
+  const userId = session?.user?.id;
+
+  const organisations = userId ? await getUserOrganisations(store, userId) : [];
 
   const namespace = await store.namespaces.findBySlug(slug);
 
@@ -24,43 +97,8 @@ export default async function NamespaceLayout({
     const organisation = await store.organisations.findById(namespace.entityId);
     if (!organisation || !organisation.isActive) notFound();
 
-    const projects = await store.projects.findByOrgId(organisation.id, { isActive: true });
-    const members = await store.organisationMembers.findByOrgId(organisation.id);
-
-    const activeShares = await store.projectShares.findSharedWithEntity('ORGANISATION', organisation.id, 'ACTIVE');
-    const sharedProjects = [];
-    for (const share of activeShares) {
-      const project = await store.projects.findById(share.projectId);
-      if (project && project.isActive) {
-        const ownerOrg = await store.organisations.findById(project.organisationId);
-        sharedProjects.push({ ...project, ownerName: ownerOrg?.name || 'Unknown', ownerSlug: ownerOrg?.slug || ownerOrg?.name || 'unknown' });
-      }
-    }
-
-    return (
-      <OrganisationProvider
-        organisation={{
-          id: organisation.id,
-          name: organisation.name,
-          description: organisation.description,
-          ownerId: organisation.ownerId,
-          isActive: organisation.isActive,
-          projects,
-          sharedProjects,
-          _count: {
-            members: members.length,
-            projects: projects.length,
-          },
-        }}
-      >
-        <div className="flex min-h-[calc(100vh-2.5rem)]">
-          <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
-            <OrgSidebar />
-          </div>
-          <main className="flex-1 p-6">{children}</main>
-        </div>
-      </OrganisationProvider>
-    );
+    const { projects, members, sharedProjects } = await getOrganisationData(store, organisation);
+    return renderOrgLayout(organisation, projects, members, sharedProjects, organisations, children);
   }
 
   if (namespace?.entityType === 'USER') {
@@ -71,43 +109,8 @@ export default async function NamespaceLayout({
 
   const orgByName = await store.organisations.findByName(slug);
   if (orgByName && orgByName.isActive) {
-    const projects = await store.projects.findByOrgId(orgByName.id, { isActive: true });
-    const members = await store.organisationMembers.findByOrgId(orgByName.id);
-
-    const activeShares = await store.projectShares.findSharedWithEntity('ORGANISATION', orgByName.id, 'ACTIVE');
-    const sharedProjects = [];
-    for (const share of activeShares) {
-      const project = await store.projects.findById(share.projectId);
-      if (project && project.isActive) {
-        const ownerOrg = await store.organisations.findById(project.organisationId);
-        sharedProjects.push({ ...project, ownerName: ownerOrg?.name || 'Unknown', ownerSlug: ownerOrg?.slug || ownerOrg?.name || 'unknown' });
-      }
-    }
-
-    return (
-      <OrganisationProvider
-        organisation={{
-          id: orgByName.id,
-          name: orgByName.name,
-          description: orgByName.description,
-          ownerId: orgByName.ownerId,
-          isActive: orgByName.isActive,
-          projects,
-          sharedProjects,
-          _count: {
-            members: members.length,
-            projects: projects.length,
-          },
-        }}
-      >
-        <div className="flex min-h-[calc(100vh-2.5rem)]">
-          <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
-            <OrgSidebar />
-          </div>
-          <main className="flex-1 p-6">{children}</main>
-        </div>
-      </OrganisationProvider>
-    );
+    const { projects, members, sharedProjects } = await getOrganisationData(store, orgByName);
+    return renderOrgLayout(orgByName, projects, members, sharedProjects, organisations, children);
   }
 
   notFound();

--- a/src/app/(main)/orga/layout.tsx
+++ b/src/app/(main)/orga/layout.tsx
@@ -1,8 +1,31 @@
-import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
 import SidebarNavigation from '@/components/navigation/SidebarNavigation';
 import MobileNavigation from '@/components/navigation/MobileNavigation';
+
+async function getUserOrganisations(userId: string) {
+  const store = await getStoreAsync();
+  const memberships = await store.organisationMembers.findByUserId(userId);
+  const memberOrgIds = new Set(memberships.map(m => m.organisationId));
+
+  const allOrgs = await store.organisations.search('', 1000);
+  const userOrgs = allOrgs.filter(org =>
+    org.isActive && (org.ownerId === userId || memberOrgIds.has(org.id))
+  );
+
+  const orgDataPromises = userOrgs
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(async (org) => {
+      const projects = await store.projects.findByOrgId(org.id, { isActive: true });
+      return {
+        id: org.id,
+        name: org.name,
+        projects: projects.map(p => ({ id: p.id, name: p.name, status: p.status })),
+      };
+    });
+
+  return Promise.all(orgDataPromises);
+}
 
 export default async function Layout({
   children,
@@ -10,59 +33,26 @@ export default async function Layout({
   children: React.ReactNode;
 }>) {
   const session = await auth();
-  //if (!session) return redirect('/');
 
-  // Note: We can't extract organisationId from URL in layout
-  // The sidebar will handle organisation context detection client-side from pathname
-  // We fetch all organisations with their projects for the sidebar
-
-  let organisations: { id: string; name: string; description: string | null; _count: { projects: number; members: number } }[] = [];
+  let organisations: { id: string; name: string; projects: { id: string; name: string; status: string }[] }[] = [];
 
   if (session?.user?.id) {
     try {
-      const store = await getStoreAsync();
-      const memberships = await store.organisationMembers.findByUserId(session.user.id);
-      const memberOrgIds = new Set(memberships.map(m => m.organisationId));
-
-      const allOrgs = await store.organisations.search('', 1000);
-      const userOrgs = allOrgs.filter(org =>
-        org.isActive && (org.ownerId === session.user.id || memberOrgIds.has(org.id))
-      );
-
-      const orgDataPromises = userOrgs
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(async (org) => {
-          const memberCount = memberships.filter(m => m.organisationId === org.id).length ||
-            (org.ownerId === session.user.id ? 1 : 0);
-          const projects = await store.projects.findByOrgId(org.id, { isActive: true });
-          return {
-            id: org.id,
-            name: org.name,
-            description: org.description,
-            _count: { projects: projects.length, members: memberCount },
-          };
-        });
-      organisations = await Promise.all(orgDataPromises);
+      organisations = await getUserOrganisations(session.user.id);
     } catch (error) {
       console.error('Error fetching sidebar data:', error);
     }
   }
 
   return (
-    <div className="flex pt-10 lg:pt-5">
-      {/* Desktop Sidebar - Hidden on mobile */}
+    <div className="flex">
       <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
-        <SidebarNavigation
-          user={session?.user}
-          organisations={organisations}
-        />
+        <SidebarNavigation organisations={organisations} />
       </div>
 
-      {/* Mobile Navigation - Visible only on mobile */}
-      <MobileNavigation user={session?.user} organisations={organisations} />
+      <MobileNavigation organisations={organisations} />
 
-      {/* Main Content */}
-      <main className="flex-1 p-6 lg:p-6 pt-5 lg:pt-6">
+      <main className="flex-1 p-6">
         {children}
       </main>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,4 @@
 import type { Metadata } from "next";
-//import { GeistSans } from "geist/font/sans";
-import Image from "next/image";
 import { Geist } from 'next/font/google';
 import "./globals.css";
 
@@ -8,6 +6,7 @@ import { auth } from '@/lib/auth';
 
 import UserBar from '@/components/layout/UserBar';
 import CommandPaletteProvider from '@/components/navigation/CommandPaletteProvider';
+import { MobileMenuProvider } from '@/hooks/useMobileMenu';
 
 const geist = Geist({
   subsets: ['latin'],
@@ -32,11 +31,13 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={`${geist.className} antialiased bg-gray-50 dark:bg-gray-950`}>
-        <div className="text-neutral-800 dark:text-neutral-200">
-          <UserBar user={session?.user} />
-          {children}
-          <CommandPaletteProvider />
-        </div>
+        <MobileMenuProvider>
+          <div className="text-neutral-800 dark:text-neutral-200">
+            <UserBar user={session?.user} />
+            {children}
+            <CommandPaletteProvider />
+          </div>
+        </MobileMenuProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,14 +20,6 @@ export default async function Page() {
 
   return (
     <main>
-      {/* Mobile header — visible only below lg where UserBar is hidden */}
-      <div className="lg:hidden flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-800">
-        <span className="text-sm font-semibold text-gray-900 dark:text-white">Enopax</span>
-        <Link href="/signin">
-          <Button variant="secondary" className="text-sm">Sign In</Button>
-        </Link>
-      </div>
-
       <section className="mx-auto max-w-6xl">
         <Container>
           <div className="relative w-full py-16 md:py-20">

--- a/src/components/layout/UserBar.tsx
+++ b/src/components/layout/UserBar.tsx
@@ -1,19 +1,93 @@
-import UserBarMenu from '@/components/layout/UserBarMenu';
+'use client';
 
-export default function UserBar({
-  user,
-}: {
-  user?: Object,
-}) {
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import Avatar from '@/components/common/Avatar';
+import { useCommandPalette } from '@/hooks/useCommandPalette';
+import { RiMenuLine, RiSearchLine, RiLockLine } from '@remixicon/react';
+import UserBarMenu from '@/components/layout/UserBarMenu';
+import { useMobileMenu } from '@/hooks/useMobileMenu';
+
+interface TopNavProps {
+  user?: any;
+}
+
+export default function UserBar({ user }: TopNavProps) {
+  const pathname = usePathname();
+  const { open } = useCommandPalette();
+  const { toggle: toggleMobileMenu } = useMobileMenu();
+
+  const segments = pathname.split('/').filter(Boolean);
+
+  const isOrgPage = segments.length >= 1
+    && segments[0] !== 'account'
+    && segments[0] !== 'admin'
+    && segments[0] !== 'orga'
+    && segments[0] !== 'signin'
+    && segments[0] !== 'register'
+    && segments[0] !== 'docs';
+
+  const orgName = isOrgPage ? segments[0] : null;
+
+  const orgSubRoutes = ['members', 'teams', 'roles', 'invitations', 'settings'];
+  const isProjectPage = isOrgPage && segments.length >= 2 && !orgSubRoutes.includes(segments[1]);
+  const projectName = isProjectPage ? segments[1] : null;
+
   return (
-    <header className="hidden lg:flex border-b border-gray-200 dark:border-gray-800">
-      <div className="px-4 text-sm w-full">
-        <div className="mx-auto max-w-6xl w-full relative flex items-center">
-          <span className="text-xs text-gray-400 dark:text-gray-600">v{process.env.APP_VERSION}</span>
-          <div className="ml-auto px-4">
-            <UserBarMenu user={user} />
-          </div>
-        </div>
+    <header className="flex items-center px-4 py-2 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+      {/* Left: hamburger + breadcrumb */}
+      <div className="flex items-center gap-3">
+        {user && (
+          <button
+            onClick={toggleMobileMenu}
+            className="lg:hidden p-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            aria-label="Toggle menu"
+          >
+            <RiMenuLine className="h-5 w-5" />
+          </button>
+        )}
+
+        {orgName && (
+          <nav className="flex items-center gap-1.5 text-sm">
+            <Link
+              href={`/${orgName}`}
+              className="font-medium text-gray-900 dark:text-white hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
+            >
+              {orgName}
+            </Link>
+            {projectName && (
+              <>
+                <span className="text-gray-400 dark:text-gray-600">/</span>
+                <Link
+                  href={`/${orgName}/${projectName}`}
+                  className="font-semibold text-gray-900 dark:text-white hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
+                >
+                  {projectName}
+                </Link>
+              </>
+            )}
+            <span className="ml-1 inline-flex items-center px-1.5 py-0.5 text-[10px] text-gray-500 dark:text-gray-400 border border-gray-300 dark:border-gray-600 rounded-full">
+              <RiLockLine className="h-2.5 w-2.5 mr-0.5" />
+              Private
+            </span>
+          </nav>
+        )}
+      </div>
+
+      {/* Right: search + user */}
+      <div className="ml-auto flex items-center gap-3">
+        {user && (
+          <button
+            onClick={open}
+            className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors min-w-[180px]"
+          >
+            <RiSearchLine className="h-3.5 w-3.5" />
+            <span className="flex-1 text-left">Search or jump to...</span>
+            <kbd className="text-[10px] text-gray-400 dark:text-gray-500 border border-gray-300 dark:border-gray-600 rounded px-1">&#8984;K</kbd>
+          </button>
+        )}
+
+        <UserBarMenu user={user} />
       </div>
     </header>
   );

--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -1,9 +1,8 @@
-import { type User } from '@/lib/store';
+'use client';
 
 import Link from 'next/link';
 import { Button } from '@/components/common/Button';
 import Avatar from '@/components/common/Avatar';
-import { RiMenuLine } from '@remixicon/react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,48 +12,43 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/menu/DropdownMenu';
-import { signOut } from '@/lib/auth';
+import { handleSignOut } from '@/actions/auth';
 
 export default function UserBarMenu({
   user,
 }: {
-  user?: User,
+  user?: any,
 }) {
   if (!user) return (
     <Link href="/signin">
-      <Button variant="secondary">
+      <Button variant="secondary" className="text-sm">
         Sign In
       </Button>
     </Link>
   );
 
   return (
-    <div className="flex items-center gap-2">
-      <Link href={user.slug ? `/${user.slug}` : '/account/settings'} aria-label="My profile" className="inline-flex">
-        <Avatar
-          name={user.name || user.email}
-          image={user.image}
-          size="small"
-        />
-      </Link>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" className="p-2" aria-label="Open menu">
-            <RiMenuLine className="h-5 w-5" />
-          </Button>
-        </DropdownMenuTrigger>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button className="inline-flex" aria-label="User menu">
+          <Avatar
+            name={user.name || user.email}
+            image={user.image}
+            size="small"
+          />
+        </button>
+      </DropdownMenuTrigger>
 
-      <DropdownMenuContent>
-        {/* ----- Account ----- */}
+      <DropdownMenuContent align="end">
         <DropdownMenuLabel>
           <u>Main</u>
         </DropdownMenuLabel>
 
         <DropdownMenuGroup>
           <Link href="/orga">
-             <DropdownMenuItem>
-               Organisations
-             </DropdownMenuItem>
+            <DropdownMenuItem>
+              Organisations
+            </DropdownMenuItem>
           </Link>
         </DropdownMenuGroup>
 
@@ -64,19 +58,18 @@ export default function UserBarMenu({
 
         <DropdownMenuGroup>
           <Link href="/account/developer">
-             <DropdownMenuItem>
-               Developer
-             </DropdownMenuItem>
+            <DropdownMenuItem>
+              Developer
+            </DropdownMenuItem>
           </Link>
           <Link href="/account/settings">
-             <DropdownMenuItem>
-                Settings
-             </DropdownMenuItem>
+            <DropdownMenuItem>
+              Settings
+            </DropdownMenuItem>
           </Link>
         </DropdownMenuGroup>
 
-        {/* ----- Admin ----- */}
-        {user.role == 'SUPERADMIN' && (
+        {user.role === 'SUPERADMIN' && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel>
@@ -85,14 +78,10 @@ export default function UserBarMenu({
 
             <DropdownMenuGroup>
               <Link href="/admin/users">
-                <DropdownMenuItem>
-                  Users
-                </DropdownMenuItem>
+                <DropdownMenuItem>Users</DropdownMenuItem>
               </Link>
               <Link href="/admin/organisations">
-                <DropdownMenuItem>
-                  Organisations
-                </DropdownMenuItem>
+                <DropdownMenuItem>Organisations</DropdownMenuItem>
               </Link>
             </DropdownMenuGroup>
           </>
@@ -100,14 +89,7 @@ export default function UserBarMenu({
 
         <DropdownMenuSeparator />
 
-        <form
-          action={async () => {
-            'use server';
-            await signOut({
-              redirectTo: '/',
-            });
-          }}
-        >
+        <form action={handleSignOut}>
           <button className="w-full">
             <DropdownMenuItem className="text-red-500">
               Sign Out
@@ -115,7 +97,6 @@ export default function UserBarMenu({
           </button>
         </form>
       </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    </DropdownMenu>
   );
 }

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -1,429 +1,202 @@
 'use client';
 
-import { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import {
-  RiMenuLine,
   RiCloseLine,
-  RiSettings3Line,
-  RiBuildingLine,
-  RiProjectorLine,
-  RiArrowDownSLine,
-  RiArrowUpSLine,
-  RiExternalLinkLine,
-  RiAddLine,
+  RiDashboardLine,
   RiUserLine,
-  RiShieldLine,
-  RiCodeLine,
-  RiDatabaseLine,
   RiTeamLine,
-  RiMailLine,
+  RiShieldLine,
+  RiSettings3Line,
+  RiMailSendLine,
+  RiProjectorLine,
+  RiDatabaseLine,
+  RiLockLine,
+  RiShareLine,
+  RiExchangeLine,
 } from '@remixicon/react';
-import { Button } from '@/components/common/Button';
-import { Badge } from '@/components/common/Badge';
-import Avatar from '@/components/common/Avatar';
-import { User } from '@/lib/store';
-import { useCommandPalette } from '@/hooks/useCommandPalette';
-import { handleSignOut } from '@/actions/auth';
+import { useMobileMenu } from '@/hooks/useMobileMenu';
 
 type Project = {
   id: string;
   name: string;
   status: string;
-  progress: number;
-  organisationId: string;
 };
 
 type Organisation = {
   id: string;
   name: string;
-  description?: string | null;
-  _count?: {
-    projects: number;
-    members: number;
-  };
   projects?: Project[];
 };
 
 interface MobileNavigationProps {
-  user: Partial<User>;
   organisations?: Organisation[];
 }
 
-export default function MobileNavigation({ user, organisations: initialOrganisations = [] }: MobileNavigationProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [showOrgDropdown, setShowOrgDropdown] = useState(false);
+export default function MobileNavigation({ organisations = [] }: MobileNavigationProps) {
+  const { isOpen, close: onClose } = useMobileMenu();
   const pathname = usePathname();
-  const { open } = useCommandPalette();
 
-  const getOrganisationName = () => {
-    const pathSegments = pathname.split('/');
-    if (pathSegments[1] === 'orga' && pathSegments[2]) {
-      return pathSegments[2];
-    }
-    if (pathSegments[1] && pathSegments[1] !== 'account' && pathSegments[1] !== 'admin' && pathSegments[1] !== 'api') {
-      const candidate = pathSegments[1];
-      const match = initialOrganisations.find(org => org.name === candidate);
-      if (match) return candidate;
-    }
-    return null;
-  };
+  const segments = pathname.split('/').filter(Boolean);
+  const orgSubRoutes = ['members', 'teams', 'roles', 'invitations', 'settings'];
 
-  const organisationName = getOrganisationName();
-
-  // Find current organisation and its projects from server-provided data
-  const organisation = organisationName
-    ? initialOrganisations.find(org => org.name === organisationName) || null
+  const orgName = (segments.length >= 1
+    && segments[0] !== 'account'
+    && segments[0] !== 'admin'
+    && segments[0] !== 'orga'
+    && segments[0] !== 'signin'
+    && segments[0] !== 'register'
+    && segments[0] !== 'docs')
+    ? segments[0]
     : null;
 
-  const organisationId = organisation?.id; // Get the actual ID from the organisation object
+  const isProjectPage = orgName && segments.length >= 2 && !orgSubRoutes.includes(segments[1]);
+  const projectName = isProjectPage ? segments[1] : null;
+  const isOrgOverview = orgName && !projectName && segments.length === 1;
+
+  const organisation = orgName
+    ? organisations.find(org => org.name === orgName) || null
+    : null;
 
   const projects = organisation?.projects || [];
+  const orgBase = orgName ? `/${orgName}` : '';
 
-  const isActivePath = (href: string) => {
-    return pathname.startsWith(href);
-  };
+  const orgItems = orgName ? [
+    { href: orgBase, label: 'Overview', icon: RiDashboardLine, exact: true },
+    { href: `${orgBase}/members`, label: 'Members', icon: RiUserLine },
+    { href: `${orgBase}/teams`, label: 'Teams', icon: RiTeamLine },
+    { href: `${orgBase}/roles`, label: 'Roles', icon: RiShieldLine },
+    { href: `${orgBase}/invitations`, label: 'Invitations', icon: RiMailSendLine },
+    { href: `${orgBase}/settings`, label: 'Settings', icon: RiSettings3Line },
+  ] : [];
 
-  const handleLinkClick = () => {
-    setIsOpen(false);
-    setShowOrgDropdown(false);
-  };
+  const projectItems = projectName ? [
+    { href: `${orgBase}/${projectName}`, label: 'Resources', icon: RiDatabaseLine, exact: true },
+    { href: `${orgBase}/${projectName}/access`, label: 'Access', icon: RiLockLine },
+    { href: `${orgBase}/${projectName}/share`, label: 'Share', icon: RiShareLine },
+    { href: `${orgBase}/${projectName}/transfer`, label: 'Transfer', icon: RiExchangeLine },
+    { href: `${orgBase}/${projectName}/settings`, label: 'Settings', icon: RiSettings3Line },
+  ] : [];
 
   return (
     <>
-      {/* Mobile Header */}
-      <div className="lg:hidden flex items-center justify-between px-4 absolute top-0 z-40 w-full border-b border-gray-200 dark:border-gray-800">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setIsOpen(!isOpen)}
-            className="p-2"
-          >
-            {isOpen ? (
-              <RiCloseLine className="size-5 shrink-0" />
-            ) : (
-              <RiMenuLine className="size-5 shrink-0" />
-            )}
-          </Button>
-        </div>
-      </div>
-
-      {/* Mobile Overlay */}
       {isOpen && (
-        <div className="lg:hidden fixed inset-0 z-50 bg-black/50" onClick={() => setIsOpen(false)} />
+        <div className="lg:hidden fixed inset-0 z-50 bg-black/50" onClick={onClose} />
       )}
 
-      {/* Mobile Sidebar */}
-      <div className={`lg:hidden fixed inset-y-0 left-0 z-50 w-80 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 transform transition-transform duration-300 ${
+      <div className={`lg:hidden fixed inset-y-0 left-0 z-50 w-72 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 transform transition-transform duration-300 ${
         isOpen ? 'translate-x-0' : '-translate-x-full'
       }`}>
         <div className="flex flex-col h-full">
-          {/* Organisation Selector */}
-          <div className="px-3 py-4 border-b border-gray-200 dark:border-gray-700">
-            <div className="relative">
-              <button
-                onClick={() => setShowOrgDropdown(!showOrgDropdown)}
-                className="w-full flex items-center justify-between p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center min-w-0 flex-1">
-                  <RiBuildingLine className="mr-3 h-5 w-5 text-brand-600 dark:text-brand-400 flex-shrink-0" />
-                  <div className="min-w-0 flex-1 text-left">
-                    {organisation ? (
-                      <>
-                        <div className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                          {organisation.name}
-                        </div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">
-                          Current organisation
-                        </div>
-                      </>
-                    ) : (
-                      <div className="text-sm text-gray-500 dark:text-gray-400">
-                        Select organisation
-                      </div>
-                    )}
-                  </div>
-                </div>
-                {showOrgDropdown ? (
-                  <RiArrowUpSLine className="h-5 w-5 text-gray-400 flex-shrink-0" />
-                ) : (
-                  <RiArrowDownSLine className="h-5 w-5 text-gray-400 flex-shrink-0" />
-                )}
-              </button>
-
-              {/* Dropdown */}
-              {showOrgDropdown && (
-                <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto">
-                  {initialOrganisations.length > 0 ? (
-                    <>
-                      {initialOrganisations.map((org) => {
-                        const isSelected = org.id === organisationId;
-                        return (
-                          <Link
-                            key={org.id}
-                            href={`/${org.name}`}
-                            onClick={handleLinkClick}
-                            className={`
-                              block p-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors border-l-4
-                              ${isSelected
-                                ? 'bg-brand-50 dark:bg-brand-900/20 border-brand-500 dark:border-brand-400'
-                                : 'border-transparent'
-                              }
-                            `}
-                          >
-                            <div className="flex items-center">
-                              <RiBuildingLine className={`mr-3 h-4 w-4 flex-shrink-0 ${
-                                isSelected
-                                  ? 'text-brand-600 dark:text-brand-400'
-                                  : 'text-gray-400 dark:text-gray-600'
-                              }`} />
-                              <div className="min-w-0 flex-1">
-                                <div className={`text-sm font-medium truncate ${
-                                  isSelected
-                                    ? 'text-brand-900 dark:text-brand-100'
-                                    : 'text-gray-900 dark:text-white'
-                                }`}>
-                                  {org.name}
-                                </div>
-                                {org._count && (
-                                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                                    {org._count.projects} projects • {org._count.members} members
-                                  </div>
-                                )}
-                              </div>
-                              {isSelected && (
-                                <div className="ml-2 flex-shrink-0">
-                                  <div className="h-2 w-2 rounded-full bg-brand-500" />
-                                </div>
-                              )}
-                            </div>
-                          </Link>
-                        );
-                      })}
-                      <div className="border-t border-gray-200 dark:border-gray-700 p-2">
-                        <Link
-                          href="/orga"
-                          onClick={handleLinkClick}
-                          className="flex items-center p-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded transition-colors"
-                        >
-                          <RiExternalLinkLine className="mr-2 h-4 w-4" />
-                          My Organisations
-                        </Link>
-                      </div>
-                    </>
-                  ) : (
-                    <div className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                      No organisations found
-                      <Link
-                        href="/orga/new"
-                        onClick={handleLinkClick}
-                        className="block mt-2 text-brand-600 dark:text-brand-400 hover:underline"
-                      >
-                        Create one
-                      </Link>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+          <div className="flex items-center justify-end px-3 py-2 border-b border-gray-200 dark:border-gray-800">
+            <button onClick={onClose} className="p-1 text-gray-500 dark:text-gray-400">
+              <RiCloseLine className="h-5 w-5" />
+            </button>
           </div>
 
-          {!organisationId ? (
-            <div className="flex-1 flex items-center justify-center p-6">
-              <div className="text-center">
-                <RiBuildingLine className="mx-auto h-12 w-12 text-gray-400 mb-4" />
-                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                  No organisation selected
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Use the dropdown above to select one
-                </p>
-              </div>
-            </div>
-          ) : (
-            <>
-              {/* Organisation Navigation */}
-              {organisation && (
-                <div className="px-3 py-4 flex-1 flex flex-col">
-                  <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
-                    Organisation
-                  </h4>
-                  <div className="space-y-1">
-                    {[
-                      {
-                        name: 'Projects',
-                        icon: RiProjectorLine,
-                        href: `/${organisationName}`,
-                        active: pathname === `/${organisationName}`
-                      },
-                      {
-                        name: 'Members',
-                        icon: RiUserLine,
-                        href: `/${organisationName}/members`,
-                        active: pathname.startsWith(`/${organisationName}/members`)
-                      },
-                      {
-                        name: 'Roles',
-                        icon: RiShieldLine,
-                        href: `/${organisationName}/roles`,
-                        active: pathname.startsWith(`/${organisationName}/roles`)
-                      },
-                      {
-                        name: 'Settings',
-                        icon: RiSettings3Line,
-                        href: `/${organisationName}/settings`,
-                        active: pathname.startsWith(`/${organisationName}/settings`)
-                      },
-                    ].map((item) => (
-                      <Link
-                        key={item.name}
-                        href={item.href}
-                        onClick={handleLinkClick}
-                        className={`
-                          flex items-center px-3 py-2 text-sm rounded-lg transition-colors
-                          ${item.active
-                            ? 'bg-brand-50 text-brand-900 dark:bg-brand-900/20 dark:text-brand-100'
-                            : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/50 dark:hover:text-white'
-                          }
-                        `}
-                      >
-                        <item.icon
-                          className={`
-                            mr-3 h-4 w-4
-                            ${item.active
-                              ? 'text-brand-600 dark:text-brand-400'
-                              : 'text-gray-400'
-                            }
-                          `}
-                        />
-                        <span>{item.name}</span>
-                      </Link>
-                    ))}
-                  </div>
+          <div className="flex-1 overflow-y-auto py-4 px-3">
+            {/* Project section (on top when inside a project) */}
+            {projectName && (
+              <>
+                <div className="mb-2 px-3">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Project
+                  </span>
                 </div>
-              )}
-            </>
-          )}
+                <nav className="space-y-0.5">
+                  {projectItems.map((item) => {
+                    const active = item.exact
+                      ? pathname === item.href
+                      : pathname === item.href || pathname.startsWith(`${item.href}/`);
+                    const Icon = item.icon;
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={onClose}
+                        className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+                          active
+                            ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        <Icon className="h-4 w-4 shrink-0" />
+                        {item.label}
+                      </Link>
+                    );
+                  })}
+                </nav>
 
-          {/* User section */}
-          <div className="border-t border-gray-200 dark:border-gray-800 p-4 flex-shrink-0">
-            {/* User info with avatar */}
-            <div className="flex items-center gap-3 mb-4">
-              <Avatar
-                name={user.name || user.email || 'User'}
-                image={user.image || null}
-                size="medium"
-              />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                  {user.name || 'User'}
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                  {user.email || 'customer@example.com'}
-                </p>
-              </div>
-            </div>
+                <div className="my-4 mx-3 border-t border-gray-200 dark:border-gray-700" />
+              </>
+            )}
 
-            {/* Action buttons */}
-            <div className="space-y-1">
-              {/* Smart Search (keep existing) */}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  open();
-                  setIsOpen(false);
-                }}
-                className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50"
-              >
-                <span className="mr-2 h-4 w-4 text-xs font-mono border rounded px-1.5 py-0.5 text-gray-500 border-gray-300 dark:border-gray-600">
-                  ⌘K
-                </span>
-                Smart Search
-              </Button>
+            {/* Organisation section */}
+            {orgName && (
+              <>
+                <div className="mb-2 px-3">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Organisation
+                  </span>
+                </div>
+                <nav className="space-y-0.5">
+                  {orgItems.map((item) => {
+                    const active = item.exact
+                      ? pathname === item.href
+                      : pathname === item.href || pathname.startsWith(`${item.href}/`);
+                    const Icon = item.icon;
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={onClose}
+                        className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+                          active
+                            ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        <Icon className="h-4 w-4 shrink-0" />
+                        {item.label}
+                      </Link>
+                    );
+                  })}
+                </nav>
+              </>
+            )}
 
-              {/* Account Menu Items */}
-              <Link href="/account/developer" onClick={handleLinkClick}>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50"
-                >
-                  <RiCodeLine className="mr-2 h-4 w-4" />
-                  Developer
-                </Button>
-              </Link>
-
-              <Link href="/account/settings" onClick={handleLinkClick}>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50"
-                >
-                  <RiSettings3Line className="mr-2 h-4 w-4" />
-                  Settings
-                </Button>
-              </Link>
-
-              {/* Admin Menu Items (conditional) */}
-              {user.role === 'SUPERADMIN' && (
-                <>
-                  <div className="my-2 border-t border-gray-200 dark:border-gray-700" />
-
-                  <Link href="/admin" onClick={handleLinkClick}>
-                    <Button variant="ghost" size="sm" className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                      <RiDatabaseLine className="mr-2 h-4 w-4" />
-                      Nodes
-                    </Button>
-                  </Link>
-
-                  <Link href="/admin/users" onClick={handleLinkClick}>
-                    <Button variant="ghost" size="sm" className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                      <RiUserLine className="mr-2 h-4 w-4" />
-                      Users
-                    </Button>
-                  </Link>
-
-                  <Link href="/admin/organisations" onClick={handleLinkClick}>
-                    <Button variant="ghost" size="sm" className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                      <RiBuildingLine className="mr-2 h-4 w-4" />
-                      Organisations
-                    </Button>
-                  </Link>
-
-                  <Link href="/admin/projects" onClick={handleLinkClick}>
-                    <Button variant="ghost" size="sm" className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                      <RiProjectorLine className="mr-2 h-4 w-4" />
-                      Projects
-                    </Button>
-                  </Link>
-
-                  <Link href="/admin/previews/email" onClick={handleLinkClick}>
-                    <Button variant="ghost" size="sm" className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                      <RiMailLine className="mr-2 h-4 w-4" />
-                      Preview Email
-                    </Button>
-                  </Link>
-                </>
-              )}
-
-              {/* Separator before Sign Out */}
-              <div className="my-2 border-t border-gray-200 dark:border-gray-700" />
-
-              {/* Sign Out Button */}
-              <form action={handleSignOut}>
-                <Button
-                  type="submit"
-                  variant="ghost"
-                  size="sm"
-                  className="w-full justify-start text-red-600 dark:text-red-500 hover:text-red-700 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
-                >
-                  Sign Out
-                </Button>
-              </form>
-            </div>
+            {/* Project list */}
+            {!projectName && !isOrgOverview && projects.length > 0 && (
+              <>
+                <div className="mt-6 mb-2 px-3">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Projects
+                  </span>
+                </div>
+                <nav className="space-y-0.5">
+                  {projects.map((project) => {
+                    const projectHref = `${orgBase}/${project.name}`;
+                    const active = pathname === projectHref || pathname.startsWith(`${projectHref}/`);
+                    return (
+                      <Link
+                        key={project.id}
+                        href={projectHref}
+                        onClick={onClose}
+                        className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+                          active
+                            ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        <RiProjectorLine className="h-4 w-4 shrink-0" />
+                        {project.name}
+                      </Link>
+                    );
+                  })}
+                </nav>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/navigation/SidebarNavigation.tsx
+++ b/src/components/navigation/SidebarNavigation.tsx
@@ -1,322 +1,184 @@
 'use client';
 
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
 import {
-  RiSettings3Line,
-  RiServerLine,
-  RiBuildingLine,
-  RiProjectorLine,
-  RiArrowDownSLine,
-  RiFileTextLine,
-  RiBarChartLine,
-  RiAddLine,
-  RiArrowUpSLine,
-  RiExternalLinkLine,
+  RiDashboardLine,
   RiUserLine,
-  RiShieldLine
+  RiTeamLine,
+  RiShieldLine,
+  RiSettings3Line,
+  RiMailSendLine,
+  RiProjectorLine,
+  RiShareLine,
+  RiExchangeLine,
+  RiDatabaseLine,
+  RiLockLine,
 } from '@remixicon/react';
-import { Button } from '@/components/common/Button';
-import { User } from '@/lib/store';
-import { useCommandPalette } from '@/hooks/useCommandPalette';
-import { Badge } from '@/components/common/Badge';
 
 type Project = {
   id: string;
   name: string;
   status: string;
-  progress: number;
-  organisationId: string;
 };
 
 type Organisation = {
   id: string;
   name: string;
-  description?: string | null;
-  _count?: {
-    projects: number;
-    members: number;
-  };
   projects?: Project[];
 };
 
-export default function SidebarNavigation({
-  user,
-  organisations: initialOrganisations = [],
-}: {
-  user: Partial<User>;
+interface SidebarNavigationProps {
   organisations?: Organisation[];
-}) {
+}
+
+export default function SidebarNavigation({
+  organisations = [],
+}: SidebarNavigationProps) {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const { open } = useCommandPalette();
 
-  const [showOrgDropdown, setShowOrgDropdown] = useState(false);
+  const segments = pathname.split('/').filter(Boolean);
 
-  const getOrganisationName = () => {
-    const pathSegments = pathname.split('/');
-    if (pathSegments[1] === 'orga' && pathSegments[2]) {
-      return pathSegments[2];
-    }
-    if (pathSegments[1] && pathSegments[1] !== 'account' && pathSegments[1] !== 'admin' && pathSegments[1] !== 'api') {
-      const candidate = pathSegments[1];
-      const match = initialOrganisations.find(org => org.name === candidate);
-      if (match) return candidate;
-    }
-    return null;
-  };
+  const orgSubRoutes = ['members', 'teams', 'roles', 'invitations', 'settings'];
 
-  const organisationName = getOrganisationName();
-
-  // Find current organisation and its projects from server-provided data
-  const organisation = organisationName
-    ? initialOrganisations.find(org => org.name === organisationName) || null
+  const orgName = (segments.length >= 1
+    && segments[0] !== 'account'
+    && segments[0] !== 'admin'
+    && segments[0] !== 'orga'
+    && segments[0] !== 'signin'
+    && segments[0] !== 'register'
+    && segments[0] !== 'docs')
+    ? segments[0]
     : null;
 
-  const organisationId = organisation?.id; // Get the actual ID from the organisation object
+  const isProjectPage = orgName && segments.length >= 2 && !orgSubRoutes.includes(segments[1]);
+  const projectName = isProjectPage ? segments[1] : null;
+
+  const isOrgOverview = orgName && !projectName && (segments.length === 1 || (segments.length === 2 && segments[1] === ''));
+
+  const organisation = orgName
+    ? organisations.find(org => org.name === orgName) || null
+    : null;
+
   const projects = organisation?.projects || [];
 
-  const isActivePath = (href: string) => {
-    if (href === '') {
-      return pathname === '' && organisationId;
-    }
-    return pathname.startsWith(href);
-  };
+  if (!orgName) return null;
+
+  const orgBase = `/${orgName}`;
+
+  const orgItems = [
+    { href: orgBase, label: 'Overview', icon: RiDashboardLine, exact: true },
+    { href: `${orgBase}/members`, label: 'Members', icon: RiUserLine },
+    { href: `${orgBase}/teams`, label: 'Teams', icon: RiTeamLine },
+    { href: `${orgBase}/roles`, label: 'Roles', icon: RiShieldLine },
+    { href: `${orgBase}/invitations`, label: 'Invitations', icon: RiMailSendLine },
+    { href: `${orgBase}/settings`, label: 'Settings', icon: RiSettings3Line },
+  ];
+
+  const projectItems = projectName ? [
+    { href: `${orgBase}/${projectName}`, label: 'Resources', icon: RiDatabaseLine, exact: true },
+    { href: `${orgBase}/${projectName}/access`, label: 'Access', icon: RiLockLine },
+    { href: `${orgBase}/${projectName}/share`, label: 'Share', icon: RiShareLine },
+    { href: `${orgBase}/${projectName}/transfer`, label: 'Transfer', icon: RiExchangeLine },
+    { href: `${orgBase}/${projectName}/settings`, label: 'Settings', icon: RiSettings3Line },
+  ] : [];
 
   return (
-    <div className="w-64 min-h-screen border-r flex flex-col flex-shrink-0">
-
-      {/* Organisation Selector */}
-      <div className="px-3 py-4 border-b border-gray-200 dark:border-gray-700">
-        <div className="relative">
-          <button
-            onClick={() => setShowOrgDropdown(!showOrgDropdown)}
-            className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-colors ${
-              organisation
-                ? 'border-brand-500 dark:border-brand-400 bg-brand-50 dark:bg-brand-900/20'
-                : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50'
-            }`}
-          >
-            <div className="flex items-center min-w-0 flex-1">
-              <RiBuildingLine className={`mr-3 h-5 w-5 flex-shrink-0 ${
-                organisation
-                  ? 'text-brand-600 dark:text-brand-400'
-                  : 'text-gray-400 dark:text-gray-600'
-              }`} />
-              <div className="min-w-0 flex-1 text-left">
-                {organisation ? (
-                  <>
-                    <div className={`text-sm font-semibold truncate ${
-                      organisation
-                        ? 'text-brand-900 dark:text-brand-100'
-                        : 'text-gray-900 dark:text-white'
-                    }`}>
-                      {organisation.name}
-                    </div>
-                    <div className="text-xs text-brand-700 dark:text-brand-300">
-                      Current organisation
-                    </div>
-                  </>
-                ) : (
-                  <div className="text-sm text-gray-500 dark:text-gray-400">
-                    Select organisation
-                  </div>
-                )}
-              </div>
-            </div>
-            {showOrgDropdown ? (
-              <RiArrowUpSLine className="h-5 w-5 text-gray-400 flex-shrink-0" />
-            ) : (
-              <RiArrowDownSLine className="h-5 w-5 text-gray-400 flex-shrink-0" />
-            )}
-          </button>
-
-          {/* Dropdown */}
-          {showOrgDropdown && (
-            <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-60 overflow-y-auto">
-              {initialOrganisations.length > 0 ? (
-                <>
-                  {initialOrganisations.map((org) => {
-                    const isSelected = org.id === organisationId;
-                    return (
-                      <Link
-                        key={org.id}
-                        href={`/${org.name}`}
-                        onClick={() => setShowOrgDropdown(false)}
-                        className={`
-                          block p-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors border-l-4
-                          ${isSelected
-                            ? 'bg-brand-50 dark:bg-brand-900/20 border-brand-500 dark:border-brand-400'
-                            : 'border-transparent'
-                          }
-                        `}
-                      >
-                        <div className="flex items-center">
-                          <RiBuildingLine className={`mr-3 h-4 w-4 flex-shrink-0 ${
-                            isSelected
-                              ? 'text-brand-600 dark:text-brand-400'
-                              : 'text-gray-400 dark:text-gray-600'
-                          }`} />
-                          <div className="min-w-0 flex-1">
-                            <div className={`text-sm font-medium truncate ${
-                              isSelected
-                                ? 'text-brand-900 dark:text-brand-100'
-                                : 'text-gray-900 dark:text-white'
-                            }`}>
-                              {org.name}
-                            </div>
-                            {org._count && (
-                              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                                {org._count.projects} projects • {org._count.members} members
-                              </div>
-                            )}
-                          </div>
-                          {isSelected && (
-                            <div className="ml-2 flex-shrink-0">
-                              <div className="h-2 w-2 rounded-full bg-brand-500" />
-                            </div>
-                          )}
-                        </div>
-                      </Link>
-                    );
-                  })}
-                  <div className="border-t border-gray-200 dark:border-gray-700 p-2">
-                    <Link
-                      href="/orga"
-                      onClick={() => setShowOrgDropdown(false)}
-                      className="flex items-center p-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded transition-colors"
-                    >
-                      <RiExternalLinkLine className="mr-2 h-4 w-4" />
-                      My Organisations
-                    </Link>
-                  </div>
-                </>
-              ) : (
-                <div className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                  No organisations found
-                  <Link
-                    href="/orga/new"
-                    onClick={() => setShowOrgDropdown(false)}
-                    className="block mt-2 text-brand-600 dark:text-brand-400 hover:underline"
-                  >
-                    Create one
-                  </Link>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {!organisation && (
-        <div className="flex-1 flex items-center justify-center p-6">
-          <div className="text-center">
-            <RiBuildingLine className="mx-auto h-12 w-12 text-gray-400 mb-4" />
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-              No organisation selected
-            </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Use the dropdown above to select one
-            </p>
+    <aside className="w-56 shrink-0 border-r border-gray-200 dark:border-gray-800 min-h-screen py-4 px-3">
+      {/* Project section (on top when inside a project) */}
+      {projectName && (
+        <>
+          <div className="mb-2 px-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+              Project
+            </span>
           </div>
-        </div>
+          <nav className="space-y-0.5">
+            {projectItems.map((item) => {
+              const active = item.exact
+                ? pathname === item.href
+                : pathname === item.href || pathname.startsWith(`${item.href}/`);
+              const Icon = item.icon;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm transition-colors ${
+                    active
+                      ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                      : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                  }`}
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className="my-4 mx-3 border-t border-gray-200 dark:border-gray-700" />
+        </>
       )}
 
-          {/* Organisation Navigation */}
-          {organisation && (
-            <div className="border-t border-gray-200 dark:border-gray-700 px-3 py-4 flex-1 flex flex-col">
-              <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
-                Organisation
-              </h4>
-              <div className="space-y-1">
-                {[
-                  {
-                    name: 'Projects',
-                    icon: RiProjectorLine,
-                    href: `/${organisationName}`,
-                    active: pathname === `/${organisationName}`
-                  },
-                  {
-                    name: 'Members',
-                    icon: RiUserLine,
-                    href: `/${organisationName}/members`,
-                    active: pathname.startsWith(`/${organisationName}/members`)
-                  },
-                  {
-                    name: 'Roles',
-                    icon: RiShieldLine,
-                    href: `/${organisationName}/roles`,
-                    active: pathname.startsWith(`/${organisationName}/roles`)
-                  },
-                  {
-                    name: 'Settings',
-                    icon: RiSettings3Line,
-                    href: `/${organisationName}/settings`,
-                    active: pathname.startsWith(`/${organisationName}/settings`)
-                  },
-                ].map((item) => (
-                  <Link
-                    key={item.name}
-                    href={item.href}
-                    className={`
-                      flex items-center px-3 py-2 text-sm rounded-lg transition-colors
-                      ${item.active
-                        ? 'bg-brand-50 text-brand-900 dark:bg-brand-900/20 dark:text-brand-100'
-                        : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/50 dark:hover:text-white'
-                      }
-                    `}
-                  >
-                    <item.icon
-                      className={`
-                        mr-3 h-4 w-4
-                        ${item.active
-                          ? 'text-brand-600 dark:text-brand-400'
-                          : 'text-gray-400'
-                        }
-                      `}
-                    />
-                    <span>{item.name}</span>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          )}
-
-      {/* User section */}
-      <div className="border-t p-4 flex-shrink-0">
-        <div className="flex items-center mb-3">
-          <div className="ml-3 flex-1 min-w-0">
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              {user.email || 'customer@example.com'}
-            </p>
-          </div>
-        </div>
-
-        <div className="space-y-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={open}
-            className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50"
-          >
-            <span className="mr-2 h-4 w-4 text-xs font-mono border rounded px-1.5 py-0.5 text-gray-500 border-gray-300 dark:border-gray-600">
-              ⌘K
-            </span>
-            Smart Search
-          </Button>
-          <Link href="/account/settings">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800/50"
-            >
-              <RiSettings3Line className="mr-2 h-4 w-4" />
-              Account Settings
-            </Button>
-          </Link>
-        </div>
+      {/* Organisation section */}
+      <div className="mb-2 px-3">
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+          Organisation
+        </span>
       </div>
-    </div>
+      <nav className="space-y-0.5">
+        {orgItems.map((item) => {
+          const active = item.exact
+            ? pathname === item.href
+            : pathname === item.href || pathname.startsWith(`${item.href}/`);
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm transition-colors ${
+                active
+                  ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+              }`}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Project list (only on org-level pages, not on overview which shows them as content) */}
+      {!projectName && !isOrgOverview && projects.length > 0 && (
+        <>
+          <div className="mt-6 mb-2 px-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+              Projects
+            </span>
+          </div>
+          <nav className="space-y-0.5">
+            {projects.map((project) => {
+              const projectHref = `${orgBase}/${project.name}`;
+              const active = pathname === projectHref || pathname.startsWith(`${projectHref}/`);
+              return (
+                <Link
+                  key={project.id}
+                  href={projectHref}
+                  className={`flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm transition-colors ${
+                    active
+                      ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                      : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                  }`}
+                >
+                  <RiProjectorLine className="h-4 w-4 shrink-0" />
+                  {project.name}
+                </Link>
+              );
+            })}
+          </nav>
+        </>
+      )}
+    </aside>
   );
 }

--- a/src/hooks/useMobileMenu.tsx
+++ b/src/hooks/useMobileMenu.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback } from 'react';
+
+interface MobileMenuContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+const MobileMenuContext = createContext<MobileMenuContextValue | null>(null);
+
+export function MobileMenuProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen(prev => !prev), []);
+
+  return (
+    <MobileMenuContext.Provider value={{ isOpen, open, close, toggle }}>
+      {children}
+    </MobileMenuContext.Provider>
+  );
+}
+
+export function useMobileMenu(): MobileMenuContextValue {
+  const context = useContext(MobileMenuContext);
+  if (!context) {
+    return { isOpen: false, open: () => {}, close: () => {}, toggle: () => {} };
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- **Top nav bar**: hamburger (mobile) + breadcrumb (Org / Project) + Private badge + smart search (right-aligned) + user avatar dropdown
- **Unified sidebar**: replaces both SidebarNavigation and OrgSidebar — context-aware content shows project actions on top when inside a project, org nav below
- **No org selector dropdown**: switch orgs via Organisations page or command palette
- **Mobile**: hamburger in top nav toggles slide-in drawer with same sidebar content
- **New**: MobileMenuProvider context, useMobileMenu hook

## Files changed
- `UserBar` — rewritten as top nav with breadcrumb + search
- `UserBarMenu` — simplified to avatar trigger only
- `SidebarNavigation` — rewritten as unified context-aware sidebar
- `MobileNavigation` — updated to match new sidebar, uses context for open/close
- `[slug]/layout.tsx` — uses unified sidebar, removed OrgSidebar
- `orga/layout.tsx` — simplified, uses unified sidebar
- `layout.tsx` — added MobileMenuProvider
- `page.tsx` — removed mobile header (top nav handles it)

## Test plan
- [ ] Org overview page: sidebar shows org nav + project list, no org selector
- [ ] Inside a project: sidebar shows project actions on top, org nav below
- [ ] Top nav: breadcrumb shows Org / Project, search right-aligned
- [ ] Mobile: hamburger toggles drawer with context-aware content
- [ ] Command palette still works (cmd+K)
- [ ] User dropdown: Organisations, Account, Admin, Sign Out
- [ ] Homepage: top nav shows Sign In button, no broken mobile header