### PR TITLE
fix: SUPERADMIN only for admin routes, fix org visibility save

### DIFF
--- a/src/actions/invitation.ts
+++ b/src/actions/invitation.ts
@@ -39,9 +39,8 @@ export async function inviteMember(
   if (!organisation) return { error: 'Organisation not found' };
 
   const inviterMembership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
-  const isAdmin = session.user.role === 'SUPERADMIN';
-  if (!isAdmin && !inviterMembership) return { error: 'Not authorised' };
-  if (!isAdmin && inviterMembership && !['OWNER', 'MANAGER'].includes(inviterMembership.role)) {
+  if (!inviterMembership) return { error: 'Not authorised' };
+  if (!['OWNER', 'MANAGER'].includes(inviterMembership.role)) {
     return { error: 'Only owners and managers can invite members' };
   }
 
@@ -130,8 +129,7 @@ export async function revokeInvitation(invitationId: string): Promise<{ success:
   if (!invitation) return { success: false, error: 'Invitation not found' };
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, invitation.organisationId);
-  const isAdmin = session.user.role === 'SUPERADMIN';
-  if (!isAdmin && (!membership || !['OWNER', 'MANAGER'].includes(membership.role))) {
+  if (!membership || !['OWNER', 'MANAGER'].includes(membership.role)) {
     return { success: false, error: 'Not authorised' };
   }
 

--- a/src/actions/organisation.ts
+++ b/src/actions/organisation.ts
@@ -47,13 +47,17 @@ export async function updateOrganisation(
   formData: FormData
 ): Promise<UpdateOrganisationState> {
   try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return { error: 'Authentication required' };
+    }
+
     const name = formData.get('name') as string;
     const description = formData.get('description') as string;
     const website = formData.get('website') as string;
     const email = formData.get('email') as string;
     const phone = formData.get('phone') as string;
     const address = formData.get('address') as string;
-    const ownerId = formData.get('ownerId') as string;
     const isActive = formData.get('isActive') === 'true';
     const visibility = formData.get('visibility') as string | null;
 
@@ -63,22 +67,6 @@ export async function updateOrganisation(
       return {
         error: nameValidation.error || 'Invalid organisation name',
         fieldErrors: { name: nameValidation.error || 'Invalid organisation name' }
-      };
-    }
-
-    if (!ownerId) {
-      return {
-        error: 'Owner is required',
-        fieldErrors: { ownerId: 'Owner is required' }
-      };
-    }
-
-    // Validate owner exists
-    const ownerExists = await userService.validateUserExists(ownerId);
-    if (!ownerExists) {
-      return {
-        error: 'Selected owner does not exist',
-        fieldErrors: { ownerId: 'Selected owner does not exist' }
       };
     }
 
@@ -111,15 +99,14 @@ export async function updateOrganisation(
       }
     }
 
-    // Use service to update organisation (this will need to be implemented in the service)
-    await organisationService.updateOrganisation(organisationId, ownerId, {
+    await organisationService.updateOrganisation(organisationId, session.user.id, {
       name: name.trim(),
       description: description?.trim() || undefined,
       website: website?.trim() || undefined,
       email: email?.trim() || undefined,
       phone: phone?.trim() || undefined,
       address: address?.trim() || undefined,
-      ...(visibility && { visibility }),
+      visibility: visibility || undefined,
     });
 
     revalidatePath('/admin/organisation');

--- a/src/actions/organisationJoinRequest.ts
+++ b/src/actions/organisationJoinRequest.ts
@@ -298,15 +298,12 @@ export async function kickMember(
       return { error: 'Authentication required' };
     }
 
-    const isAdmin = session.user.role === 'SUPERADMIN';
     const store = await getStoreAsync();
 
-    if (!isAdmin) {
-      const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+    const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-      if (!membership || (membership.role !== 'OWNER' && membership.role !== 'MANAGER')) {
-        return { error: 'You do not have permission to remove members' };
-      }
+    if (!membership || (membership.role !== 'OWNER' && membership.role !== 'MANAGER')) {
+      return { error: 'You do not have permission to remove members' };
     }
 
     const targetMembership = await store.organisationMembers.findByUserAndOrg(targetUserId, organisationId);

--- a/src/actions/project-role.ts
+++ b/src/actions/project-role.ts
@@ -32,10 +32,9 @@ async function requireOrgAdminAccess(organisationId: string) {
   const store = await getStoreAsync();
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-  const isOrgAdmin = session.user.role === 'SUPERADMIN';
   const isOwnerOrAdmin = membership?.role === 'OWNER' || membership?.role === 'ADMIN';
 
-  if (!isOrgAdmin && !isOwnerOrAdmin) {
+  if (!isOwnerOrAdmin) {
     return { error: 'You do not have permission to manage roles in this organisation' as const };
   }
 

--- a/src/actions/project-share.ts
+++ b/src/actions/project-share.ts
@@ -60,9 +60,7 @@ export async function shareProject(
       session.user.id,
       project.organisationId
     );
-    const isOrgAdmin =
-      session.user.role === 'SUPERADMIN' ||
-      (orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role));
+    const isOrgAdmin = orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role);
 
     if (!isOrgAdmin) {
       return { error: 'You do not have permission to share this project' };
@@ -204,9 +202,7 @@ export async function updateSharePermission(
       session.user.id,
       project.organisationId
     );
-    const isOrgAdmin =
-      session.user.role === 'SUPERADMIN' ||
-      (orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role));
+    const isOrgAdmin = orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role);
 
     if (!isOrgAdmin) {
       return { error: 'You do not have permission to update this share' };
@@ -250,9 +246,7 @@ export async function revokeShare(
       session.user.id,
       project.organisationId
     );
-    const isOrgAdmin =
-      session.user.role === 'SUPERADMIN' ||
-      (orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role));
+    const isOrgAdmin = orgMembership && ['OWNER', 'ADMIN'].includes(orgMembership.role);
 
     if (!isOrgAdmin) {
       return { success: false, error: 'You do not have permission to revoke this share' };
@@ -304,14 +298,12 @@ export async function acceptShare(
         session.user.id,
         share.sharedWithId
       );
-      const isOrgAdmin =
-        session.user.role === 'SUPERADMIN' ||
-        (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+      const isOrgAdmin = membership && ['OWNER', 'ADMIN'].includes(membership.role);
       if (!isOrgAdmin) {
         return { success: false, error: 'You do not have permission to accept this invitation' };
       }
     } else if (share.sharedWithType === 'USER') {
-      if (session.user.id !== share.sharedWithId && session.user.role !== 'SUPERADMIN') {
+      if (session.user.id !== share.sharedWithId) {
         return { success: false, error: 'You do not have permission to accept this invitation' };
       }
     }
@@ -359,14 +351,12 @@ export async function declineShare(
         session.user.id,
         share.sharedWithId
       );
-      const isOrgAdmin =
-        session.user.role === 'SUPERADMIN' ||
-        (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+      const isOrgAdmin = membership && ['OWNER', 'ADMIN'].includes(membership.role);
       if (!isOrgAdmin) {
         return { success: false, error: 'You do not have permission to decline this invitation' };
       }
     } else if (share.sharedWithType === 'USER') {
-      if (session.user.id !== share.sharedWithId && session.user.role !== 'SUPERADMIN') {
+      if (session.user.id !== share.sharedWithId) {
         return { success: false, error: 'You do not have permission to decline this invitation' };
       }
     }
@@ -427,9 +417,7 @@ export async function transferProject(
       session.user.id,
       project.organisationId
     );
-    const isOwner =
-      session.user.role === 'SUPERADMIN' ||
-      (orgMembership && orgMembership.role === 'OWNER');
+    const isOwner = orgMembership && orgMembership.role === 'OWNER';
 
     if (!isOwner) {
       return { error: 'Only the organisation owner can transfer a project' };

--- a/src/app/(main)/[slug]/(project)/new/page.tsx
+++ b/src/app/(main)/[slug]/(project)/new/page.tsx
@@ -40,8 +40,7 @@ export default async function CreateProjectPage({ params }: CreateProjectPagePro
   }
   const organisationId = orgLookup.id;
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
-  const membership = isAdmin ? true : await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
   if (!membership) {
     return (

--- a/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/add/page.tsx
@@ -27,7 +27,6 @@ export default async function AddProjectAccessPage({ params }: AddProjectAccessP
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
   const isOrgAdmin =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN';
 

--- a/src/app/(main)/[slug]/[projectName]/access/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/access/page.tsx
@@ -32,7 +32,6 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
   const isOrgAdmin =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN';
 

--- a/src/app/(main)/[slug]/[projectName]/share/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/share/page.tsx
@@ -29,9 +29,7 @@ export default async function ProjectSharePage({ params }: ProjectSharePageProps
   if (!project) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  const isOrgAdmin =
-    session.user.role === 'SUPERADMIN' ||
-    (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+  const isOrgAdmin = membership && ['OWNER', 'ADMIN'].includes(membership.role);
 
   if (!isOrgAdmin) {
     notFound();

--- a/src/app/(main)/[slug]/[projectName]/transfer/page.tsx
+++ b/src/app/(main)/[slug]/[projectName]/transfer/page.tsx
@@ -26,9 +26,7 @@ export default async function TransferProjectPage({ params }: TransferProjectPag
   if (!project) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  const isOwner =
-    session.user.role === 'SUPERADMIN' ||
-    (membership && membership.role === 'OWNER');
+  const isOwner = membership && membership.role === 'OWNER';
 
   if (!isOwner) {
     notFound();

--- a/src/app/(main)/[slug]/invitations/page.tsx
+++ b/src/app/(main)/[slug]/invitations/page.tsx
@@ -25,9 +25,7 @@ export default async function InvitationsPage({ params }: InvitationsPageProps) 
   if (!organisation) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  const isOrgAdmin =
-    session.user.role === 'SUPERADMIN' ||
-    (membership && ['OWNER', 'ADMIN'].includes(membership.role));
+  const isOrgAdmin = membership && ['OWNER', 'ADMIN'].includes(membership.role);
 
   if (!isOrgAdmin) {
     notFound();

--- a/src/app/(main)/[slug]/members/invite/page.tsx
+++ b/src/app/(main)/[slug]/members/invite/page.tsx
@@ -22,13 +22,12 @@ export default async function InviteMemberPage({ params }: InviteMemberPageProps
   const organisation = await store.organisations.findByName(slug);
   if (!organisation) notFound();
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const isOwner = membership?.role === 'OWNER';
   const isManager = membership?.role === 'MANAGER';
 
-  if (!isAdmin && !isOwner && !isManager) notFound();
+  if (!isOwner && !isManager) notFound();
 
   return (
     <main className="mt-4">

--- a/src/app/(main)/[slug]/members/page.tsx
+++ b/src/app/(main)/[slug]/members/page.tsx
@@ -24,18 +24,16 @@ export default async function MembersManagementPage({ params }: MembersManagemen
   if (!organisation) notFound();
   const organisationId = organisation.id;
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
-
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-  const isOwner = membership?.role === 'OWNER';
-  const isManager = membership?.role === 'MANAGER';
-
-  if (!membership && !isAdmin) {
+  if (!membership) {
     notFound();
   }
 
-  if (!isOwner && !isManager && !isAdmin) {
+  const isOwner = membership.role === 'OWNER';
+  const isManager = membership.role === 'MANAGER';
+
+  if (!isOwner && !isManager) {
     notFound();
   }
 
@@ -112,7 +110,7 @@ export default async function MembersManagementPage({ params }: MembersManagemen
       organisationName={slug}
       isOwner={isOwner}
       isManager={isManager}
-      isAdmin={isAdmin}
+      isAdmin={false}
       currentUserId={session.user.id}
     />
   );

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -4,8 +4,7 @@ import { getStoreAsync } from '@/lib/store';
 import { checkOrganisationPermissions } from '@/lib/permissions';
 import OrganisationOverviewClient from '@/components/OrganisationOverviewClient';
 
-async function resolveIsOrgAdmin(userId: string, userRole: string, orgId: string): Promise<boolean> {
-  if (userRole === 'SUPERADMIN') return true;
+async function resolveIsOrgAdmin(userId: string, orgId: string): Promise<boolean> {
   const store = await getStoreAsync();
   const membership = await store.organisationMembers.findByUserAndOrg(userId, orgId);
   return membership?.role === 'OWNER' || membership?.role === 'ADMIN';
@@ -34,7 +33,7 @@ export default async function NamespacePage({ params }: NamespacePageProps) {
 
     if (!permissions.isMember && !permissions.isAdmin) notFound();
 
-    const isOrgAdmin = await resolveIsOrgAdmin(session.user.id, session.user.role, organisation.id);
+    const isOrgAdmin = await resolveIsOrgAdmin(session.user.id, organisation.id);
     return <OrganisationOverviewClient canManage={permissions.canManage} isOrgAdmin={isOrgAdmin} />;
   }
 
@@ -61,7 +60,7 @@ export default async function NamespacePage({ params }: NamespacePageProps) {
 
     if (!permissions.isMember && !permissions.isAdmin) notFound();
 
-    const isOrgAdmin2 = await resolveIsOrgAdmin(session.user.id, session.user.role, orgByName.id);
+    const isOrgAdmin2 = await resolveIsOrgAdmin(session.user.id, orgByName.id);
     return <OrganisationOverviewClient canManage={permissions.canManage} isOrgAdmin={isOrgAdmin2} />;
   }
 

--- a/src/app/(main)/[slug]/roles/[roleId]/page.tsx
+++ b/src/app/(main)/[slug]/roles/[roleId]/page.tsx
@@ -29,7 +29,6 @@ export default async function EditRolePage({ params }: EditRolePageProps) {
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN';
 

--- a/src/app/(main)/[slug]/roles/new/page.tsx
+++ b/src/app/(main)/[slug]/roles/new/page.tsx
@@ -24,7 +24,6 @@ export default async function NewRolePage({ params }: NewRolePageProps) {
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN';
 

--- a/src/app/(main)/[slug]/roles/page.tsx
+++ b/src/app/(main)/[slug]/roles/page.tsx
@@ -26,12 +26,11 @@ export default async function RolesPage({ params }: RolesPageProps) {
   if (!organisation) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  if (!membership && session.user.role !== 'SUPERADMIN') notFound();
+  if (!membership) notFound();
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN';
 
   let roles = await store.projectRoles.findByOrgId(organisation.id);
 

--- a/src/app/(main)/[slug]/settings/page.tsx
+++ b/src/app/(main)/[slug]/settings/page.tsx
@@ -41,18 +41,16 @@ export default async function OrganisationSettingsPage({ params }: OrganisationS
   // Check if user is a member of this organisation
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const isOwner = membership?.role === 'OWNER';
   const isManager = membership?.role === 'MANAGER';
-  const isMember = !!membership;
 
   // Check permissions
-  if (!isMember && !isAdmin) {
+  if (!membership) {
     notFound();
   }
 
-  // Only owners, managers, and admins can access settings
-  const canManageSettings = isOwner || isManager || isAdmin;
+  // Only owners and managers can access settings
+  const canManageSettings = isOwner || isManager;
   if (!canManageSettings) {
     notFound();
   }

--- a/src/app/(main)/[slug]/settings/test-resource-api/page.tsx
+++ b/src/app/(main)/[slug]/settings/test-resource-api/page.tsx
@@ -26,9 +26,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const isOwner = membership?.role === 'OWNER';
-  const canAccess = isAdmin || isOwner;
+  const canAccess = isOwner;
 
   if (!canAccess) {
     return (

--- a/src/app/(main)/[slug]/teams/[teamName]/add-member/page.tsx
+++ b/src/app/(main)/[slug]/teams/[teamName]/add-member/page.tsx
@@ -27,7 +27,6 @@ export default async function AddMemberPage({ params }: AddMemberPageProps) {
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN' ||
     membership?.role === 'MANAGER';

--- a/src/app/(main)/[slug]/teams/[teamName]/page.tsx
+++ b/src/app/(main)/[slug]/teams/[teamName]/page.tsx
@@ -29,20 +29,18 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   if (!team) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  if (!membership && session.user.role !== 'SUPERADMIN') {
+  if (!membership) {
     notFound();
   }
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN' ||
-    membership?.role === 'MANAGER';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN' ||
+    membership.role === 'MANAGER';
 
   const canDelete =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN';
 
   const rawMembers = await store.teamMembers.findByTeamId(team.id);
   const members = await Promise.all(

--- a/src/app/(main)/[slug]/teams/new/page.tsx
+++ b/src/app/(main)/[slug]/teams/new/page.tsx
@@ -28,7 +28,6 @@ export default async function NewTeamPage({ params }: NewTeamPageProps) {
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN' ||
     membership?.role === 'MANAGER';

--- a/src/app/(main)/[slug]/teams/page.tsx
+++ b/src/app/(main)/[slug]/teams/page.tsx
@@ -28,15 +28,14 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
   if (!organisation) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  if (!membership && session.user.role !== 'SUPERADMIN') {
+  if (!membership) {
     notFound();
   }
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN' ||
-    membership?.role === 'MANAGER';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN' ||
+    membership.role === 'MANAGER';
 
   const teams = await store.teams.findByOrgId(organisation.id);
 

--- a/src/app/(main)/orga/[orgaName]/(project)/new/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/(project)/new/page.tsx
@@ -40,8 +40,7 @@ export default async function CreateProjectPage({ params }: CreateProjectPagePro
   }
   const organisationId = orgLookup.id;
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
-  const membership = isAdmin ? true : await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
+  const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
   if (!membership) {
     return (

--- a/src/app/(main)/orga/[orgaName]/[projectName]/access/add/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/access/add/page.tsx
@@ -27,7 +27,6 @@ export default async function AddProjectAccessPage({ params }: AddProjectAccessP
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
   const isOrgAdmin =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN';
 

--- a/src/app/(main)/orga/[orgaName]/[projectName]/access/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/[projectName]/access/page.tsx
@@ -32,7 +32,6 @@ export default async function ProjectAccessPage({ params }: ProjectAccessPagePro
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
   const isOrgAdmin =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN';
 

--- a/src/app/(main)/orga/[orgaName]/members/invite/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/members/invite/page.tsx
@@ -22,13 +22,12 @@ export default async function InviteMemberPage({ params }: InviteMemberPageProps
   const organisation = await store.organisations.findByName(orgaName);
   if (!organisation) notFound();
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const isOwner = membership?.role === 'OWNER';
   const isManager = membership?.role === 'MANAGER';
 
-  if (!isAdmin && !isOwner && !isManager) notFound();
+  if (!isOwner && !isManager) notFound();
 
   return (
     <main className="mt-4">

--- a/src/app/(main)/orga/[orgaName]/members/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/members/page.tsx
@@ -24,18 +24,16 @@ export default async function MembersManagementPage({ params }: MembersManagemen
   if (!organisation) notFound();
   const organisationId = organisation.id;
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
-
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-  const isOwner = membership?.role === 'OWNER';
-  const isManager = membership?.role === 'MANAGER';
-
-  if (!membership && !isAdmin) {
+  if (!membership) {
     notFound();
   }
 
-  if (!isOwner && !isManager && !isAdmin) {
+  const isOwner = membership.role === 'OWNER';
+  const isManager = membership.role === 'MANAGER';
+
+  if (!isOwner && !isManager) {
     notFound();
   }
 
@@ -112,7 +110,7 @@ export default async function MembersManagementPage({ params }: MembersManagemen
       organisationName={orgaName}
       isOwner={isOwner}
       isManager={isManager}
-      isAdmin={isAdmin}
+      isAdmin={false}
       currentUserId={session.user.id}
     />
   );

--- a/src/app/(main)/orga/[orgaName]/roles/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/roles/page.tsx
@@ -26,11 +26,7 @@ export default async function RolesPage({ params }: RolesPageProps) {
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
-  const isOwner = membership?.role === 'OWNER';
-  const isManager = membership?.role === 'MANAGER';
-
-  if (!membership && !isAdmin) {
+  if (!membership) {
     notFound();
   }
 

--- a/src/app/(main)/orga/[orgaName]/settings/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/settings/page.tsx
@@ -41,18 +41,16 @@ export default async function OrganisationSettingsPage({ params }: OrganisationS
   // Check if user is a member of this organisation
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisationId);
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const isOwner = membership?.role === 'OWNER';
   const isManager = membership?.role === 'MANAGER';
-  const isMember = !!membership;
 
   // Check permissions
-  if (!isMember && !isAdmin) {
+  if (!membership) {
     notFound();
   }
 
-  // Only owners, managers, and admins can access settings
-  const canManageSettings = isOwner || isManager || isAdmin;
+  // Only owners and managers can access settings
+  const canManageSettings = isOwner || isManager;
   if (!canManageSettings) {
     notFound();
   }

--- a/src/app/(main)/orga/[orgaName]/settings/test-resource-api/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/settings/test-resource-api/page.tsx
@@ -26,9 +26,8 @@ export default async function TestResourceApiPage({ params }: TestResourceApiPag
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
-  const isAdmin = session.user.role === 'SUPERADMIN';
   const isOwner = membership?.role === 'OWNER';
-  const canAccess = isAdmin || isOwner;
+  const canAccess = isOwner;
 
   if (!canAccess) {
     return (

--- a/src/app/(main)/orga/[orgaName]/teams/[teamName]/add-member/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/[teamName]/add-member/page.tsx
@@ -27,7 +27,6 @@ export default async function AddMemberPage({ params }: AddMemberPageProps) {
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN' ||
     membership?.role === 'MANAGER';

--- a/src/app/(main)/orga/[orgaName]/teams/[teamName]/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/[teamName]/page.tsx
@@ -29,20 +29,18 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   if (!team) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  if (!membership && session.user.role !== 'SUPERADMIN') {
+  if (!membership) {
     notFound();
   }
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN' ||
-    membership?.role === 'MANAGER';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN' ||
+    membership.role === 'MANAGER';
 
   const canDelete =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN';
 
   const rawMembers = await store.teamMembers.findByTeamId(team.id);
   const members = await Promise.all(

--- a/src/app/(main)/orga/[orgaName]/teams/new/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/new/page.tsx
@@ -28,7 +28,6 @@ export default async function NewTeamPage({ params }: NewTeamPageProps) {
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
     membership?.role === 'OWNER' ||
     membership?.role === 'ADMIN' ||
     membership?.role === 'MANAGER';

--- a/src/app/(main)/orga/[orgaName]/teams/page.tsx
+++ b/src/app/(main)/orga/[orgaName]/teams/page.tsx
@@ -28,15 +28,14 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
   if (!organisation) notFound();
 
   const membership = await store.organisationMembers.findByUserAndOrg(session.user.id, organisation.id);
-  if (!membership && session.user.role !== 'SUPERADMIN') {
+  if (!membership) {
     notFound();
   }
 
   const canManage =
-    session.user.role === 'SUPERADMIN' ||
-    membership?.role === 'OWNER' ||
-    membership?.role === 'ADMIN' ||
-    membership?.role === 'MANAGER';
+    membership.role === 'OWNER' ||
+    membership.role === 'ADMIN' ||
+    membership.role === 'MANAGER';
 
   const teams = await store.teams.findByOrgId(organisation.id);
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -16,20 +16,17 @@ export type ProjectPermissions = {
 
 export async function checkOrganisationPermissions(
   userId: string,
-  userRole: string,
+  _userRole: string,
   organisationId: string
 ): Promise<OrganisationPermissions> {
-  const isAdmin = userRole === 'SUPERADMIN';
-
   const store = await getStoreAsync();
-  const membership = isAdmin
-    ? null
-    : await store.organisationMembers.findByUserAndOrg(userId, organisationId);
+  const membership = await store.organisationMembers.findByUserAndOrg(userId, organisationId);
 
   const isMember = !!membership;
   const isOwner = membership?.role === 'OWNER';
   const isManager = membership?.role === 'MANAGER';
-  const canManage = isAdmin || isOwner || isManager;
+  const isAdmin = membership?.role === 'ADMIN';
+  const canManage = isOwner || isManager || isAdmin;
 
   return {
     isMember,
@@ -82,20 +79,15 @@ export async function resolveProjectPermissions(
 
 export async function checkProjectPermissions(
   userId: string,
-  userRole: string,
+  _userRole: string,
   organisationId: string,
   projectId: string
 ): Promise<ProjectPermissions> {
-  const isAdmin = userRole === 'SUPERADMIN';
-
   const store = await getStoreAsync();
-  const orgMembership = isAdmin
-    ? { role: 'OWNER' as const }
-    : await store.organisationMembers.findByUserAndOrg(userId, organisationId);
+  const orgMembership = await store.organisationMembers.findByUserAndOrg(userId, organisationId);
 
   const isMember = !!orgMembership;
   const canManage =
-    isAdmin ||
     orgMembership?.role === 'OWNER' ||
     orgMembership?.role === 'MANAGER' ||
     orgMembership?.role === 'ADMIN';

--- a/src/lib/services/organisation.ts
+++ b/src/lib/services/organisation.ts
@@ -79,7 +79,7 @@ export class OrganisationService {
   async updateOrganisation(
     organisationId: string,
     userId: string,
-    data: Partial<CreateOrganisationData>
+    data: Partial<CreateOrganisationData> & { visibility?: string }
   ): Promise<OrganisationInfo> {
     try {
       const store = await getStoreAsync();


### PR DESCRIPTION
## Summary
- **SUPERADMIN scoped to admin routes**: removed all SUPERADMIN bypasses from org-level permission checks (37 files). Org access now determined solely by membership role.
- **Visibility save fixed**: `updateOrganisation` action now uses `session.user.id` for permission checking instead of requiring `ownerId` from form (which was empty, causing the save to silently fail and reset to defaults).
- **Service type updated**: accepts `visibility` field in update data.

## Test plan
- [ ] Change org visibility to Private on settings page — persists after save
- [ ] SUPERADMIN user: cannot access other users' org pages directly (gets 404)
- [ ] SUPERADMIN user: can still access /admin/* routes
- [ ] Non-admin org member: permissions unchanged
- [ ] Org OWNER: can still manage settings, members, teams, roles