### PR TITLE
fix(auth): make imprint page publicly accessible

### DIFF
--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -16,7 +16,7 @@ export default {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
 
-      const publicPaths = ['/', '/signin', '/register', '/accept-invite', '/api/auth', '/api/email'];
+      const publicPaths = ['/', '/signin', '/register', '/accept-invite', '/docs/imprint', '/api/auth', '/api/email'];
       const isPublic = publicPaths.some(p =>
         nextUrl.pathname === p || nextUrl.pathname.startsWith(p + '/')
       );

--- a/tests/validation/auth-config.test.ts
+++ b/tests/validation/auth-config.test.ts
@@ -1,0 +1,50 @@
+import authConfig from '@/lib/auth.config';
+
+type Session = { user?: unknown } | null;
+
+function isAuthorized(pathname: string, session: Session): boolean {
+  const authorized = authConfig.callbacks!.authorized!;
+  return authorized({
+    auth: session,
+    request: { nextUrl: new URL(`https://enopax.com${pathname}`) },
+  } as never) as boolean;
+}
+
+describe('auth.config authorized callback', () => {
+  const loggedIn: Session = { user: { id: 'u1' } };
+  const anonymous: Session = null;
+
+  describe('public paths are reachable without a session', () => {
+    const publicPaths = [
+      '/',
+      '/signin',
+      '/register',
+      '/accept-invite',
+      '/docs/imprint',
+      '/api/auth',
+      '/api/email',
+    ];
+
+    it.each(publicPaths)('allows %s for anonymous users', (path) => {
+      expect(isAuthorized(path, anonymous)).toBe(true);
+    });
+  });
+
+  it('keeps the imprint legal page public (no login wall)', () => {
+    expect(isAuthorized('/docs/imprint', anonymous)).toBe(true);
+  });
+
+  it('still protects other docs pages', () => {
+    expect(isAuthorized('/docs/api', anonymous)).toBe(false);
+    expect(isAuthorized('/docs/api', loggedIn)).toBe(true);
+  });
+
+  it('protects application routes for anonymous users', () => {
+    expect(isAuthorized('/orga/acme', anonymous)).toBe(false);
+    expect(isAuthorized('/account', anonymous)).toBe(false);
+  });
+
+  it('allows protected routes for logged-in users', () => {
+    expect(isAuthorized('/orga/acme', loggedIn)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The Imprint page (`/docs/imprint`), linked from the footer under **Legal**, was protected by the NextAuth middleware. Anonymous visitors were redirected to `/signin` instead of seeing the imprint. A legal imprint must be reachable without authentication.

## Cause

`src/middleware.ts` runs `auth` over all routes (except `api`/static assets). The `authorized` callback in `src/lib/auth.config.ts` only allowed a fixed `publicPaths` allowlist — which did not include `/docs/imprint`.

## Fix

- Add `/docs/imprint` to `publicPaths` so the imprint renders without a session.
- Other `/docs/*` pages (e.g. `/docs/api`) remain protected, as before.

## Tests

- New `tests/validation/auth-config.test.ts` covers the `authorized` callback: imprint is public, other docs/app routes stay protected, logged-in users keep access.
- `npm run test:validation` → 11 passing.