### PR TITLE
fix: permanent sidebar on desktop, hamburger is navigation menu

### DIFF
--- a/src/app/(main)/[slug]/layout.tsx
+++ b/src/app/(main)/[slug]/layout.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { getStoreAsync } from '@/lib/store';
 import { OrganisationProvider } from '@/contexts/OrganisationContext';
-import MobileNavigation from '@/components/navigation/MobileNavigation';
+import SidebarNavigation from '@/components/navigation/SidebarNavigation';
 
 async function getOrganisationData(store: any, org: any) {
   const projects = await store.projects.findByOrgId(org.id, { isActive: true });
@@ -43,7 +43,7 @@ async function getUserOrganisations(store: any, userId: string) {
   return Promise.all(orgDataPromises);
 }
 
-function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjects: any[], organisations: any[], user: any, children: React.ReactNode) {
+function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjects: any[], organisations: any[], children: React.ReactNode) {
   return (
     <OrganisationProvider
       organisation={{
@@ -60,9 +60,11 @@ function renderOrgLayout(org: any, projects: any[], members: any[], sharedProjec
         },
       }}
     >
-      <div className="min-h-[calc(100vh-2.5rem)]">
-        <MobileNavigation organisations={organisations} user={user} />
-        <main className="p-6">{children}</main>
+      <div className="flex min-h-[calc(100vh-2.5rem)]">
+        <div className="hidden lg:block sticky top-0 h-screen overflow-y-auto">
+          <SidebarNavigation organisations={organisations} />
+        </div>
+        <main className="flex-1 p-6">{children}</main>
       </div>
     </OrganisationProvider>
   );
@@ -94,7 +96,7 @@ export default async function NamespaceLayout({
     if (!organisation || !organisation.isActive) notFound();
 
     const { projects, members, sharedProjects } = await getOrganisationData(store, organisation);
-    return renderOrgLayout(organisation, projects, members, sharedProjects, organisations, session?.user, children);
+    return renderOrgLayout(organisation, projects, members, sharedProjects, organisations, children);
   }
 
   if (namespace?.entityType === 'USER') {
@@ -106,7 +108,7 @@ export default async function NamespaceLayout({
   const orgByName = await store.organisations.findByName(slug);
   if (orgByName && orgByName.isActive) {
     const { projects, members, sharedProjects } = await getOrganisationData(store, orgByName);
-    return renderOrgLayout(orgByName, projects, members, sharedProjects, organisations, session?.user, children);
+    return renderOrgLayout(orgByName, projects, members, sharedProjects, organisations, children);
   }
 
   notFound();

--- a/src/app/(main)/orga/layout.tsx
+++ b/src/app/(main)/orga/layout.tsx
@@ -1,55 +1,7 @@
-import { auth } from '@/lib/auth';
-import { getStoreAsync } from '@/lib/store';
-import MobileNavigation from '@/components/navigation/MobileNavigation';
-
-async function getUserOrganisations(userId: string) {
-  const store = await getStoreAsync();
-  const memberships = await store.organisationMembers.findByUserId(userId);
-  const memberOrgIds = new Set(memberships.map(m => m.organisationId));
-
-  const allOrgs = await store.organisations.search('', 1000);
-  const userOrgs = allOrgs.filter(org =>
-    org.isActive && (org.ownerId === userId || memberOrgIds.has(org.id))
-  );
-
-  const orgDataPromises = userOrgs
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map(async (org) => {
-      const projects = await store.projects.findByOrgId(org.id, { isActive: true });
-      return {
-        id: org.id,
-        name: org.name,
-        projects: projects.map(p => ({ id: p.id, name: p.name, status: p.status })),
-      };
-    });
-
-  return Promise.all(orgDataPromises);
-}
-
-export default async function Layout({
+export default function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await auth();
-
-  let organisations: { id: string; name: string; projects: { id: string; name: string; status: string }[] }[] = [];
-
-  if (session?.user?.id) {
-    try {
-      organisations = await getUserOrganisations(session.user.id);
-    } catch (error) {
-      console.error('Error fetching sidebar data:', error);
-    }
-  }
-
-  return (
-    <div>
-      <MobileNavigation organisations={organisations} user={session?.user} />
-
-      <main className="p-6">
-        {children}
-      </main>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { auth } from '@/lib/auth';
 
 import UserBar from '@/components/layout/UserBar';
+import MobileNavigation from '@/components/navigation/MobileNavigation';
 import CommandPaletteProviderWrapper from '@/components/navigation/CommandPaletteProvider';
 import { CommandPaletteProvider } from '@/hooks/useCommandPalette';
 import { MobileMenuProvider } from '@/hooks/useMobileMenu';
@@ -36,6 +37,7 @@ export default async function RootLayout({
           <MobileMenuProvider>
             <div className="text-neutral-800 dark:text-neutral-200">
               <UserBar user={session?.user} />
+              <MobileNavigation user={session?.user} />
               {children}
               <CommandPaletteProviderWrapper />
             </div>

--- a/src/components/OrganisationsClient.tsx
+++ b/src/components/OrganisationsClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { RiBuildingLine, RiAddLine } from '@remixicon/react';
+import { RiBuildingLine, RiAddLine, RiSearchLine } from '@remixicon/react';
 import { Button } from '@/components/common/Button';
 import { OrganisationCard } from '@/components/OrganisationCard';
 import { Card } from '@/components/common/Card';
@@ -32,58 +33,125 @@ interface OrganisationsClientProps {
 export function OrganisationsClient({
   organisations
 }: OrganisationsClientProps) {
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState('name');
+
+  const filtered = useMemo(() => {
+    let result = organisations;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(org =>
+        org.name.toLowerCase().includes(q) ||
+        org.description?.toLowerCase().includes(q)
+      );
+    }
+
+    if (sort === 'recent') {
+      result = [...result].sort((a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+    } else {
+      result = [...result].sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    return result;
+  }, [organisations, search, sort]);
+
   return (
-    <div className="max-w-7xl mx-auto px-4">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-          My Organisations
-        </h1>
-        <div className="flex items-center gap-3">
-          <Link href="/orga/new">
-            <Button>
-              <RiAddLine className="mr-2 h-4 w-4" />
-              New Organisation
-            </Button>
-          </Link>
+    <div className="flex">
+      {/* Filter sidebar — desktop only */}
+      {organisations.length > 0 && (
+        <aside className="hidden lg:block w-56 shrink-0 border-r border-gray-200 dark:border-gray-800 min-h-[calc(100vh-3rem)] py-4 px-3">
+          <div className="mb-4 px-1">
+            <div className="relative">
+              <RiSearchLine className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400 dark:text-gray-500" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Find an organisation..."
+                className="w-full pl-8 pr-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+              />
+            </div>
+          </div>
+
+          <div className="px-1">
+            <div className="mb-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                Sort by
+              </span>
+            </div>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value)}
+              className="w-full px-2 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            >
+              <option value="name">Name</option>
+              <option value="recent">Recently created</option>
+            </select>
+          </div>
+        </aside>
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 p-6">
+        <div className="max-w-5xl">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-6">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              My Organisations
+            </h1>
+            <Link href="/orga/new">
+              <Button>
+                <RiAddLine className="mr-2 h-4 w-4" />
+                New Organisation
+              </Button>
+            </Link>
+          </div>
+
+          {/* Organisations Grid */}
+          {filtered.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+              {filtered.map((org) => (
+                <OrganisationCard
+                  key={org.id}
+                  id={org.id}
+                  name={org.name}
+                  description={org.description}
+                  isActive={org.isActive}
+                  owner={org.owner}
+                  projectCount={org._count.projects}
+                  memberCount={org._count.members}
+                  resourceCount={org._count.resources || 0}
+                  createdAt={org.createdAt}
+                />
+              ))}
+            </div>
+          ) : organisations.length > 0 ? (
+            <Card className="p-12 text-center">
+              <RiSearchLine className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600 mb-4" />
+              <p className="text-gray-500 dark:text-gray-400">No organisations match your search</p>
+            </Card>
+          ) : (
+            <Card className="p-12 text-center">
+              <RiBuildingLine className="mx-auto h-16 w-16 text-gray-400 mb-6" />
+              <h3 className="text-xl font-medium text-gray-900 dark:text-white mb-3">
+                No Organisations Yet
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-8 max-w-md mx-auto">
+                Create your first organisation to start managing projects and resources.
+              </p>
+              <Link href="/orga/new">
+                <Button size="lg">
+                  <RiAddLine className="mr-2 h-5 w-5" />
+                  Create First Organisation
+                </Button>
+              </Link>
+            </Card>
+          )}
         </div>
       </div>
-
-      {/* Organisations Grid */}
-      {organisations.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {organisations.map((org) => (
-            <OrganisationCard
-              key={org.id}
-              id={org.id}
-              name={org.name}
-              description={org.description}
-              isActive={org.isActive}
-              owner={org.owner}
-              projectCount={org._count.projects}
-              memberCount={org._count.members}
-              resourceCount={org._count.resources || 0}
-              createdAt={org.createdAt}
-            />
-          ))}
-        </div>
-      ) : (
-        <Card className="p-12 text-center">
-          <RiBuildingLine className="mx-auto h-16 w-16 text-gray-400 mb-6" />
-          <h3 className="text-xl font-medium text-gray-900 dark:text-white mb-3">
-            No Organisations Yet
-          </h3>
-          <p className="text-gray-600 dark:text-gray-400 mb-8 max-w-md mx-auto">
-            Create your first organisation to start managing projects and resources.
-          </p>
-          <Link href="/orga/new">
-            <Button size="lg">
-              <RiAddLine className="mr-2 h-5 w-5" />
-              Create First Organisation
-            </Button>
-          </Link>
-        </Card>
-      )}
     </div>
   );
 }

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -5,86 +5,22 @@ import Link from 'next/link';
 import {
   RiCloseLine,
   RiBuildingLine,
-  RiDashboardLine,
   RiUserLine,
-  RiTeamLine,
-  RiShieldLine,
-  RiSettings3Line,
-  RiMailSendLine,
-  RiProjectorLine,
-  RiDatabaseLine,
-  RiLockLine,
-  RiShareLine,
-  RiExchangeLine,
 } from '@remixicon/react';
 import { useMobileMenu } from '@/hooks/useMobileMenu';
 
-type Project = {
-  id: string;
-  name: string;
-  status: string;
-};
-
-type Organisation = {
-  id: string;
-  name: string;
-  projects?: Project[];
-};
-
 interface MobileNavigationProps {
-  organisations?: Organisation[];
   user?: any;
 }
 
-export default function MobileNavigation({ organisations = [], user }: MobileNavigationProps) {
-  const { isOpen, close: onClose } = useMobileMenu();
+export default function MobileNavigation({ user }: MobileNavigationProps) {
+  const { isOpen, close } = useMobileMenu();
   const pathname = usePathname();
-
-  const segments = pathname.split('/').filter(Boolean);
-  const orgSubRoutes = ['members', 'teams', 'roles', 'invitations', 'settings'];
-
-  const orgName = (segments.length >= 1
-    && segments[0] !== 'account'
-    && segments[0] !== 'admin'
-    && segments[0] !== 'orga'
-    && segments[0] !== 'signin'
-    && segments[0] !== 'register'
-    && segments[0] !== 'docs')
-    ? segments[0]
-    : null;
-
-  const isProjectPage = orgName && segments.length >= 2 && !orgSubRoutes.includes(segments[1]);
-  const projectName = isProjectPage ? segments[1] : null;
-  const isOrgOverview = orgName && !projectName && segments.length === 1;
-
-  const organisation = orgName
-    ? organisations.find(org => org.name === orgName) || null
-    : null;
-
-  const projects = organisation?.projects || [];
-  const orgBase = orgName ? `/${orgName}` : '';
-
-  const orgItems = orgName ? [
-    { href: orgBase, label: 'Overview', icon: RiDashboardLine, exact: true },
-    { href: `${orgBase}/members`, label: 'Members', icon: RiUserLine },
-    { href: `${orgBase}/teams`, label: 'Teams', icon: RiTeamLine },
-    { href: `${orgBase}/roles`, label: 'Roles', icon: RiShieldLine },
-    { href: `${orgBase}/invitations`, label: 'Invitations', icon: RiMailSendLine },
-    { href: `${orgBase}/settings`, label: 'Settings', icon: RiSettings3Line },
-  ] : [];
-
-  const projectItems = projectName ? [
-    { href: `${orgBase}/${projectName}`, label: 'Resources', icon: RiDatabaseLine, exact: true },
-    { href: `${orgBase}/${projectName}/access`, label: 'Access', icon: RiLockLine },
-    { href: `${orgBase}/${projectName}/share`, label: 'Share', icon: RiShareLine },
-    { href: `${orgBase}/${projectName}/transfer`, label: 'Transfer', icon: RiExchangeLine },
-    { href: `${orgBase}/${projectName}/settings`, label: 'Settings', icon: RiSettings3Line },
-  ] : [];
 
   return (
     <>
       {isOpen && (
-        <div className="fixed inset-0 z-50 bg-black/50" onClick={onClose} />
+        <div className="fixed inset-0 z-50 bg-black/50" onClick={close} />
       )}
 
       <div className={`fixed inset-y-0 left-0 z-50 w-72 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 transform transition-transform duration-300 ${
@@ -92,155 +28,57 @@ export default function MobileNavigation({ organisations = [], user }: MobileNav
       }`}>
         <div className="flex flex-col h-full">
           <div className="flex items-center justify-end px-3 py-2 border-b border-gray-200 dark:border-gray-800">
-            <button onClick={onClose} className="p-1 text-gray-500 dark:text-gray-400">
+            <button onClick={close} className="p-1 text-gray-500 dark:text-gray-400">
               <RiCloseLine className="h-5 w-5" />
             </button>
           </div>
 
           <div className="flex-1 overflow-y-auto py-4 px-3">
-            {/* Project section (on top when inside a project) */}
-            {projectName && (
-              <>
-                <div className="mb-2 px-3">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                    Project
-                  </span>
-                </div>
-                <nav className="space-y-0.5">
-                  {projectItems.map((item) => {
-                    const active = item.exact
-                      ? pathname === item.href
-                      : pathname === item.href || pathname.startsWith(`${item.href}/`);
-                    const Icon = item.icon;
-                    return (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        onClick={onClose}
-                        className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
-                          active
-                            ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
-                            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
-                        }`}
-                      >
-                        <Icon className="h-4 w-4 shrink-0" />
-                        {item.label}
-                      </Link>
-                    );
-                  })}
-                </nav>
-
-                <div className="my-4 mx-3 border-t border-gray-200 dark:border-gray-700" />
-              </>
-            )}
-
-            {/* Organisation section */}
-            {orgName && (
-              <>
-                <div className="mb-2 px-3">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                    Organisation
-                  </span>
-                </div>
-                <nav className="space-y-0.5">
-                  {orgItems.map((item) => {
-                    const active = item.exact
-                      ? pathname === item.href
-                      : pathname === item.href || pathname.startsWith(`${item.href}/`);
-                    const Icon = item.icon;
-                    return (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        onClick={onClose}
-                        className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
-                          active
-                            ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
-                            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
-                        }`}
-                      >
-                        <Icon className="h-4 w-4 shrink-0" />
-                        {item.label}
-                      </Link>
-                    );
-                  })}
-                </nav>
-              </>
-            )}
-
-            {/* Project list */}
-            {!projectName && !isOrgOverview && projects.length > 0 && (
-              <>
-                <div className="mt-6 mb-2 px-3">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                    Projects
-                  </span>
-                </div>
-                <nav className="space-y-0.5">
-                  {projects.map((project) => {
-                    const projectHref = `${orgBase}/${project.name}`;
-                    const active = pathname === projectHref || pathname.startsWith(`${projectHref}/`);
-                    return (
-                      <Link
-                        key={project.id}
-                        href={projectHref}
-                        onClick={onClose}
-                        className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
-                          active
-                            ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
-                            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
-                        }`}
-                      >
-                        <RiProjectorLine className="h-4 w-4 shrink-0" />
-                        {project.name}
-                      </Link>
-                    );
-                  })}
-                </nav>
-              </>
-            )}
-            {/* Navigation links */}
-            <div className="mt-6 mx-3 border-t border-gray-200 dark:border-gray-700 pt-4">
-              <div className="mb-2 px-3">
-                <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                  Navigation
-                </span>
-              </div>
-              <nav className="space-y-0.5">
-                <Link
-                  href="/orga"
-                  onClick={onClose}
-                  className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
-                    pathname === '/orga'
-                      ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
-                      : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
-                  }`}
-                >
-                  <RiBuildingLine className="h-4 w-4 shrink-0" />
-                  Organisations
-                </Link>
-                {user?.role === 'SUPERADMIN' && (
-                  <>
-                    <Link
-                      href="/admin/users"
-                      onClick={onClose}
-                      className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                    >
-                      <RiUserLine className="h-4 w-4 shrink-0" />
-                      Admin: Users
-                    </Link>
-                    <Link
-                      href="/admin/organisations"
-                      onClick={onClose}
-                      className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                    >
-                      <RiBuildingLine className="h-4 w-4 shrink-0" />
-                      Admin: Organisations
-                    </Link>
-                  </>
-                )}
-              </nav>
+            <div className="mb-2 px-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                Navigation
+              </span>
             </div>
+            <nav className="space-y-0.5">
+              <Link
+                href="/orga"
+                onClick={close}
+                className={`flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors ${
+                  pathname === '/orga'
+                    ? 'bg-brand-50 text-brand-700 dark:bg-brand-900/20 dark:text-brand-300'
+                    : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                }`}
+              >
+                <RiBuildingLine className="h-4 w-4 shrink-0" />
+                Organisations
+              </Link>
+
+              {user?.role === 'SUPERADMIN' && (
+                <>
+                  <div className="mt-4 mb-2 px-3">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                      Admin
+                    </span>
+                  </div>
+                  <Link
+                    href="/admin/users"
+                    onClick={close}
+                    className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  >
+                    <RiUserLine className="h-4 w-4 shrink-0" />
+                    Users
+                  </Link>
+                  <Link
+                    href="/admin/organisations"
+                    onClick={close}
+                    className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  >
+                    <RiBuildingLine className="h-4 w-4 shrink-0" />
+                    Organisations
+                  </Link>
+                </>
+              )}
+            </nav>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Sidebar**: permanent on desktop (`hidden lg:block`), context-aware org/project nav — hidden on mobile
- **Hamburger menu**: navigation drawer only (Organisations, Admin links) — NOT the sidebar
- **/orga page**: filter sidebar with search + sort built into OrganisationsClient
- **MobileNavigation**: moved to root layout (rendered once globally)

## Test plan
- [ ] Desktop: sidebar always visible on org/project pages
- [ ] Desktop: hamburger opens navigation menu (Organisations, Admin)
- [ ] Mobile: no sidebar, hamburger opens navigation menu
- [ ] /orga: filter sidebar with search + sort on desktop
- [ ] /orga: no filter sidebar on mobile