### PR TITLE
feat: org visibility toggle, fix orga listing and admin filter

### DIFF
--- a/src/actions/organisation.ts
+++ b/src/actions/organisation.ts
@@ -55,6 +55,7 @@ export async function updateOrganisation(
     const address = formData.get('address') as string;
     const ownerId = formData.get('ownerId') as string;
     const isActive = formData.get('isActive') === 'true';
+    const visibility = formData.get('visibility') as string | null;
 
     // Validate name format
     const nameValidation = validateNameFormat(name, 'organisation');
@@ -118,6 +119,7 @@ export async function updateOrganisation(
       email: email?.trim() || undefined,
       phone: phone?.trim() || undefined,
       address: address?.trim() || undefined,
+      ...(visibility && { visibility }),
     });
 
     revalidatePath('/admin/organisation');

--- a/src/app/(main)/orga/page.tsx
+++ b/src/app/(main)/orga/page.tsx
@@ -10,21 +10,15 @@ export default async function OrganisationsPage() {
     return redirect('/auth/signin');
   }
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const store = await getStoreAsync();
 
-  const userMemberships = isAdmin
-    ? []
-    : await store.organisationMembers.findByUserId(session.user.id);
+  const userMemberships = await store.organisationMembers.findByUserId(session.user.id);
+  const memberOrgIds = new Set(userMemberships.map(m => m.organisationId));
 
-  let activeOrgs;
-  if (isAdmin) {
-    activeOrgs = await store.organisations.search('', 1000);
-  } else {
-    const memberOrgIds = new Set(userMemberships.map(m => m.organisationId));
-    const allOrgs = await store.organisations.search('', 1000);
-    activeOrgs = allOrgs.filter(org => memberOrgIds.has(org.id));
-  }
+  const allOrgs = await store.organisations.search('', 1000);
+  const activeOrgs = allOrgs.filter(org =>
+    org.isActive && (org.ownerId === session.user.id || memberOrgIds.has(org.id))
+  );
 
   const organisations = await Promise.all(
     activeOrgs
@@ -33,7 +27,7 @@ export default async function OrganisationsPage() {
         const owner = await store.users.findById(org.ownerId);
         const members = await store.organisationMembers.findByOrgId(org.id);
         const membership = userMemberships.find(m => m.organisationId === org.id);
-        const userIsAdmin = isAdmin || org.ownerId === session.user.id || membership?.role === 'OWNER' || membership?.role === 'ADMIN';
+        const userIsAdmin = org.ownerId === session.user.id || membership?.role === 'OWNER' || membership?.role === 'ADMIN';
         return {
           id: org.id,
           name: org.name,

--- a/src/components/form/OrganisationSettingsForm.tsx
+++ b/src/components/form/OrganisationSettingsForm.tsx
@@ -188,6 +188,24 @@ export default function OrganisationSettingsForm({
           )}
         </div>
 
+        <div>
+          <Label htmlFor="visibility">
+            Visibility
+          </Label>
+          <select
+            id="visibility"
+            name="visibility"
+            defaultValue={(organisation as any).visibility || 'PUBLIC'}
+            className="mt-1 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          >
+            <option value="PUBLIC">Public</option>
+            <option value="PRIVATE">Private</option>
+          </select>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Public organisations can be found and receive project share requests.
+          </p>
+        </div>
+
         <div className="md:col-span-2">
           <div className="flex items-center space-x-2">
             <Switch

--- a/src/lib/store/repositories/organisation.repository.ts
+++ b/src/lib/store/repositories/organisation.repository.ts
@@ -29,7 +29,7 @@ export interface IOrganisationRepository {
   findByIdWithMemberCount(id: string): Promise<OrganisationWithMemberCount | null>;
   findByName(name: string): Promise<Organisation | null>;
   findByNameWithMemberCount(name: string): Promise<OrganisationWithMemberCount | null>;
-  update(id: string, data: Partial<CreateOrganisationData> & { isActive?: boolean }): Promise<Organisation>;
+  update(id: string, data: Partial<CreateOrganisationData> & { isActive?: boolean; visibility?: string }): Promise<Organisation>;
   search(query: string, limit?: number): Promise<Organisation[]>;
   findActiveByName(name: string, excludeId?: string): Promise<Organisation | null>;
 }

--- a/src/lib/store/tinybase/organisation.tinybase.ts
+++ b/src/lib/store/tinybase/organisation.tinybase.ts
@@ -142,7 +142,7 @@ export class TinyBaseOrganisationRepository implements IOrganisationRepository {
     return { ...org, memberCount: this.countMembers(org.id) };
   }
 
-  async update(id: string, data: Partial<CreateOrganisationData> & { isActive?: boolean }): Promise<Organisation> {
+  async update(id: string, data: Partial<CreateOrganisationData> & { isActive?: boolean; visibility?: string }): Promise<Organisation> {
     const row = this.store.getRow(ORG_TABLE, id);
     if (!row.name) throw new Error(`Organisation ${id} not found`);
 
@@ -153,6 +153,7 @@ export class TinyBaseOrganisationRepository implements IOrganisationRepository {
     if (data.email !== undefined) this.store.setCell(ORG_TABLE, id, 'email', data.email ?? '');
     if (data.logo !== undefined) this.store.setCell(ORG_TABLE, id, 'logo', data.logo ?? '');
     if (data.isActive !== undefined) this.store.setCell(ORG_TABLE, id, 'isActive', data.isActive ? 1 : 0);
+    if (data.visibility !== undefined) this.store.setCell(ORG_TABLE, id, 'visibility', data.visibility);
     this.store.setCell(ORG_TABLE, id, 'updatedAt', new Date().toISOString());
 
     return rowToOrg(id, this.store.getRow(ORG_TABLE, id));


### PR DESCRIPTION
## Summary
- **Visibility toggle**: Public/Private select on org settings page, persisted to store
- **/orga listing**: only shows orgs where user is member/owner (SUPERADMIN excluded from auto-listing all orgs)
- **Admin filter**: based on actual org membership role (OWNER/ADMIN), not platform SUPERADMIN status

## Test plan
- [ ] Org settings: visibility dropdown shows Public/Private
- [ ] Change visibility to Private, save — reflected in /orga filter
- [ ] /orga: only shows orgs you're a member of
- [ ] Admin filter: only shows orgs where you're OWNER or ADMIN role
- [ ] SUPERADMIN: doesn't see other people's orgs on /orga (use /admin instead)