### PR TITLE
fix: navigation follow-up issues

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,8 @@ import "./globals.css";
 import { auth } from '@/lib/auth';
 
 import UserBar from '@/components/layout/UserBar';
-import CommandPaletteProvider from '@/components/navigation/CommandPaletteProvider';
+import CommandPaletteProviderWrapper from '@/components/navigation/CommandPaletteProvider';
+import { CommandPaletteProvider } from '@/hooks/useCommandPalette';
 import { MobileMenuProvider } from '@/hooks/useMobileMenu';
 
 const geist = Geist({
@@ -31,13 +32,15 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={`${geist.className} antialiased bg-gray-50 dark:bg-gray-950`}>
-        <MobileMenuProvider>
-          <div className="text-neutral-800 dark:text-neutral-200">
-            <UserBar user={session?.user} />
-            {children}
-            <CommandPaletteProvider />
-          </div>
-        </MobileMenuProvider>
+        <CommandPaletteProvider>
+          <MobileMenuProvider>
+            <div className="text-neutral-800 dark:text-neutral-200">
+              <UserBar user={session?.user} />
+              {children}
+              <CommandPaletteProviderWrapper />
+            </div>
+          </MobileMenuProvider>
+        </CommandPaletteProvider>
       </body>
     </html>
   );

--- a/src/components/OrganisationOverviewClient.tsx
+++ b/src/components/OrganisationOverviewClient.tsx
@@ -8,12 +8,8 @@ import ProjectCard from '@/components/project/ProjectCard';
 import Link from 'next/link';
 import { Badge } from '@/components/common/Badge';
 import {
-  RiSettings3Line,
   RiProjectorLine,
   RiAddLine,
-  RiUserLine,
-  RiTeamLine,
-  RiMailLine,
   RiShareLine,
 } from '@remixicon/react';
 
@@ -31,29 +27,25 @@ export default function OrganisationOverviewClient({
   return (
     <main className="mt-4">
       <Container>
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-              {organisation.name}
-            </h1>
-            {organisation.description && (
-              <p className="text-gray-600 dark:text-gray-300 mt-2">
-                {organisation.description}
-              </p>
-            )}
-            <div className="flex items-center gap-4 mt-3 text-sm text-gray-500 dark:text-gray-400">
-              <span className="flex items-center gap-1">
-                <RiUserLine className="h-4 w-4" />
-                {organisation._count?.members} members
-              </span>
-              <span className="flex items-center gap-1">
-                <RiProjectorLine className="h-4 w-4" />
-                {organisation._count?.projects} projects
-              </span>
-            </div>
-          </div>
+        {/* Header — hidden on desktop (name is in top nav breadcrumb) */}
+        <div className="lg:hidden mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            {organisation.name}
+          </h1>
+          {organisation.description && (
+            <p className="text-gray-600 dark:text-gray-300 mt-2">
+              {organisation.description}
+            </p>
+          )}
         </div>
+        {/* Description only on desktop (no title duplication) */}
+        {organisation.description && (
+          <div className="hidden lg:block mb-8">
+            <p className="text-gray-600 dark:text-gray-300">
+              {organisation.description}
+            </p>
+          </div>
+        )}
 
 
         {/* Projects Section */}

--- a/src/components/OrganisationsClient.tsx
+++ b/src/components/OrganisationsClient.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { RiBuildingLine, RiAddLine } from '@remixicon/react';
 import { Button } from '@/components/common/Button';
 import { OrganisationCard } from '@/components/OrganisationCard';
-import OrganisationSearchSection from '@/components/OrganisationSearchSection';
 import { Card } from '@/components/common/Card';
 
 type OrganisationType = {
@@ -41,11 +40,6 @@ export function OrganisationsClient({
           My Organisations
         </h1>
         <div className="flex items-center gap-3">
-          {organisations.length > 0 && (
-            <div className="relative w-64">
-              <OrganisationSearchSection />
-            </div>
-          )}
           <Link href="/orga/new">
             <Button>
               <RiAddLine className="mr-2 h-4 w-4" />

--- a/src/components/layout/UserBar.tsx
+++ b/src/components/layout/UserBar.tsx
@@ -48,7 +48,7 @@ export default function UserBar({ user }: TopNavProps) {
         )}
 
         {orgName && (
-          <nav className="flex items-center gap-1.5 text-sm">
+          <nav className={`flex items-center gap-1.5 text-sm ${!projectName ? 'hidden lg:flex' : ''}`}>
             <Link
               href={`/${orgName}`}
               className="font-medium text-gray-900 dark:text-white hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
@@ -66,10 +66,7 @@ export default function UserBar({ user }: TopNavProps) {
                 </Link>
               </>
             )}
-            <span className="ml-1 inline-flex items-center px-1.5 py-0.5 text-[10px] text-gray-500 dark:text-gray-400 border border-gray-300 dark:border-gray-600 rounded-full">
-              <RiLockLine className="h-2.5 w-2.5 mr-0.5" />
-              Private
-            </span>
+            <RiLockLine className="ml-1 h-3.5 w-3.5 text-gray-400 dark:text-gray-500" title="Private" />
           </nav>
         )}
       </div>

--- a/src/components/navigation/CommandPaletteProvider.tsx
+++ b/src/components/navigation/CommandPaletteProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { CommandPaletteProvider, useCommandPalette } from '@/hooks/useCommandPalette';
+import { useCommandPalette } from '@/hooks/useCommandPalette';
 import CommandPalette from '@/components/navigation/CommandPalette';
 
 function CommandPaletteKeyHandler() {
@@ -26,9 +26,5 @@ function CommandPaletteKeyHandler() {
 }
 
 export default function CommandPaletteProviderWrapper() {
-  return (
-    <CommandPaletteProvider>
-      <CommandPaletteKeyHandler />
-    </CommandPaletteProvider>
-  );
+  return <CommandPaletteKeyHandler />;
 }


### PR DESCRIPTION
## Summary
- **Search click fixed**: CommandPaletteProvider moved to root layout so UserBar can access context
- **Removed org search section**: from Organisations listing page (search is in top nav now)
- **Private/Public**: icon only, no text label
- **Org overview header**: hidden on desktop (name in breadcrumb), shown on mobile. Removed member/project counts.
- **Breadcrumb**: hidden on mobile when only showing org name (page title handles it)

## Test plan
- [ ] Click search in top nav — command palette opens
- [ ] cmd+K still works
- [ ] `/orga` page: no search section
- [ ] `/Enopax` desktop: no "Enopax" header, no member/project counts
- [ ] `/Enopax` mobile: "Enopax" header visible, no breadcrumb in top nav
- [ ] `/Enopax/ResourceTest`: breadcrumb visible on both mobile and desktop
- [ ] Lock icon shows without "Private" text