### PR TITLE
chore: publish image under images/ namespace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  # Legacy image path — kept working during the transition.
   IMAGE_NAME: ${{ github.repository_owner }}/platform
+  # New org-wide namespaced path (see enopax/enopax PR #15).
+  IMAGE_NAME_NAMESPACED: ${{ github.repository_owner }}/images/platform
 
 jobs:
   build:
@@ -31,7 +34,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Publish to BOTH the legacy path and the new namespaced path during
+          # the transition so existing deploys keep working. Every tag below is
+          # produced for both image paths. The legacy path will be removed in a
+          # follow-up PR once all consumers pull the namespaced path.
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_NAMESPACED }}
           tags: |
             type=sha,prefix=
             type=raw,value=latest


### PR DESCRIPTION
## What

Switches the published container image for **enopax/platform** to the new org-wide namespaced path, per the package naming schema proposed in [enopax/enopax PR #15](https://github.com/enopax/enopax/pull/15):

- Container images -> `ghcr.io/enopax/images/<repo>`
- (Helm charts -> `ghcr.io/enopax/charts/<repo>` — not applicable to this repo)

For this repo the new image path is **`ghcr.io/enopax/images/platform`**.

## Conservative dual-publish (no breakage)

This is the production platform, so the build workflow now publishes to **BOTH** paths on every push to `main`:

- `ghcr.io/enopax/platform` (legacy — kept working during the transition)
- `ghcr.io/enopax/images/platform` (new namespaced path)

`docker/metadata-action` is given both image names, so every tag (`latest`, commit SHA) is produced for both paths. The legacy path is **not** removed.

## Changes

- **`.github/workflows/deploy.yml`**
  - Added `IMAGE_NAME_NAMESPACED: ${{ github.repository_owner }}/images/platform` env var alongside the existing `IMAGE_NAME`.
  - The `Extract metadata` step's `images:` now lists both image paths (multiline block scalar).
  - Build/push step is unchanged — it already pushes `steps.meta.outputs.tags`, which now covers both paths.

No other in-repo file references the image path (README's Deployment section and CLAUDE.md only mention GHCR generically, not the path, so nothing else needed changing).

## Cutover plan

1. **Merge this PR.** The next push to `main` publishes to both paths. Verify both packages appear under the org GHCR packages and that tags match.
2. **Migrate the deploy consumer** to pull `ghcr.io/enopax/images/platform`. See the consumer audit below — the live compose file is server-side and not in any org repo, so it must be edited out-of-band.
3. **Soak** for one release cycle to confirm the new path is healthy and the consumer is switched.
4. **Remove the legacy path** in a follow-up PR (delete the `IMAGE_NAME` line from the `images:` list) and optionally delete the old GHCR package.

## Consumer audit (cross-repo usage)

In-repo references to `ghcr.io/enopax/platform`: **none** (the only image references in this repo are the workflow itself and the unrelated `ghcr.io/enopax/dex` dev image in `docker-compose.yml`).

Searched the entire **enopax** org (all 6 repos: `enopax`, `infra`, `platform`, `provider-git`, `server-deploy`, `server_setup`) for where this image is pulled for deployment:

- **No committed file in any org repo references `ghcr.io/enopax/platform`.**
- `enopax/infra/docker-compose.yml` only runs `nginx:latest`.
- `enopax/server-deploy` and `enopax/server_setup` are empty scaffolds (`.gitkeep` only).
- `enopax/provider-git` contains only bash scripts, no image references.

> :warning: The platform deploy workflow SSHes into the production server (`deploy@${SERVER_HOST}`), and CLAUDE.md states server config is managed via `enopax.com_setup/` (a git-push workflow). The compose/deploy file that actually pulls the image is **not committed to any org repo** — it lives on the production server. **It must be updated out-of-band** to pull `ghcr.io/enopax/images/platform` before the legacy path is removed in step 4. This PR cannot change it.

## Risks / notes

- Low risk: dual-publish is additive; deploys pulling the legacy path keep working.
- Negligible extra push time (two image references for the same layers).
- Do **not** combine merge with legacy removal — keep both paths until the server-side consumer is migrated.
- Out of scope, noted for awareness: the `deploy` job's SSH step opens a session but runs no remote command (no `docker compose pull/up`); the actual redeploy mechanism appears to live elsewhere (server-side). Unrelated to this change.