### PR TITLE
fix: hamburger menu works on desktop, split nav/profile menus

### DIFF
--- a/src/app/(main)/[slug]/layout.tsx
+++ b/src/app/(main)/[slug]/layout.tsx
@@ -2,7 +2,6 @@ import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
 import { OrganisationProvider } from '@/contexts/OrganisationContext';
-import SidebarNavigation from '@/components/navigation/SidebarNavigation';
 import MobileNavigation from '@/components/navigation/MobileNavigation';
 
 async function getOrganisationData(store: any, org: any) {
@@ -44,7 +43,7 @@ async function getUserOrganisations(store: any, userId: string) {
   return Promise.all(orgDataPromises);
 }
 
-function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjects: any[], organisations: any[], children: React.ReactNode) {
+function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjects: any[], organisations: any[], user: any, children: React.ReactNode) {
   return (
     <OrganisationProvider
       organisation={{
@@ -61,12 +60,9 @@ function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjec
         },
       }}
     >
-      <div className="flex min-h-[calc(100vh-2.5rem)]">
-        <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
-          <SidebarNavigation organisations={organisations} />
-        </div>
-        <MobileNavigation organisations={organisations} />
-        <main className="flex-1 p-6">{children}</main>
+      <div className="min-h-[calc(100vh-2.5rem)]">
+        <MobileNavigation organisations={organisations} user={user} />
+        <main className="p-6">{children}</main>
       </div>
     </OrganisationProvider>
   );
@@ -98,7 +94,7 @@ export default async function NamespaceLayout({
     if (!organisation || !organisation.isActive) notFound();
 
     const { projects, members, sharedProjects } = await getOrganisationData(store, organisation);
-    return renderOrgLayout(organisation, projects, members, sharedProjects, organisations, children);
+    return renderOrgLayout(organisation, projects, members, sharedProjects, organisations, session?.user, children);
   }
 
   if (namespace?.entityType === 'USER') {
@@ -110,7 +106,7 @@ export default async function NamespaceLayout({
   const orgByName = await store.organisations.findByName(slug);
   if (orgByName && orgByName.isActive) {
     const { projects, members, sharedProjects } = await getOrganisationData(store, orgByName);
-    return renderOrgLayout(orgByName, projects, members, sharedProjects, organisations, children);
+    return renderOrgLayout(orgByName, projects, members, sharedProjects, organisations, session?.user, children);
   }
 
   notFound();

--- a/src/app/(main)/orga/layout.tsx
+++ b/src/app/(main)/orga/layout.tsx
@@ -1,6 +1,5 @@
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
-import SidebarNavigation from '@/components/navigation/SidebarNavigation';
 import MobileNavigation from '@/components/navigation/MobileNavigation';
 
 async function getUserOrganisations(userId: string) {
@@ -45,14 +44,10 @@ export default async function Layout({
   }
 
   return (
-    <div className="flex">
-      <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
-        <SidebarNavigation organisations={organisations} />
-      </div>
+    <div>
+      <MobileNavigation organisations={organisations} user={session?.user} />
 
-      <MobileNavigation organisations={organisations} />
-
-      <main className="flex-1 p-6">
+      <main className="p-6">
         {children}
       </main>
     </div>

--- a/src/components/layout/UserBarMenu.tsx
+++ b/src/components/layout/UserBarMenu.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/menu/DropdownMenu';
@@ -40,52 +39,14 @@ export default function UserBarMenu({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="end">
-        <DropdownMenuLabel>
-          <u>Main</u>
-        </DropdownMenuLabel>
-
         <DropdownMenuGroup>
-          <Link href="/orga">
-            <DropdownMenuItem>
-              Organisations
-            </DropdownMenuItem>
-          </Link>
-        </DropdownMenuGroup>
-
-        <DropdownMenuLabel>
-          <u>Account</u>
-        </DropdownMenuLabel>
-
-        <DropdownMenuGroup>
-          <Link href="/account/developer">
-            <DropdownMenuItem>
-              Developer
-            </DropdownMenuItem>
-          </Link>
           <Link href="/account/settings">
-            <DropdownMenuItem>
-              Settings
-            </DropdownMenuItem>
+            <DropdownMenuItem>Settings</DropdownMenuItem>
+          </Link>
+          <Link href="/account/developer">
+            <DropdownMenuItem>Developer</DropdownMenuItem>
           </Link>
         </DropdownMenuGroup>
-
-        {user.role === 'SUPERADMIN' && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel>
-              <u>Admin</u>
-            </DropdownMenuLabel>
-
-            <DropdownMenuGroup>
-              <Link href="/admin/users">
-                <DropdownMenuItem>Users</DropdownMenuItem>
-              </Link>
-              <Link href="/admin/organisations">
-                <DropdownMenuItem>Organisations</DropdownMenuItem>
-              </Link>
-            </DropdownMenuGroup>
-          </>
-        )}
 
         <DropdownMenuSeparator />
 

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import {
   RiCloseLine,
+  RiBuildingLine,
   RiDashboardLine,
   RiUserLine,
   RiTeamLine,
@@ -32,9 +33,10 @@ type Organisation = {
 
 interface MobileNavigationProps {
   organisations?: Organisation[];
+  user?: any;
 }
 
-export default function MobileNavigation({ organisations = [] }: MobileNavigationProps) {
+export default function MobileNavigation({ organisations = [], user }: MobileNavigationProps) {
   const { isOpen, close: onClose } = useMobileMenu();
   const pathname = usePathname();
 
@@ -82,10 +84,10 @@ export default function MobileNavigation({ organisations = [] }: MobileNavigatio
   return (
     <>
       {isOpen && (
-        <div className="lg:hidden fixed inset-0 z-50 bg-black/50" onClick={onClose} />
+        <div className="fixed inset-0 z-50 bg-black/50" onClick={onClose} />
       )}
 
-      <div className={`lg:hidden fixed inset-y-0 left-0 z-50 w-72 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 transform transition-transform duration-300 ${
+      <div className={`fixed inset-y-0 left-0 z-50 w-72 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 transform transition-transform duration-300 ${
         isOpen ? 'translate-x-0' : '-translate-x-full'
       }`}>
         <div className="flex flex-col h-full">
@@ -197,6 +199,48 @@ export default function MobileNavigation({ organisations = [] }: MobileNavigatio
                 </nav>
               </>
             )}
+            {/* Navigation links */}
+            <div className="mt-6 mx-3 border-t border-gray-200 dark:border-gray-700 pt-4">
+              <div className="mb-2 px-3">
+                <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Navigation
+                </span>
+              </div>
+              <nav className="space-y-0.5">
+                <Link
+                  href="/orga"
+                  onClick={onClose}
+                  className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+                    pathname === '/orga'
+                      ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                      : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                  }`}
+                >
+                  <RiBuildingLine className="h-4 w-4 shrink-0" />
+                  Organisations
+                </Link>
+                {user?.role === 'SUPERADMIN' && (
+                  <>
+                    <Link
+                      href="/admin/users"
+                      onClick={onClose}
+                      className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    >
+                      <RiUserLine className="h-4 w-4 shrink-0" />
+                      Admin: Users
+                    </Link>
+                    <Link
+                      href="/admin/organisations"
+                      onClick={onClose}
+                      className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    >
+                      <RiBuildingLine className="h-4 w-4 shrink-0" />
+                      Admin: Organisations
+                    </Link>
+                  </>
+                )}
+              </nav>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Hamburger works on desktop**: sidebar is now toggle-based on all screen sizes (removed permanent desktop sidebar, drawer slides in everywhere)
- **Menu split**: navigation items (Organisations, Admin) moved to hamburger drawer; user avatar dropdown now only has profile actions (Settings, Developer, Sign Out)
- **Drawer shows org list** on /orga page

## Test plan
- [ ] Desktop: click hamburger — drawer slides in with context sidebar + navigation links
- [ ] Click hamburger again or overlay — drawer closes
- [ ] User avatar dropdown: only Settings, Developer, Sign Out
- [ ] Admin links visible in drawer for SUPERADMIN users
- [ ] /orga page: drawer shows organisations list
- [ ] Mobile: same behaviour as desktop